### PR TITLE
feat: pelagos vm shell — interactive shell directly in the VM

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -119,6 +119,11 @@ pub enum GuestCommand {
         #[serde(default)]
         force: bool,
     },
+    /// Open a shell directly in the VM (no container, no namespaces).
+    Shell {
+        #[serde(default)]
+        tty: bool,
+    },
     Ping,
 }
 
@@ -260,6 +265,17 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                     cmd.arg("--force");
                 }
                 spawn_and_stream(&mut writer, cmd)?;
+            }
+            GuestCommand::Shell { tty } => {
+                // Send ready ack — switches the connection to framed binary protocol.
+                send_response(&mut writer, &GuestResponse::Ready { ready: true })?;
+                let cmd = Command::new("/bin/sh");
+                if tty {
+                    handle_exec_tty(fd, cmd)?;
+                } else {
+                    handle_exec_piped(fd, cmd)?;
+                }
+                return Ok(());
             }
         }
     }
@@ -579,22 +595,7 @@ fn handle_exec(
         send_response(&mut tmp_writer, &GuestResponse::Ready { ready: true })?;
     }
 
-    if tty {
-        handle_exec_tty(fd, &pelagos, image, args, env)
-    } else {
-        handle_exec_piped(fd, &pelagos, image, args, env)
-    }
-}
-
-/// Non-TTY exec: spawn with piped stdin/stdout/stderr, forward via frames.
-fn handle_exec_piped(
-    fd: libc::c_int,
-    pelagos: &str,
-    image: &str,
-    args: &[String],
-    env: &std::collections::HashMap<String, String>,
-) -> std::io::Result<()> {
-    let mut cmd = Command::new(pelagos);
+    let mut cmd = Command::new(&pelagos);
     cmd.arg("run").arg(image);
     if !args.is_empty() {
         cmd.args(args);
@@ -602,6 +603,16 @@ fn handle_exec_piped(
     for (k, v) in env {
         cmd.env(k, v);
     }
+
+    if tty {
+        handle_exec_tty(fd, cmd)
+    } else {
+        handle_exec_piped(fd, cmd)
+    }
+}
+
+/// Non-TTY exec: spawn with piped stdin/stdout/stderr, forward via frames.
+fn handle_exec_piped(fd: libc::c_int, mut cmd: Command) -> std::io::Result<()> {
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -706,13 +717,7 @@ fn handle_exec_piped(
 }
 
 /// TTY exec: allocate a pseudo-TTY, spawn child with it, forward via frames.
-fn handle_exec_tty(
-    fd: libc::c_int,
-    pelagos: &str,
-    image: &str,
-    args: &[String],
-    env: &std::collections::HashMap<String, String>,
-) -> std::io::Result<()> {
+fn handle_exec_tty(fd: libc::c_int, mut cmd: Command) -> std::io::Result<()> {
     use std::os::unix::io::FromRawFd;
 
     // Open a pseudo-TTY.
@@ -735,15 +740,7 @@ fn handle_exec_tty(
         return Ok(());
     }
 
-    // Spawn child with slave as stdin/stdout/stderr.
-    let mut cmd = Command::new(pelagos);
-    cmd.arg("run").arg(image);
-    if !args.is_empty() {
-        cmd.args(args);
-    }
-    for (k, v) in env {
-        cmd.env(k, v);
-    }
+    // Set slave as stdin/stdout/stderr and configure PTY session.
     unsafe {
         cmd.stdin(Stdio::from_raw_fd(slave_fd));
         cmd.stdout(Stdio::from_raw_fd(slave_fd));
@@ -1125,6 +1122,20 @@ mod tests {
         let json = r#"{"cmd":"rm","name":"mybox","force":true}"#;
         let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
         assert!(matches!(cmd, GuestCommand::Rm { name, force: true } if name == "mybox"));
+    }
+
+    #[test]
+    fn shell_deserializes() {
+        let json = r#"{"cmd":"shell","tty":true}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        assert!(matches!(cmd, GuestCommand::Shell { tty: true }));
+    }
+
+    #[test]
+    fn shell_defaults_tty_false() {
+        let json = r#"{"cmd":"shell"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        assert!(matches!(cmd, GuestCommand::Shell { tty: false }));
     }
 
     #[test]

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -128,6 +128,8 @@ enum VmCommands {
     Stop,
     /// Show persistent VM daemon status
     Status,
+    /// Open an interactive shell directly in the VM (not in a container)
+    Shell,
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +167,11 @@ enum GuestCommand {
         args: Vec<String>,
         #[serde(default)]
         env: std::collections::HashMap<String, String>,
+        tty: bool,
+    },
+    /// Open a shell directly in the VM (no container, no namespaces).
+    Shell {
+        #[serde(skip_serializing_if = "is_false")]
         tty: bool,
     },
     Ps {
@@ -245,6 +252,18 @@ fn main() {
         Commands::Vm {
             sub: VmCommands::Status,
         } => vm_status(),
+        Commands::Vm {
+            sub: VmCommands::Shell,
+        } => {
+            let tty = unsafe { libc::isatty(libc::STDOUT_FILENO) } != 0;
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit();
+            process::exit(exec_command(stream, GuestCommand::Shell { tty }, tty));
+        }
 
         Commands::Run {
             ref image,
@@ -299,7 +318,16 @@ fn main() {
                 process::exit(1);
             }
             let stream = connect_or_exit();
-            process::exit(exec_command(stream, image, args, tty));
+            process::exit(exec_command(
+                stream,
+                GuestCommand::Exec {
+                    image,
+                    args,
+                    env: std::collections::HashMap::new(),
+                    tty,
+                },
+                tty,
+            ));
         }
 
         Commands::Ping => {
@@ -559,17 +587,13 @@ fn ping_command(stream: UnixStream) -> i32 {
 
 /// Run an exec command: send the exec JSON handshake, read ready ack, then
 /// switch to framed binary protocol forwarding stdin/stdout/stderr.
-fn exec_command(stream: UnixStream, image: String, args: Vec<String>, tty: bool) -> i32 {
+/// Send an exec-style command (Exec or Shell) and handle the binary frame protocol.
+/// `tty` controls whether the host terminal is put into raw mode.
+fn exec_command(stream: UnixStream, cmd: GuestCommand, tty: bool) -> i32 {
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
     let mut writer = stream.try_clone().expect("clone stream");
 
-    // Send exec handshake.
-    let cmd = GuestCommand::Exec {
-        image,
-        args,
-        env: std::collections::HashMap::new(),
-        tty,
-    };
+    // Send handshake.
     let mut msg = serde_json::to_string(&cmd).unwrap();
     msg.push('\n');
     if let Err(e) = writer.write_all(msg.as_bytes()) {
@@ -949,6 +973,24 @@ mod tests {
         assert_eq!(v["cmd"], "rm");
         assert_eq!(v["name"], "mybox");
         assert_eq!(v["force"], true);
+    }
+
+    #[test]
+    fn shell_command_serializes() {
+        let cmd = GuestCommand::Shell { tty: true };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "shell");
+        assert_eq!(v["tty"], true);
+    }
+
+    #[test]
+    fn shell_command_omits_tty_when_false() {
+        let cmd = GuestCommand::Shell { tty: false };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "shell");
+        assert!(v["tty"].is_null(), "tty should be omitted when false");
     }
 
     #[test]

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -248,6 +248,30 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 7a: vm shell (non-TTY) — shell directly in the VM, not in a container
+#
+# Runs `uname -s` inside the VM shell and checks output is "Linux".
+# This confirms: (a) GuestCommand::Shell is dispatched correctly, and
+# (b) we are in the raw VM environment (not inside a container namespace).
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== test 7a: vm shell (non-tty) ==="
+# Use shell read built-in — no external commands needed (initramfs has busybox
+# but not all applets are symlinked; 'cat' and 'uname' may be absent).
+OUT=$(pelagos vm shell <<'VMEOF'
+read ver < /proc/version
+echo "$ver"
+VMEOF
+)
+echo "$OUT" | grep -v "^\["
+if echo "$OUT" | grep -qi "linux"; then
+    pass "vm shell: /proc/version contains 'Linux' (we are in the VM)"
+else
+    fail "vm shell: expected 'Linux' in /proc/version, got: $(echo "$OUT" | grep -v '^\[')"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 7b: exec with explicit -t (TTY / PTY mode)
 #
 # PTY output uses \r\n line endings; strip \r before comparing.

--- a/scripts/vm-shell.sh
+++ b/scripts/vm-shell.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# vm-shell.sh — Open an interactive shell directly inside the Linux VM.
+#
+# Unlike scripts/test-interactive.sh (which runs a container via pelagos exec),
+# this drops you into the VM's own environment — no container namespaces, no
+# overlay filesystem, full access to the VM's processes and kernel interfaces.
+#
+# Usage:
+#   ./scripts/vm-shell.sh
+#
+# Prerequisites:
+#   - make image   (builds out/vmlinuz, out/initramfs-custom.gz, out/root.img)
+#   - make sign    (builds and signs target/aarch64-apple-darwin/release/pelagos)
+#
+# What you get:
+#   - /bin/sh (busybox ash) running as PID 1's child in the VM
+#   - Access to /proc, /sys, /dev, /run/pelagos (container state)
+#   - socket_vmnet network interface visible via 'busybox ip addr'
+#   - pelagos-guest process visible via 'busybox ps'
+#   - No container isolation — you are in the raw VM init namespace
+#
+# Note: the initramfs does not symlink all busybox applets. Use the 'busybox'
+# prefix for commands that are not found (e.g. 'busybox ps', 'busybox ip').
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+KERNEL="$REPO_ROOT/out/vmlinuz"
+INITRD="$REPO_ROOT/out/initramfs-custom.gz"
+DISK="$REPO_ROOT/out/root.img"
+BINARY="$REPO_ROOT/target/aarch64-apple-darwin/release/pelagos"
+CMDLINE="console=hvc0"
+
+# Verify required artifacts exist.
+for f in "$KERNEL" "$INITRD" "$DISK" "$BINARY"; do
+    if [ ! -f "$f" ]; then
+        echo "Missing: $f" >&2
+        echo "Run 'make image' and 'make sign' first." >&2
+        exit 1
+    fi
+done
+
+exec "$BINARY" \
+    --kernel  "$KERNEL" \
+    --initrd  "$INITRD" \
+    --disk    "$DISK" \
+    --cmdline "$CMDLINE" \
+    vm shell


### PR DESCRIPTION
## Summary

Adds `pelagos vm shell` — an interactive shell inside the Linux VM itself, bypassing the container runtime. Useful for debugging VM state, inspecting pelagos-guest, checking network interfaces, and kernel state.

```
./scripts/vm-shell.sh        # drops into /bin/sh in the VM
pelagos vm shell             # same, via CLI
```

This is Option A from epic #41.

## Changes

- **`GuestCommand::Shell { tty }`** — new protocol variant; guest dispatches to `handle_exec_tty` or `handle_exec_piped` with `Command::new("/bin/sh")` (no `pelagos run`, no container namespace)
- **Refactored `handle_exec_tty` / `handle_exec_piped`** to accept a pre-built `Command` instead of `(pelagos, image, args, env)` — eliminates duplication between container exec and VM shell paths
- **`pelagos vm shell`** — new CLI subcommand under the existing `vm` group; TTY auto-detected from stdout
- **`scripts/vm-shell.sh`** — convenience wrapper
- **Test 7a** — non-TTY vm shell test: pipes `read ver < /proc/version; echo "$ver"` via stdin, asserts output contains "Linux" (uses shell built-ins only; initramfs does not symlink all busybox applets)
- **Unit tests** for `GuestCommand::Shell` serialization (tty field omitted when false)

## Test plan

- [x] All 16 e2e tests pass (`scripts/test-e2e.sh`)
- [x] `./scripts/vm-shell.sh` opens an interactive shell in the VM with job control
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean

Closes #42
Part of epic #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)