### PR TITLE
test: add TTY exec test (7b) to catch devpts and auto-detect regressions

### DIFF
--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -247,6 +247,25 @@ else
     fail "exec: expected 'hello from stdin', got: $(echo "$OUT" | grep -v '^\[')"
 fi
 
+# ---------------------------------------------------------------------------
+# Test 7b: exec with explicit -t (TTY / PTY mode)
+#
+# PTY output uses \r\n line endings; strip \r before comparing.
+# This test catches two failure modes that are invisible in non-TTY context:
+#   1. /dev/pts not mounted in the VM (openpty returns ENOENT)
+#   2. TTY auto-detection logic choosing wrong mode
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== test 7b: exec -t (tty mode) ==="
+OUT=$(pelagos exec -t alpine /bin/echo hello-tty 2>&1 | tr -d '\r')
+echo "$OUT" | grep -v "^\["
+if echo "$OUT" | grep -q "hello-tty"; then
+    pass "exec -t: PTY output correct"
+else
+    fail "exec -t: expected 'hello-tty', got: $(echo "$OUT" | grep -v '^\[')"
+fi
+
 # Stop daemon so lifecycle tests get a clean slate.
 pelagos vm stop > /dev/null 2>&1 || true
 sleep 1


### PR DESCRIPTION
## Summary

Adds test 7b: `pelagos exec -t alpine /bin/echo hello-tty`

This covers two failure modes that are invisible when tests run in a non-TTY context (CI, tool subprocesses, `$(...)` capture):

1. `/dev/pts` not mounted in the VM → `openpty()` returns `ENOENT`
2. `isatty()` auto-detect using wrong fd → wrong TTY mode selected

Both bugs were caught manually by the user but not by the existing test suite. PTY output uses CRLF line endings; the test strips `\r` with `tr` before comparing.

## Test plan

- [x] 15/15 e2e tests pass on real hardware (`scripts/test-e2e.sh`)
- [x] Test 7b passes from a real interactive terminal (the environment where the original bugs manifested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)