### PR TITLE
fix: exec TTY auto-detect and mount devpts in VM init

### DIFF
--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -289,7 +289,10 @@ fn main() {
         } => {
             let image = image.clone();
             let args = args.clone();
-            let tty = tty || unsafe { libc::isatty(libc::STDIN_FILENO) } != 0;
+            // Auto-detect: enable TTY only when stdout is a real terminal.
+            // Checking STDOUT (not STDIN) correctly handles `OUT=$(pelagos exec ...)`:
+            // stdout is a pipe, so TTY is skipped even when stdin is a terminal.
+            let tty = tty || unsafe { libc::isatty(libc::STDOUT_FILENO) } != 0;
             let daemon_args = daemon_args_from_cli(&cli);
             if let Err(e) = daemon::ensure_running(&daemon_args) {
                 log::error!("failed to start VM daemon: {}", e);

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -264,6 +264,8 @@ UDHCPC
 
 # Mount kernel virtual filesystems — required by container namespaces and cgroups.
 busybox mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+busybox mkdir -p /dev/pts
+busybox mount -t devpts   devpts   /dev/pts 2>/dev/null || true
 busybox mount -t proc     proc     /proc 2>/dev/null || true
 busybox mount -t sysfs    sysfs    /sys 2>/dev/null || true
 busybox mkdir -p /sys/fs/cgroup


### PR DESCRIPTION
## Summary

Two related bugs in `pelagos exec`:

- **Wrong fd for TTY auto-detect**: auto-detection used `isatty(STDIN_FILENO)`. When exec is captured as `OUT=$(pelagos exec ...)`, stdin is still the real terminal, so exec incorrectly switched to PTY mode. Fixed to use `isatty(STDOUT_FILENO)` — stdout is a pipe in that case, so non-TTY mode is correctly chosen. Interactive use (stdout is a terminal) still auto-enables TTY.

- **`/dev/pts` not mounted**: `openpty()` requires the devpts filesystem; the VM init script only mounted devtmpfs. Added `mkdir /dev/pts` + `mount -t devpts devpts /dev/pts` after the devtmpfs mount so PTY allocation works.

## Test plan

- [x] All 14 e2e tests pass (`scripts/test-e2e.sh`)
- [x] Test 7 (exec non-TTY) passes when run from a real terminal
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)