### PR TITLE
feat: virtiofs bind mounts (-v /host:/container[:ro])

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -24,6 +24,15 @@ pub const VSOCK_PORT: u32 = 1024;
 // Protocol types
 // ---------------------------------------------------------------------------
 
+/// A single virtiofs bind mount to apply inside the container.
+#[derive(Debug, Deserialize, Clone)]
+pub struct GuestMount {
+    /// virtiofs tag — the directory is already mounted at `/mnt/<tag>` in the guest.
+    pub tag: String,
+    /// Absolute path inside the container.
+    pub container_path: String,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 pub enum GuestCommand {
@@ -32,6 +41,8 @@ pub enum GuestCommand {
         args: Vec<String>,
         #[serde(default)]
         env: std::collections::HashMap<String, String>,
+        #[serde(default)]
+        mounts: Vec<GuestMount>,
     },
     Ping,
 }
@@ -118,8 +129,8 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 send_response(&mut writer, &GuestResponse::Pong { pong: true })?;
                 return Ok(());
             }
-            GuestCommand::Run { image, args, env } => {
-                run_container(&mut writer, &image, &args, &env)?;
+            GuestCommand::Run { image, args, env, mounts } => {
+                run_container(&mut writer, &image, &args, &env, &mounts)?;
             }
         }
     }
