### PR TITLE
feat(run): add protocol round-trip tests for pelagos run command

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -102,9 +102,12 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
         let cmd: GuestCommand = match serde_json::from_str(&line) {
             Ok(c) => c,
             Err(e) => {
-                send_response(&mut writer, &GuestResponse::Error {
-                    error: format!("parse error: {}", e),
-                })?;
+                send_response(
+                    &mut writer,
+                    &GuestResponse::Error {
+                        error: format!("parse error: {}", e),
+                    },
+                )?;
                 continue;
             }
         };

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -189,7 +189,7 @@ fn run_command(vm: &Vm, image: String, args: Vec<String>) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::GuestResponse;
+    use super::{GuestCommand, GuestResponse};
 
     #[test]
     fn pong_deserializes() {
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn stream_deserializes() {
+    fn stream_stdout_deserializes() {
         let json = r#"{"stream":{"stream":"stdout","data":"hello\n"}}"#;
         let resp: GuestResponse = serde_json::from_str(json).expect("parse failed");
         match resp {
@@ -212,10 +212,64 @@ mod tests {
     }
 
     #[test]
+    fn stream_stderr_deserializes() {
+        let json = r#"{"stream":{"stream":"stderr","data":"error\n"}}"#;
+        let resp: GuestResponse = serde_json::from_str(json).expect("parse failed");
+        match resp {
+            GuestResponse::Stream { stream, data } => {
+                assert_eq!(stream, "stderr");
+                assert_eq!(data, "error\n");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
     fn exit_deserializes() {
         let json = r#"{"exit":{"exit":0}}"#;
         let resp: GuestResponse = serde_json::from_str(json).expect("parse failed");
         assert!(matches!(resp, GuestResponse::Exit { exit: 0 }));
+    }
+
+    #[test]
+    fn exit_nonzero_deserializes() {
+        let json = r#"{"exit":{"exit":127}}"#;
+        let resp: GuestResponse = serde_json::from_str(json).expect("parse failed");
+        assert!(matches!(resp, GuestResponse::Exit { exit: 127 }));
+    }
+
+    #[test]
+    fn run_command_serializes() {
+        let cmd = GuestCommand::Run {
+            image: "alpine".into(),
+            args: vec!["/bin/echo".into(), "hello".into()],
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "run");
+        assert_eq!(v["image"], "alpine");
+        assert_eq!(v["args"][0], "/bin/echo");
+        assert_eq!(v["args"][1], "hello");
+    }
+
+    #[test]
+    fn ping_command_serializes() {
+        let cmd = GuestCommand::Ping;
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "ping");
+    }
+
+    /// Integration test: requires VM image artifacts in out/ and code-signed binary.
+    ///
+    /// Run with:
+    ///   PELAGOS_KERNEL=out/vmlinuz PELAGOS_INITRD=out/initramfs-custom.gz \
+    ///   PELAGOS_DISK=out/root.img cargo test -- --ignored run_echo_hello
+    #[test]
+    #[ignore]
+    fn run_echo_hello() {
+        // This test is a manual execution guide; the actual run is validated
+        // interactively. See ONGOING_TASKS.md for the full test command.
     }
 }
 

--- a/pelagos-vz/src/vm.rs
+++ b/pelagos-vz/src/vm.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use block2::RcBlock;
 use dispatch2::{DispatchQueue, DispatchQueueAttr};
 use objc2::{rc::Retained, AnyThread};
+use objc2_foundation::NSFileHandle;
 use objc2_foundation::{NSArray, NSError, NSString, NSURL};
 use objc2_virtualization::{
     VZDirectorySharingDeviceConfiguration, VZDiskImageStorageDeviceAttachment,
@@ -22,7 +23,6 @@ use objc2_virtualization::{
     VZVirtioNetworkDeviceConfiguration, VZVirtioSocketDevice, VZVirtioSocketDeviceConfiguration,
     VZVirtualMachine, VZVirtualMachineConfiguration,
 };
-use objc2_foundation::NSFileHandle;
 use std::os::fd::FromRawFd;
 
 // ---------------------------------------------------------------------------
@@ -377,11 +377,12 @@ unsafe fn start_vm(config: VmConfig) -> Result<Vm, crate::Error> {
     // 9. Virtio serial console → guest's hvc0 → host stderr.
     //    This lets us see kernel boot messages and init script output for debugging.
     let stderr_fh = NSFileHandle::fileHandleWithStandardError();
-    let serial_attach = VZFileHandleSerialPortAttachment::initWithFileHandleForReading_fileHandleForWriting(
-        VZFileHandleSerialPortAttachment::alloc(),
-        None,           // no host→guest input
-        Some(&stderr_fh),
-    );
+    let serial_attach =
+        VZFileHandleSerialPortAttachment::initWithFileHandleForReading_fileHandleForWriting(
+            VZFileHandleSerialPortAttachment::alloc(),
+            None, // no host→guest input
+            Some(&stderr_fh),
+        );
     let serial_port = VZVirtioConsoleDeviceSerialPortConfiguration::new();
     serial_port.setAttachment(Some(&*serial_attach));
     let serial_ref: &VZSerialPortConfiguration = &serial_port;
@@ -421,10 +422,14 @@ unsafe fn start_vm(config: VmConfig) -> Result<Vm, crate::Error> {
                 let desc = e.localizedDescription();
                 let domain = e.domain();
                 let code = e.code();
-                let reason = e.localizedFailureReason()
+                let reason = e
+                    .localizedFailureReason()
                     .map(|s| s.to_string())
                     .unwrap_or_default();
-                Err(format!("[{} {}] {} | reason: {}", domain, code, desc, reason))
+                Err(format!(
+                    "[{} {}] {} | reason: {}",
+                    domain, code, desc, reason
+                ))
             });
             c3.notify_one();
         });


### PR DESCRIPTION
Closes #14
Part of epic #10.

## Changes

- Unit tests for `GuestCommand::Run` and `Ping` serialization (host→guest wire format verification)
- Unit tests for `GuestResponse::Stream` (stdout + stderr), `Exit` (0 and 127), `Pong` deserialization
- Ignored integration test stub with documented manual invocation command
- `cargo fmt` applied to pelagos-guest and pelagos-vz (no logic changes)

## Manual E2E Test

After rebuilding the VM image:
```
RUST_LOG=info ./target/aarch64-apple-darwin/release/pelagos \
  --kernel out/vmlinuz --initrd out/initramfs-custom.gz --disk out/root.img \
  --cmdline 'console=hvc0' run alpine /bin/echo hello
# → hello
```