### PR TITLE
feat: container lifecycle commands (ps, logs, stop, rm, --detach, --name)

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -83,6 +83,12 @@ pub enum GuestCommand {
         env: std::collections::HashMap<String, String>,
         #[serde(default)]
         mounts: Vec<GuestMount>,
+        /// Optional container name passed to `pelagos run --name`.
+        #[serde(default)]
+        name: Option<String>,
+        /// Run detached; maps to `pelagos run --detach`.
+        #[serde(default)]
+        detach: bool,
     },
     Exec {
         image: String,
@@ -91,6 +97,27 @@ pub enum GuestCommand {
         env: std::collections::HashMap<String, String>,
         #[serde(default)]
         tty: bool,
+    },
+    /// List containers; maps to `pelagos ps [--all]`.
+    Ps {
+        #[serde(default)]
+        all: bool,
+    },
+    /// Print container logs; maps to `pelagos logs [--follow] <name>`.
+    Logs {
+        name: String,
+        #[serde(default)]
+        follow: bool,
+    },
+    /// Stop a running container; maps to `pelagos stop <name>`.
+    Stop {
+        name: String,
+    },
+    /// Remove a container; maps to `pelagos rm [--force] <name>`.
+    Rm {
+        name: String,
+        #[serde(default)]
+        force: bool,
     },
     Ping,
 }
@@ -183,8 +210,18 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 args,
                 env,
                 mounts,
+                name,
+                detach,
             } => {
-                run_container(&mut writer, &image, &args, &env, &mounts)?;
+                run_container(
+                    &mut writer,
+                    &image,
+                    &args,
+                    &env,
+                    &mounts,
+                    name.as_deref(),
+                    detach,
+                )?;
             }
             GuestCommand::Exec {
                 image,
@@ -195,9 +232,46 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 handle_exec(fd, &image, &args, &env, tty)?;
                 return Ok(());
             }