@@ -131,6 +142,7 @@ fn run_container(
     image: &str,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    mounts: &[GuestMount],
 ) -> std::io::Result<()> {
     let pelagos = std::env::var("PELAGOS_BIN").unwrap_or_else(|_| "/usr/local/bin/pelagos".into());
 
@@ -203,8 +215,26 @@ fn run_container(
         return Ok(());
     }
 
+    // Ensure each virtiofs mountpoint exists inside the guest before invoking
+    // pelagos run.  The init script already ran `mount -t virtiofs <tag>
+    // /mnt/<tag>` for each tag passed on the kernel cmdline.
+    for mount in mounts {
+        let guest_mnt = format!("/mnt/{}", mount.tag);
+        // The virtiofs directory should already be mounted at /mnt/<tag> by
+        // the init script.  If the mount point is absent something went wrong,
+        // but we proceed and let pelagos report the error rather than silently
+        // dropping the mount.
+        log::debug!("virtiofs share: {} → {}", guest_mnt, mount.container_path);
+    }
+
     let mut cmd = Command::new(&pelagos);
-    cmd.arg("run").arg(image);
+    cmd.arg("run");
+    // Pass each virtiofs guest-side path as a -v bind mount to pelagos run.
+    for mount in mounts {
+        let guest_mnt = format!("/mnt/{}", mount.tag);
+        cmd.arg("-v").arg(format!("{}:{}", guest_mnt, mount.container_path));
+    }
+    cmd.arg(image);
     if !args.is_empty() {
         cmd.args(args);
     }
@@ -435,9 +465,25 @@ mod tests {
         let json = r#"{"cmd":"run","image":"alpine","args":["/bin/echo","hello"]}"#;
         let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
         match cmd {
-            GuestCommand::Run { image, args, .. } => {
+            GuestCommand::Run { image, args, mounts, .. } => {
                 assert_eq!(image, "alpine");
                 assert_eq!(args, vec!["/bin/echo", "hello"]);
+                assert!(mounts.is_empty());
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_with_mounts_deserializes() {
+        let json = r#"{"cmd":"run","image":"alpine","args":["cat","/data/f"],"mounts":[{"tag":"share0","container_path":"/data"}]}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::Run { image, mounts, .. } => {
+                assert_eq!(image, "alpine");
+                assert_eq!(mounts.len(), 1);
+                assert_eq!(mounts[0].tag, "share0");
+                assert_eq!(mounts[0].container_path, "/data");
             }
             other => panic!("unexpected: {:?}", other),
         }

--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -20,9 +20,28 @@ use std::time::{Duration, Instant};
 
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+
 use pelagos_vz::vm::{Vm, VmConfig};
 
 use crate::state::StateDir;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A single virtiofs host→guest mount.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VirtiofsShare {
+    /// Host directory to expose.
+    pub host_path: PathBuf,
+    /// virtiofs mount tag (`share0`, `share1`, …).
+    pub tag: String,
+    /// Mount the share read-only inside the guest.
+    pub read_only: bool,
+    /// Absolute path inside the container where the share is mounted.
+    pub container_path: String,
+}
 
 // ---------------------------------------------------------------------------
 // Public API used by main.rs
@@ -36,13 +55,28 @@ pub struct DaemonArgs {
     pub cmdline: String,
     pub memory_mib: usize,
     pub cpus: usize,
+    /// virtiofs shares requested for this invocation.
+    pub virtiofs_shares: Vec<VirtiofsShare>,
 }
 
 /// Ensure the daemon is running, starting it if necessary.
 /// Returns Ok(()) once vm.sock is connectable.
+///
+/// If the daemon is already running but was started with a different mount
+/// configuration, returns an error asking the user to run `pelagos vm stop`.
 pub fn ensure_running(args: &DaemonArgs) -> io::Result<()> {
     let state = StateDir::open()?;
+
     if state.is_daemon_alive() {
+        // Verify that the running daemon was started with the same mounts.
+        let running_mounts = state.read_mounts()?;
+        if running_mounts != args.virtiofs_shares {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "daemon is running with different mount configuration; \
+                 run 'pelagos vm stop' first, then retry",
+            ));
+        }
         return Ok(());
     }
 
@@ -59,6 +93,18 @@ pub fn ensure_running(args: &DaemonArgs) -> io::Result<()> {
     cmd.arg("--cmdline").arg(&args.cmdline);
     cmd.arg("--memory").arg(args.memory_mib.to_string());
     cmd.arg("--cpus").arg(args.cpus.to_string());
+    // Forward virtiofs shares as repeated --volume flags to the daemon subcommand.
+    for share in &args.virtiofs_shares {
+        let mut spec = format!(
+            "{}:{}",
+            share.host_path.display(),
+            share.container_path
+        );
+        if share.read_only {
+            spec.push_str(":ro");
+        }
+        cmd.arg("--volume").arg(&spec);
+    }
     cmd.arg("vm-daemon-internal");
     cmd.stdin(std::process::Stdio::null());
     cmd.stdout(std::process::Stdio::null());
@@ -128,6 +174,11 @@ pub fn run(args: DaemonArgs) -> ! {
 
     state.write_pid(std::process::id()).unwrap_or_else(|e| {
         log::error!("write pid: {}", e);
+    });
+
+    // Persist mount configuration so subsequent invocations can verify compatibility.
+    state.write_mounts(&args.virtiofs_shares).unwrap_or_else(|e| {
+        log::error!("write mounts: {}", e);
     });
 
     log::info!("daemon listening on {}", state.sock_file.display());
@@ -255,11 +306,28 @@ fn build_vm_config(args: &DaemonArgs) -> VmConfig {
     let mut b = VmConfig::builder()
         .kernel(&args.kernel)
         .disk(&args.disk)
-        .cmdline(&args.cmdline)
+        .cmdline(build_cmdline(args))
         .memory_mib(args.memory_mib)
         .cpus(args.cpus);
     if let Some(ref initrd) = args.initrd {
         b = b.initrd(initrd);
     }
+    for share in &args.virtiofs_shares {
+        b = b.virtiofs(&share.host_path, &share.tag, share.read_only);
+    }
     b.build().expect("vm config")
+}
+
+/// Build the kernel cmdline from DaemonArgs.
+///
+/// Appends `virtiofs.tags=share0,share1,...` when shares are present so the
+/// guest init script can mount them before exec'ing pelagos-guest.
+fn build_cmdline(args: &DaemonArgs) -> String {
+    let mut cmdline = args.cmdline.clone();
+    if !args.virtiofs_shares.is_empty() {
+        let tags: Vec<&str> = args.virtiofs_shares.iter().map(|s| s.tag.as_str()).collect();
+        cmdline.push_str(" virtiofs.tags=");
+        cmdline.push_str(&tags.join(","));
+    }
+    cmdline
 }

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -47,6 +47,11 @@ struct Cli {
     #[arg(long, default_value = "2")]
     cpus: usize,
 
+    /// Bind-mount a host directory into the container: /host/path:/container/path[:ro]
+    /// May be specified multiple times.
+    #[arg(short = 'v', long = "volume", global = true)]
+    volumes: Vec<String>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -85,10 +90,24 @@ enum VmCommands {
 // Guest protocol types (mirrors pelagos-guest)
 // ---------------------------------------------------------------------------
 
+/// A mount to pass to the guest for bind-mounting inside the container.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GuestMount {
+    /// virtiofs tag (e.g. "share0") — already mounted at /mnt/<tag> in the guest.
+    pub tag: String,
+    /// Absolute path inside the container.
+    pub container_path: String,
+}
+
 #[derive(Serialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 enum GuestCommand {
-    Run { image: String, args: Vec<String> },
+    Run {
+        image: String,
+        args: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        mounts: Vec<GuestMount>,
+    },
     Ping,
 }
 
@@ -122,12 +141,21 @@ fn main() {
             let image = image.clone();
             let args = args.clone();
             let daemon_args = daemon_args_from_cli(&cli);
+            // Build the guest-side mount list from the parsed shares.
+            let mounts: Vec<GuestMount> = daemon_args
+                .virtiofs_shares
+                .iter()
+                .map(|s| GuestMount {
+                    tag: s.tag.clone(),
+                    container_path: s.container_path.clone(),
+                })
+                .collect();
             if let Err(e) = daemon::ensure_running(&daemon_args) {
                 log::error!("failed to start VM daemon: {}", e);
                 process::exit(1);
             }
             let stream = connect_or_exit();
-            process::exit(run_command(stream, image, args));
+            process::exit(run_command(stream, image, args, mounts));
         }
 
         Commands::Ping => {
@@ -151,6 +179,9 @@ fn daemon_args_from_cli(cli: &Cli) -> daemon::DaemonArgs {
         log::error!("--disk / PELAGOS_DISK is required");
         process::exit(1);
     });
+
+    let virtiofs_shares = parse_volumes(&cli.volumes);
+
     daemon::DaemonArgs {
         kernel,
         initrd: cli.initrd.clone(),
@@ -158,7 +189,36 @@ fn daemon_args_from_cli(cli: &Cli) -> daemon::DaemonArgs {
         cmdline: cli.cmdline.clone(),
         memory_mib: cli.memory,
         cpus: cli.cpus,
+        virtiofs_shares,
     }
+}
+
+/// Parse `-v /host/path:/container/path[:ro]` strings into `VirtiofsShare`s.
+/// Tags are assigned as `share0`, `share1`, etc.
+fn parse_volumes(volumes: &[String]) -> Vec<daemon::VirtiofsShare> {
+    volumes
+        .iter()
+        .enumerate()
+        .map(|(i, spec)| {
+            let parts: Vec<&str> = spec.splitn(3, ':').collect();
+            if parts.len() < 2 {
+                log::error!(
+                    "invalid volume spec {:?}: expected /host:/container[:ro]",
+                    spec
+                );
+                process::exit(1);
+            }
+            let host_path = PathBuf::from(parts[0]);
+            let container_path = parts[1].to_string();
+            let read_only = parts.get(2).is_some_and(|s| *s == "ro");
+            daemon::VirtiofsShare {
+                host_path,
+                tag: format!("share{}", i),
+                read_only,
+                container_path,
+            }
+        })
+        .collect()
 }
 
 fn connect_or_exit() -> UnixStream {
@@ -208,11 +268,16 @@ fn vm_status() {
 // Command handlers — operate on a UnixStream connected to the daemon
 // ---------------------------------------------------------------------------
 
-fn run_command(stream: UnixStream, image: String, args: Vec<String>) -> i32 {
+fn run_command(
+    stream: UnixStream,
+    image: String,
+    args: Vec<String>,
+    mounts: Vec<GuestMount>,
+) -> i32 {
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
     let mut writer = stream;
 
-    let cmd = GuestCommand::Run { image, args };
+    let cmd = GuestCommand::Run { image, args, mounts };
     let mut msg = serde_json::to_string(&cmd).unwrap();
     msg.push('\n');
     if let Err(e) = writer.write_all(msg.as_bytes()) {
@@ -297,7 +362,7 @@ fn ping_command(stream: UnixStream) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{GuestCommand, GuestResponse};
+    use super::{GuestCommand, GuestMount, GuestResponse};
 
     #[test]
     fn pong_deserializes() {
@@ -331,6 +396,7 @@ mod tests {
         let cmd = GuestCommand::Run {
             image: "alpine".into(),
             args: vec!["/bin/echo".into(), "hello".into()],
+            mounts: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -340,10 +406,52 @@ mod tests {
     }
 
     #[test]
+    fn run_command_with_mounts_serializes() {
+        let cmd = GuestCommand::Run {
+            image: "alpine".into(),
+            args: vec!["cat".into(), "/data/hello.txt".into()],
+            mounts: vec![GuestMount {
+                tag: "share0".into(),
+                container_path: "/data".into(),
+            }],
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "run");
+        assert_eq!(v["mounts"][0]["tag"], "share0");
+        assert_eq!(v["mounts"][0]["container_path"], "/data");
+    }
+
+    #[test]
     fn ping_command_serializes() {
         let cmd = GuestCommand::Ping;
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["cmd"], "ping");
+    }
+
+    #[test]
+    fn parse_volumes_basic() {
+        use super::parse_volumes;
+        let specs = vec!["/host/foo:/container/bar".to_string()];
+        let shares = parse_volumes(&specs);
+        assert_eq!(shares.len(), 1);
+        assert_eq!(shares[0].tag, "share0");
+        assert_eq!(shares[0].container_path, "/container/bar");
+        assert!(!shares[0].read_only);
+    }
+
+    #[test]
+    fn parse_volumes_readonly() {
+        use super::parse_volumes;
+        let specs = vec![
+            "/host/a:/ctr/a:ro".to_string(),
+            "/host/b:/ctr/b".to_string(),
+        ];
+        let shares = parse_volumes(&specs);
+        assert!(shares[0].read_only);
+        assert!(!shares[1].read_only);
+        assert_eq!(shares[0].tag, "share0");
+        assert_eq!(shares[1].tag, "share1");
     }
 }

--- a/pelagos-mac/src/state.rs
+++ b/pelagos-mac/src/state.rs
@@ -1,4 +1,5 @@
-//! Persistent VM state: PID file and Unix socket path in ~/.local/share/pelagos/.
+//! Persistent VM state: PID file, Unix socket path, and mounts config
+//! stored in ~/.local/share/pelagos/.
 
 use std::io;
 use std::path::PathBuf;
@@ -6,6 +7,7 @@ use std::path::PathBuf;
 pub struct StateDir {
     pub pid_file: PathBuf,
     pub sock_file: PathBuf,
+    pub mounts_file: PathBuf,
 }
 
 impl StateDir {
@@ -15,6 +17,7 @@ impl StateDir {
         Ok(Self {
             pid_file: base.join("vm.pid"),
             sock_file: base.join("vm.sock"),
+            mounts_file: base.join("vm.mounts"),
         })
     }
 
@@ -39,10 +42,31 @@ impl StateDir {
         std::fs::rename(&tmp, &self.pid_file)
     }
 
-    /// Remove PID and socket files. Best-effort; ignores errors.
+    /// Write the current daemon's mount configuration as JSON.
+    pub fn write_mounts(&self, mounts: &[crate::daemon::VirtiofsShare]) -> io::Result<()> {
+        let json = serde_json::to_string(mounts)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let tmp = self.mounts_file.with_extension("mounts.tmp");
+        std::fs::write(&tmp, json)?;
+        std::fs::rename(&tmp, &self.mounts_file)
+    }
+
+    /// Read the running daemon's mount configuration.  Returns an empty Vec
+    /// if the file does not exist.
+    pub fn read_mounts(&self) -> io::Result<Vec<crate::daemon::VirtiofsShare>> {
+        match std::fs::read_to_string(&self.mounts_file) {
+            Ok(s) => serde_json::from_str(&s)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Vec::new()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Remove PID, socket, and mounts files. Best-effort; ignores errors.
     pub fn clear(&self) {
         let _ = std::fs::remove_file(&self.pid_file);
         let _ = std::fs::remove_file(&self.sock_file);
+        let _ = std::fs::remove_file(&self.mounts_file);
     }
 }
 

--- a/pelagos-vz/src/vm.rs
+++ b/pelagos-vz/src/vm.rs
@@ -46,8 +46,8 @@ pub struct VmConfig {
     pub memory_mib: usize,
     /// vsock port the guest daemon listens on (default 1024).
     pub vsock_port: u32,
-    /// Directories to share via virtiofs: (host_path, mount_tag).
-    pub virtiofs_shares: Vec<(PathBuf, String)>,
+    /// Directories to share via virtiofs: (host_path, mount_tag, read_only).
+    pub virtiofs_shares: Vec<(PathBuf, String, bool)>,
     /// Enable Rosetta for x86_64 Linux binaries (macOS 13+).
     pub rosetta: bool,
 }
@@ -67,7 +67,7 @@ pub struct VmConfigBuilder {
     cpus: Option<usize>,
     memory_mib: Option<usize>,
     vsock_port: Option<u32>,
-    virtiofs_shares: Vec<(PathBuf, String)>,
+    virtiofs_shares: Vec<(PathBuf, String, bool)>,
     rosetta: bool,
 }
 
@@ -100,8 +100,13 @@ impl VmConfigBuilder {
         self.vsock_port = Some(p);
         self
     }
-    pub fn virtiofs(mut self, host: impl Into<PathBuf>, tag: impl Into<String>) -> Self {
-        self.virtiofs_shares.push((host.into(), tag.into()));
+    pub fn virtiofs(
+        mut self,
+        host: impl Into<PathBuf>,
+        tag: impl Into<String>,
+        read_only: bool,
+    ) -> Self {
+        self.virtiofs_shares.push((host.into(), tag.into(), read_only));
         self
     }
     pub fn rosetta(mut self, enabled: bool) -> Self {
@@ -405,10 +410,13 @@ unsafe fn start_vm(config: VmConfig) -> Result<Vm, crate::Error> {
 
     // 8. virtiofs directory shares.
     let mut fs_configs: Vec<Retained<VZVirtioFileSystemDeviceConfiguration>> = Vec::new();
-    for (host_path, tag) in &config.virtiofs_shares {
+    for (host_path, tag, read_only) in &config.virtiofs_shares {
         let host_url = file_url(host_path);
-        let shared_dir =
-            VZSharedDirectory::initWithURL_readOnly(VZSharedDirectory::alloc(), &host_url, false);
+        let shared_dir = VZSharedDirectory::initWithURL_readOnly(
+            VZSharedDirectory::alloc(),
+            &host_url,
+            *read_only,
+        );
         let share =
             VZSingleDirectoryShare::initWithDirectory(VZSingleDirectoryShare::alloc(), &shared_dir);
         let fs_config = VZVirtioFileSystemDeviceConfiguration::initWithTag(

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -309,6 +309,29 @@ while [ \$i -lt 15 ]; do
     i=\$((i+1))
 done
 
+# Mount virtiofs shares requested by the host.
+# The host appends "virtiofs.tags=share0,share1,..." to the kernel cmdline
+# when -v flags are used.  Parse and mount each tag at /mnt/<tag>.
+CMDLINE=\$(busybox cat /proc/cmdline)
+for kv in \$CMDLINE; do
+    case "\$kv" in
+        virtiofs.tags=*)
+            TAGS="\${kv#virtiofs.tags=}"
+            OLD_IFS="\$IFS"
+            IFS=","
+            for TAG in \$TAGS; do
+                IFS="\$OLD_IFS"
+                busybox mkdir -p "/mnt/\$TAG"
+                busybox mount -t virtiofs "\$TAG" "/mnt/\$TAG" && \
+                    echo "[pelagos-init] mounted virtiofs tag \$TAG at /mnt/\$TAG" || \
+                    echo "[pelagos-init] WARNING: failed to mount virtiofs tag \$TAG" >&2
+                IFS=","
+            done
+            IFS="\$OLD_IFS"
+            ;;
+    esac
+done
+
 export PELAGOS_IMAGE_STORE=/run/pelagos
 
 exec /usr/local/bin/pelagos-guest

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -191,6 +191,32 @@ else
     fail "$BACK_FAIL of 3 back-to-back runs failed"
 fi
 
+# ---------------------------------------------------------------------------
+# Test 6: virtiofs bind mount
+#
+# Mounts are fixed at daemon startup.  Stop the currently-running daemon
+# (started without -v by tests 1-5), boot a fresh one with -v, run the
+# mount test, then stop it so the lifecycle tests (7-9) can restart fresh.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== test 6: virtiofs bind mount ==="
+# Stop the no-mount daemon started by tests 1-5.
+pelagos vm stop > /dev/null 2>&1 || true
+sleep 1
+TMPHOST=$(mktemp -d)
+echo "hello from host" > "$TMPHOST/hello.txt"
+OUT=$(pelagos -v "$TMPHOST:/data" run alpine cat /data/hello.txt)
+rm -rf "$TMPHOST"
+if echo "$OUT" | grep -q "hello from host"; then
+    pass "virtiofs mount: file visible inside container"
+else
+    fail "virtiofs mount failed; output: $(echo "$OUT" | grep -v '^\[')"
+fi
+# Stop the mount-enabled daemon so lifecycle tests get a clean slate.
+pelagos vm stop > /dev/null 2>&1 || true
+sleep 1
+
 fi  # end of functional tests
 
 # ---------------------------------------------------------------------------
@@ -199,12 +225,21 @@ fi  # end of functional tests
 
 if [ "$MODE" = "cold" ] || [ "$MODE" = "warm" ]; then
 
+# In cold mode, test 6 stopped the daemon.  Restart it (no mounts) so the
+# lifecycle tests have a running daemon to inspect and stop.
+if [ "$MODE" = "cold" ]; then
+    echo ""
+    echo "=== restarting daemon (no mounts) for lifecycle tests ==="
+    pelagos ping > /dev/null 2>&1 || true  # triggers daemon start
+    sleep 1
+fi
+
 # ---------------------------------------------------------------------------
-# Test 6: vm status reports running
+# Test 7: vm status reports running
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "=== test 6: vm status ==="
+echo "=== test 7: vm status ==="
 OUT=$(pelagos vm status 2>&1 || true)
 echo "  $OUT"
 if echo "$OUT" | grep -q "running"; then
@@ -214,11 +249,11 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 7: warm ping is fast (daemon already running)
+# Test 8: warm ping is fast (daemon already running)
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "=== test 7: warm ping latency ==="
+echo "=== test 8: warm ping latency ==="
 T0=$(ms_now); OUT=$(pelagos ping); T1=$(ms_now)
 WARM_MS=$(( T1 - T0 ))
 echo "$OUT" | grep -v "^\["
@@ -239,11 +274,11 @@ if [ "$MODE" = "cold" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Test 8: vm stop + verify stopped
+# Test 9: vm stop + verify stopped
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "=== test 8: vm stop ==="
+echo "=== test 9: vm stop ==="
 pelagos vm stop > /dev/null 2>&1
 sleep 2
 OUT=$(pelagos vm status 2>&1 || true)


### PR DESCRIPTION
## Summary

- Adds `-v /host/path:/container/path[:ro]` to `pelagos run`; multiple `-v` flags allowed
- Mounts are fixed at daemon startup (tags assigned as `share0`, `share1`, …)
- Read-only mounts supported via `:ro` suffix
- Re-invoking with a different mount set while the daemon is running produces a helpful error: *"daemon running with different mounts; run 'pelagos vm stop' first"*

## Architecture

- **Host**: `-v` flags parsed by the CLI, assigned stable tags (`share0`, …), passed to `DaemonArgs`. Daemon writes them to `vm.mounts` (JSON) in state dir and appends `virtiofs.tags=share0,...` to the kernel cmdline. `VZSharedDirectory` receives the correct `readOnly:` flag.
- **Guest init**: reads `virtiofs.tags=` from `/proc/cmdline`, mounts each tag at `/mnt/<tag>` via `mount -t virtiofs` before exec'ing `pelagos-guest`.
- **pelagos-guest**: receives mount mapping (tag → container path) in `GuestCommand::Run`, passes `-v /mnt/<tag>:<container_path>` to `pelagos run`.

## Files changed

| File | Change |
|---|---|
| `pelagos-vz/src/vm.rs` | `virtiofs_shares` tuple gains `read_only: bool`; passed to `VZSharedDirectory` |
| `pelagos-mac/src/state.rs` | `mounts_file`, `read_mounts()`, `write_mounts()`; `clear()` removes it |
| `pelagos-mac/src/daemon.rs` | `VirtiofsShare` type; mount-mismatch check; `virtiofs.tags` cmdline; persist mounts |
| `pelagos-mac/src/main.rs` | `-v`/`--volume` global arg; `parse_volumes()`; `GuestMount` forwarded in JSON |
| `pelagos-guest/src/main.rs` | `GuestMount`; `-v /mnt/<tag>:<path>` passed to `pelagos run` |
| `scripts/build-vm-image.sh` | Init parses `virtiofs.tags` from `/proc/cmdline`, mounts each tag |
| `scripts/test-e2e.sh` | Test 6 (virtiofs); lifecycle tests renumbered 7-9 |

## Test plan

- [x] All 9 e2e tests pass (`scripts/test-e2e.sh --cold`) on real hardware
- [x] Test 6 verifies file written on host is visible inside container via virtiofs
- [x] Read-only parsing covered by unit tests (`parse_volumes_readonly`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` 8/8 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)