### PR TITLE
fix: closed-loop NAT readiness gate + pull retry in pelagos-guest

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -133,51 +133,70 @@ fn run_container(
     let pelagos = std::env::var("PELAGOS_BIN").unwrap_or_else(|_| "/usr/local/bin/pelagos".into());
 
     // Pull the image before running — pelagos run does not auto-pull.
-    let mut pull = match Command::new(&pelagos)
-        .arg("image")
-        .arg("pull")
-        .arg(image)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(e) => {
+    // Retry up to 3 times with 2-second backoff: the AVF NAT may not be ready
+    // for outbound TCP immediately after the network interface comes up.
+    const PULL_ATTEMPTS: u32 = 10;
+    let mut pull_error = String::new();
+    let mut pulled = false;
+    for attempt in 1..=PULL_ATTEMPTS {
+        let mut pull = match Command::new(&pelagos)
+            .arg("image")
+            .arg("pull")
+            .arg(image)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                send_response(
+                    writer,
+                    &GuestResponse::Error {
+                        error: format!("image pull spawn failed: {}", e),
+                    },
+                )?;
+                return Ok(());
+            }
+        };
+        // Collect pull output and relay it line-by-line as stderr stream.
+        let pull_stderr = pull.stderr.take().unwrap();
+        let pull_stdout = pull.stdout.take().unwrap();
+        for l in BufReader::new(pull_stderr)
+            .lines()
+            .chain(BufReader::new(pull_stdout).lines())
+            .flatten()
+        {
             send_response(
                 writer,
-                &GuestResponse::Error {
-                    error: format!("image pull spawn failed: {}", e),
+                &GuestResponse::Stream {
+                    stream: StreamKind::Stderr,
+                    data: l + "\n",
                 },
             )?;
-            return Ok(());
         }
-    };
-    // Collect pull output and relay it line-by-line as stderr stream.
-    let pull_stderr = pull.stderr.take().unwrap();
-    let pull_stdout = pull.stdout.take().unwrap();
-    for l in BufReader::new(pull_stderr)
-        .lines()
-        .chain(BufReader::new(pull_stdout).lines())
-        .flatten()
-    {
-        send_response(
-            writer,
-            &GuestResponse::Stream {
-                stream: StreamKind::Stderr,
-                data: l + "\n",
-            },
-        )?;
+        let pull_status = pull.wait()?;
+        if pull_status.success() {
+            pulled = true;
+            break;
+        }
+        pull_error = format!(
+            "image pull failed (exit {})",
+            pull_status.code().unwrap_or(-1)
+        );
+        if attempt < PULL_ATTEMPTS {
+            log::warn!(
+                "pull attempt {}/{} failed, retrying in 2s: {}",
+                attempt,
+                PULL_ATTEMPTS,
+                pull_error
+            );
+            std::thread::sleep(std::time::Duration::from_secs(2));
+        }
     }
-    let pull_status = pull.wait()?;
-    if !pull_status.success() {
+    if !pulled {
         send_response(
             writer,
-            &GuestResponse::Error {
-                error: format!(
-                    "image pull failed (exit {})",
-                    pull_status.code().unwrap_or(-1)
-                ),
-            },
+            &GuestResponse::Error { error: pull_error },
         )?;
         return Ok(());
     }

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -306,9 +306,15 @@ echo 'nameserver 8.8.4.4' >> /etc/resolv.conf
 busybox mkdir -p /tmp /run /run/pelagos
 busybox mount -t tmpfs tmpfs /tmp
 
-# Wait for the AVF NAT to be ready for outbound TCP connections.
-# Without this, the first connect() to Docker Hub races with NAT initialization.
-busybox ping -c 3 -W 5 -q 8.8.8.8 >/dev/null 2>&1 || true
+# Gate on network readiness: loop until the first ping to 8.8.8.8 succeeds,
+# then exit immediately. Exits in ~1-2s when the AVF NAT is ready on first
+# attempt; waits up to 30s if it takes longer. Without this gate, pelagos's
+# first outbound TCP connection races with NAT initialization and fails.
+i=0
+while [ \$i -lt 30 ]; do
+    busybox ping -c 1 -W 1 -q 8.8.8.8 >/dev/null 2>&1 && break
+    i=\$((i+1))
+done
 
 export PELAGOS_IMAGE_STORE=/run/pelagos
 


### PR DESCRIPTION
## Summary

- Replaces `busybox ping -c 3` (fixed 3-ping delay) in init with a `while` loop that exits on the **first successful ping** to 8.8.8.8 (max 30 attempts). True readiness gate — no wasted time when NAT is already ready.
- Adds retry logic in `pelagos-guest::run_container`: up to 10 attempts with 2s backoff on pull failure, as a defence-in-depth safety net.

## Why pure sleep-between-retries didn't work

The pull failures were immediate (sub-second), not timeouts. The NAT wasn't just slow — it was actively rejecting connections. Actively exercising the ICMP path via ping is what unblocks it; passive sleep does not.

## Test plan

- [x] `pelagos run alpine /bin/echo hello` → `hello`, 3 consecutive runs, no retries consumed
- [x] `cargo test -p pelagos-mac -p pelagos-guest` passes

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)