+            GuestCommand::Ps { all } => {
+                let mut cmd = Command::new(pelagos_bin());
+                cmd.arg("ps");
+                if all {
+                    cmd.arg("--all");
+                }
+                spawn_and_stream(&mut writer, cmd)?;
+            }
+            GuestCommand::Logs { name, follow } => {
+                let mut cmd = Command::new(pelagos_bin());
+                cmd.arg("logs").arg(&name);
+                if follow {
+                    cmd.arg("--follow");
+                }
+                spawn_and_stream(&mut writer, cmd)?;
+            }
+            GuestCommand::Stop { name } => {
+                let mut cmd = Command::new(pelagos_bin());
+                cmd.arg("stop").arg(&name);
+                spawn_and_stream(&mut writer, cmd)?;
+            }
+            GuestCommand::Rm { name, force } => {
+                let mut cmd = Command::new(pelagos_bin());
+                cmd.arg("rm").arg(&name);
+                if force {
+                    cmd.arg("--force");
+                }
+                spawn_and_stream(&mut writer, cmd)?;
+            }
         }
     }
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// pelagos binary path
+// ---------------------------------------------------------------------------
+
+fn pelagos_bin() -> String {
+    std::env::var("PELAGOS_BIN").unwrap_or_else(|_| "/usr/local/bin/pelagos".into())
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +281,7 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
 /// Pull the image, streaming stderr lines back via the provided writer.
 /// Returns Ok(true) on success, Ok(false) on failure (error response sent).
 fn pull_image(writer: &mut impl Write, image: &str) -> std::io::Result<bool> {
-    let pelagos = std::env::var("PELAGOS_BIN").unwrap_or_else(|_| "/usr/local/bin/pelagos".into());
+    let pelagos = pelagos_bin();
 
     const PULL_ATTEMPTS: u32 = 10;
     let mut pull_error = String::new();
@@ -274,8 +348,10 @@ fn run_container(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     mounts: &[GuestMount],
+    name: Option<&str>,
+    detach: bool,
 ) -> std::io::Result<()> {
-    let pelagos = std::env::var("PELAGOS_BIN").unwrap_or_else(|_| "/usr/local/bin/pelagos".into());
+    let pelagos = pelagos_bin();
 
     if !pull_image(writer, image)? {
         return Ok(());
@@ -295,6 +371,12 @@ fn run_container(
 
     let mut cmd = Command::new(&pelagos);
     cmd.arg("run");
+    if let Some(n) = name {
+        cmd.arg("--name").arg(n);
+    }
+    if detach {
+        cmd.arg("--detach");
+    }
     // Pass each virtiofs guest-side path as a -v bind mount to pelagos run.
     for mount in mounts {
         let guest_mnt = format!("/mnt/{}", mount.tag);
@@ -308,6 +390,21 @@ fn run_container(
     for (k, v) in env {
         cmd.env(k, v);
     }
+
+    if detach {
+        run_detached(writer, cmd)
+    } else {
+        spawn_and_stream(writer, cmd)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// spawn_and_stream — generic helper for non-interactive pelagos subcommands
+// ---------------------------------------------------------------------------
+
+/// Spawn `cmd` with piped stdout/stderr, relay both streams as JSON
+/// `GuestResponse::Stream` messages, then send a final `GuestResponse::Exit`.
+fn spawn_and_stream(writer: &mut impl Write, mut cmd: Command) -> std::io::Result<()> {
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     let mut child = match cmd.spawn() {
@@ -323,7 +420,6 @@ fn run_container(
         }
     };
 
-    // Stream stdout and stderr concurrently using threads.
     let stdout_pipe = child.stdout.take().unwrap();
     let stderr_pipe = child.stderr.take().unwrap();
 
@@ -364,7 +460,6 @@ fn run_container(
         let _ = tx_err.send(Chunk::Done);
     });
 
-    // Relay chunks to the vsock writer until both streams signal Done.
     let mut done_count = 0;
     while done_count < 2 {
         match rx.recv() {
@@ -398,6 +493,65 @@ fn run_container(
 }
 
 // ---------------------------------------------------------------------------
+// run_detached — reads container name then drops stdout pipe immediately
+// ---------------------------------------------------------------------------
+
+/// Run pelagos with `--detach`, read the one-line container name from stdout,
+/// then drop the pipe so the watcher child (which holds the write end) does not
+/// block this function.  Sends `GuestResponse::Stream` with the name followed
+/// by `GuestResponse::Exit`.
+fn run_detached(writer: &mut impl Write, mut cmd: Command) -> std::io::Result<()> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            send_response(
+                writer,
+                &GuestResponse::Error {
+                    error: e.to_string(),
+                },
+            )?;
+            return Ok(());
+        }
+    };
+
+    // Read exactly one line (the container name) and immediately drop the pipe.
+    // The watcher child keeps the write end open for the container's lifetime;
+    // dropping our read end here prevents blocking on the watcher.
+    let name_line = {
+        let stdout_pipe = child.stdout.take().unwrap();
+        let mut reader = BufReader::new(stdout_pipe);
+        let mut line = String::new();
+        let _ = reader.read_line(&mut line);
+        let trimmed = line
+            .trim_end_matches('\n')
+            .trim_end_matches('\r')
+            .to_string();
+        trimmed
+        // stdout_pipe (via reader) is dropped here — write end stays open in watcher
+    };
+
+    // The pelagos parent exits after printing the name; wait for it (fast).
+    let status = child.wait()?;
+    let code = status.code().unwrap_or(-1);
+
+    if !name_line.is_empty() {
+        send_response(
+            writer,
+            &GuestResponse::Stream {
+                stream: StreamKind::Stdout,
+                data: name_line + "\n",
+            },
+        )?;
+    }
+    send_response(writer, &GuestResponse::Exit { exit: code })?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Exec handler
 // ---------------------------------------------------------------------------
 
@@ -408,7 +562,7 @@ fn handle_exec(
     env: &std::collections::HashMap<String, String>,
     tty: bool,
 ) -> std::io::Result<()> {
-    let pelagos = std::env::var("PELAGOS_BIN").unwrap_or_else(|_| "/usr/local/bin/pelagos".into());
+    let pelagos = pelagos_bin();
 
     // Pull the image before sending ready; relay stderr as JSON stream so the
     // host can display pull progress while waiting.
@@ -842,11 +996,29 @@ mod tests {
                 image,
                 args,
                 mounts,
+                name,
+                detach,
                 ..
             } => {
                 assert_eq!(image, "alpine");
                 assert_eq!(args, vec!["/bin/echo", "hello"]);
                 assert!(mounts.is_empty());
+                assert!(name.is_none());
+                assert!(!detach);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_with_name_and_detach_deserializes() {
+        let json =
+            r#"{"cmd":"run","image":"alpine","args":["sleep","30"],"name":"mybox","detach":true}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::Run { name, detach, .. } => {
+                assert_eq!(name.as_deref(), Some("mybox"));
+                assert!(detach);
             }
             other => panic!("unexpected: {:?}", other),
         }
@@ -894,6 +1066,47 @@ mod tests {
             }
             other => panic!("unexpected: {:?}", other),
         }
+    }
+
+    #[test]
+    fn ps_deserializes() {
+        let json = r#"{"cmd":"ps","all":true}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        assert!(matches!(cmd, GuestCommand::Ps { all: true }));
+    }
+
+    #[test]
+    fn ps_defaults_all_false() {
+        let json = r#"{"cmd":"ps"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        assert!(matches!(cmd, GuestCommand::Ps { all: false }));
+    }
+
+    #[test]
+    fn logs_deserializes() {
+        let json = r#"{"cmd":"logs","name":"mybox","follow":true}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::Logs { name, follow } => {
+                assert_eq!(name, "mybox");
+                assert!(follow);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn stop_deserializes() {
+        let json = r#"{"cmd":"stop","name":"mybox"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        assert!(matches!(cmd, GuestCommand::Stop { name } if name == "mybox"));
+    }
+
+    #[test]
+    fn rm_deserializes() {
+        let json = r#"{"cmd":"rm","name":"mybox","force":true}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        assert!(matches!(cmd, GuestCommand::Rm { name, force: true } if name == "mybox"));
     }
 
     #[test]

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -65,6 +65,12 @@ enum Commands {
         /// Arguments to pass to the container (use -- before flags, e.g. -- -c "cmd")
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
+        /// Assign a name to the container
+        #[arg(long)]
+        name: Option<String>,
+        /// Run in background; print container name and exit
+        #[arg(short = 'd', long)]
+        detach: bool,
     },
     /// Run a command interactively in a container (stdin forwarded, optional TTY)
     Exec {
@@ -76,6 +82,33 @@ enum Commands {
         /// Allocate a pseudo-TTY (default: auto-detect from stdin)
         #[arg(short = 't', long)]
         tty: bool,
+    },
+    /// List containers (running by default; use -a for all)
+    Ps {
+        /// Show all containers, including exited
+        #[arg(short = 'a', long)]
+        all: bool,
+    },
+    /// Print container logs
+    Logs {
+        /// Container name
+        name: String,
+        /// Follow log output
+        #[arg(short = 'f', long)]
+        follow: bool,
+    },
+    /// Stop a running container
+    Stop {
+        /// Container name
+        name: String,
+    },
+    /// Remove a container
+    Rm {
+        /// Container name
+        name: String,
+        /// Force remove even if running
+        #[arg(short = 'f', long)]
+        force: bool,
     },
     /// Ping the guest daemon (readiness check)
     Ping,
@@ -110,6 +143,10 @@ pub struct GuestMount {
     pub container_path: String,
 }
 
+fn is_false(b: &bool) -> bool {
+    !b
+}
+
 #[derive(Serialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 enum GuestCommand {
@@ -118,6 +155,10 @@ enum GuestCommand {
         args: Vec<String>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         mounts: Vec<GuestMount>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(skip_serializing_if = "is_false")]
+        detach: bool,
     },
     Exec {
         image: String,
@@ -125,6 +166,23 @@ enum GuestCommand {
         #[serde(default)]
         env: std::collections::HashMap<String, String>,
         tty: bool,
+    },
+    Ps {
+        #[serde(skip_serializing_if = "is_false")]
+        all: bool,
+    },
+    Logs {
+        name: String,
+        #[serde(skip_serializing_if = "is_false")]
+        follow: bool,
+    },
+    Stop {
+        name: String,
+    },
+    Rm {
+        name: String,
+        #[serde(skip_serializing_if = "is_false")]
+        force: bool,
     },
     Ping,
 }
@@ -191,9 +249,12 @@ fn main() {
         Commands::Run {
             ref image,
             ref args,
+            ref name,
+            detach,
         } => {
             let image = image.clone();
             let args = args.clone();
+            let name = name.clone();
             let daemon_args = daemon_args_from_cli(&cli);
             // Build the guest-side mount list from the parsed shares.
             let mounts: Vec<GuestMount> = daemon_args
@@ -209,7 +270,16 @@ fn main() {
                 process::exit(1);
             }
             let stream = connect_or_exit();
-            process::exit(run_command(stream, image, args, mounts));
+            process::exit(passthrough_command(
+                stream,
+                GuestCommand::Run {
+                    image,
+                    args,
+                    mounts,
+                    name,
+                    detach,
+                },
+            ));
         }
 
         Commands::Exec {
@@ -237,6 +307,55 @@ fn main() {
             }
             let stream = connect_or_exit();
             process::exit(ping_command(stream));
+        }
+
+        Commands::Ps { all } => {
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit();
+            process::exit(passthrough_command(stream, GuestCommand::Ps { all }));
+        }
+
+        Commands::Logs { ref name, follow } => {
+            let name = name.clone();
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit();
+            process::exit(passthrough_command(
+                stream,
+                GuestCommand::Logs { name, follow },
+            ));
+        }
+
+        Commands::Stop { ref name } => {
+            let name = name.clone();
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit();
+            process::exit(passthrough_command(stream, GuestCommand::Stop { name }));
+        }
+
+        Commands::Rm { ref name, force } => {
+            let name = name.clone();
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit();
+            process::exit(passthrough_command(
+                stream,
+                GuestCommand::Rm { name, force },
+            ));
         }
     }
 }
@@ -351,20 +470,12 @@ fn vm_status() {
 // Command handlers — operate on a UnixStream connected to the daemon
 // ---------------------------------------------------------------------------
 
-fn run_command(
-    stream: UnixStream,
-    image: String,
-    args: Vec<String>,
-    mounts: Vec<GuestMount>,
-) -> i32 {
+/// Send `cmd` to the guest and relay streaming output to stdout/stderr.
+/// Returns the container exit code (or 1 on protocol error).
+fn passthrough_command(stream: UnixStream, cmd: GuestCommand) -> i32 {
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
     let mut writer = stream;
 
-    let cmd = GuestCommand::Run {
-        image,
-        args,
-        mounts,
-    };
     let mut msg = serde_json::to_string(&cmd).unwrap();
     msg.push('\n');
     if let Err(e) = writer.write_all(msg.as_bytes()) {
@@ -742,12 +853,33 @@ mod tests {
             image: "alpine".into(),
             args: vec!["/bin/echo".into(), "hello".into()],
             mounts: vec![],
+            name: None,
+            detach: false,
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["cmd"], "run");
         assert_eq!(v["image"], "alpine");
         assert_eq!(v["args"][0], "/bin/echo");
+        // name and detach omitted when None/false
+        assert!(v.get("name").is_none() || v["name"].is_null());
+        assert!(v.get("detach").is_none() || v["detach"] == false);
+    }
+
+    #[test]
+    fn run_command_with_name_detach_serializes() {
+        let cmd = GuestCommand::Run {
+            image: "alpine".into(),
+            args: vec!["sleep".into(), "30".into()],
+            mounts: vec![],
+            name: Some("mybox".into()),
+            detach: true,
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "run");
+        assert_eq!(v["name"], "mybox");
+        assert_eq!(v["detach"], true);
     }
 
     #[test]
@@ -759,12 +891,61 @@ mod tests {
                 tag: "share0".into(),
                 container_path: "/data".into(),
             }],
+            name: None,
+            detach: false,
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["cmd"], "run");
         assert_eq!(v["mounts"][0]["tag"], "share0");
         assert_eq!(v["mounts"][0]["container_path"], "/data");
+    }
+
+    #[test]
+    fn ps_command_serializes() {
+        let cmd = GuestCommand::Ps { all: true };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "ps");
+        assert_eq!(v["all"], true);
+    }
+
+    #[test]
+    fn logs_command_serializes() {
+        let cmd = GuestCommand::Logs {
+            name: "mybox".into(),
+            follow: false,
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "logs");
+        assert_eq!(v["name"], "mybox");
+        // follow omitted when false
+        assert!(v.get("follow").is_none() || v["follow"] == false);
+    }
+
+    #[test]
+    fn stop_command_serializes() {
+        let cmd = GuestCommand::Stop {
+            name: "mybox".into(),
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "stop");
+        assert_eq!(v["name"], "mybox");
+    }
+
+    #[test]
+    fn rm_command_serializes() {
+        let cmd = GuestCommand::Rm {
+            name: "mybox".into(),
+            force: true,
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "rm");
+        assert_eq!(v["name"], "mybox");
+        assert_eq!(v["force"], true);
     }
 
     #[test]

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -251,6 +251,85 @@ fi
 pelagos vm stop > /dev/null 2>&1 || true
 sleep 1
 
+# ---------------------------------------------------------------------------
+# Tests 8-13: container lifecycle (ps, logs, stop, rm, --name, --detach)
+#
+# Requires the daemon to be running without mounts; restarts clean after
+# test 7 stopped it.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== test 8: run --detach --name ==="
+# Start daemon (no mounts) before detach tests.
+pelagos ping > /dev/null 2>&1 || true
+sleep 1
+LC_NAME="pelagos-lc-test-$$"
+OUT=$(pelagos run --detach --name "$LC_NAME" alpine /bin/sh -c "echo lc-output; sleep 15")
+echo "$OUT" | grep -v "^\["
+if echo "$OUT" | grep -q "$LC_NAME"; then
+    pass "run --detach: printed container name '${LC_NAME}'"
+else
+    fail "run --detach: expected container name '${LC_NAME}', got: $(echo "$OUT" | grep -v '^\[')"
+fi
+
+echo ""
+echo "=== test 9: ps shows running container ==="
+# Give the detached container a moment to register.
+sleep 1
+OUT=$(pelagos ps)
+echo "$OUT" | grep -v "^\["
+if echo "$OUT" | grep -q "$LC_NAME"; then
+    pass "ps: running container '${LC_NAME}' visible"
+else
+    fail "ps: expected '${LC_NAME}', got: $(echo "$OUT" | grep -v '^\[')"
+fi
+
+echo ""
+echo "=== test 10: logs show container output ==="
+OUT=$(pelagos logs "$LC_NAME")
+echo "$OUT" | grep -v "^\["
+if echo "$OUT" | grep -q "lc-output"; then
+    pass "logs: 'lc-output' present in logs"
+else
+    fail "logs: expected 'lc-output', got: $(echo "$OUT" | grep -v '^\[')"
+fi
+
+echo ""
+echo "=== test 11: stop container ==="
+pelagos stop "$LC_NAME"; STOP_EXIT=$?
+# pelagos stop returns 0 on success (output may vary)
+if [ "$STOP_EXIT" -eq 0 ]; then
+    pass "stop: exited 0"
+else
+    fail "stop: non-zero exit (got $STOP_EXIT)"
+fi
+
+echo ""
+echo "=== test 12: ps --all shows exited container ==="
+sleep 1
+OUT=$(pelagos ps --all)
+echo "$OUT" | grep -v "^\["
+if echo "$OUT" | grep -q "$LC_NAME"; then
+    pass "ps --all: stopped container '${LC_NAME}' still visible"
+else
+    fail "ps --all: expected '${LC_NAME}', got: $(echo "$OUT" | grep -v '^\[')"
+fi
+
+echo ""
+echo "=== test 13: rm removes container ==="
+pelagos rm "$LC_NAME" > /dev/null 2>&1
+OUT=$(pelagos ps --all)
+echo "$OUT" | grep -v "^\["
+if echo "$OUT" | grep -q "$LC_NAME"; then
+    fail "rm: '${LC_NAME}' still appears after rm"
+else
+    pass "rm: '${LC_NAME}' no longer in ps --all"
+fi
+
+# Stop daemon so lifecycle tests get a clean slate.
+pelagos vm stop > /dev/null 2>&1 || true
+sleep 1
+
 fi  # end of functional tests
 
 # ---------------------------------------------------------------------------
@@ -259,7 +338,7 @@ fi  # end of functional tests
 
 if [ "$MODE" = "cold" ] || [ "$MODE" = "warm" ]; then
 
-# In cold mode, test 6 stopped the daemon.  Restart it (no mounts) so the
+# In cold mode, test 13 stopped the daemon.  Restart it (no mounts) so the
 # lifecycle tests have a running daemon to inspect and stop.
 if [ "$MODE" = "cold" ]; then
     echo ""
@@ -269,11 +348,11 @@ if [ "$MODE" = "cold" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Test 7: vm status reports running
+# Test 14: vm status reports running
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "=== test 7: vm status ==="
+echo "=== test 14: vm status ==="
 OUT=$(pelagos vm status 2>&1 || true)
 echo "  $OUT"
 if echo "$OUT" | grep -q "running"; then
@@ -283,11 +362,11 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 8: warm ping is fast (daemon already running)
+# Test 15: warm ping is fast (daemon already running)
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "=== test 8: warm ping latency ==="
+echo "=== test 15: warm ping latency ==="
 T0=$(ms_now); OUT=$(pelagos ping); T1=$(ms_now)
 WARM_MS=$(( T1 - T0 ))
 echo "$OUT" | grep -v "^\["
@@ -308,11 +387,11 @@ if [ "$MODE" = "cold" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Test 9: vm stop + verify stopped
+# Test 16: vm stop + verify stopped
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "=== test 9: vm stop ==="
+echo "=== test 16: vm stop ==="
 pelagos vm stop > /dev/null 2>&1
 sleep 2
 OUT=$(pelagos vm status 2>&1 || true)


### PR DESCRIPTION
## Summary

- **`pelagos run --name <n> --detach/-d`** — run a container detached, print its name
- **`pelagos ps [--all/-a]`** — list running (or all) containers
- **`pelagos logs [-f] <name>`** — print (or follow) container logs
- **`pelagos stop <name>`** — stop a running container
- **`pelagos rm [-f] <name>`** — remove a stopped container

Implements the Phase 3 lifecycle commands described in issue #36.

Key implementation detail: `run --detach` forks inside `pelagos` — the parent prints the container name and exits, the watcher child inherits stdout and holds it open for the container's entire lifetime. `run_detached()` reads exactly one line then drops its read end of the pipe immediately, avoiding an indefinite block on `BufReader::lines()`.

Closes #36

## Test plan

- [x] Unit tests for all new `GuestCommand` / `GuestResponse` serialization paths
- [x] E2E tests 8–13: `run --detach --name`, `ps`, `logs`, `stop`, `ps --all`, `rm`
- [x] All 14 e2e tests pass on real hardware (`scripts/test-e2e.sh`)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)