### PR TITLE
fix: set PATH in vm shell; use /bin/busybox directly in test 7a

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -269,7 +269,13 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
             GuestCommand::Shell { tty } => {
                 // Send ready ack — switches the connection to framed binary protocol.
                 send_response(&mut writer, &GuestResponse::Ready { ready: true })?;
-                let cmd = Command::new("/bin/sh");
+                let mut cmd = Command::new("/bin/sh");
+                // Set a sane PATH so busybox applet symlinks are findable.
+                // pelagos-guest may not inherit PATH from the init script.
+                cmd.env(
+                    "PATH",
+                    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                );
                 if tty {
                     handle_exec_tty(fd, cmd)?;
                 } else {

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -257,18 +257,17 @@ fi
 
 echo ""
 echo "=== test 7a: vm shell (non-tty) ==="
-# Use shell read built-in — no external commands needed (initramfs has busybox
-# but not all applets are symlinked; 'cat' and 'uname' may be absent).
+# Use /bin/busybox directly — always present in the Alpine initramfs regardless
+# of whether busybox --install created applet symlinks.
 OUT=$(pelagos vm shell <<'VMEOF'
-read ver < /proc/version
-echo "$ver"
+/bin/busybox uname -s
 VMEOF
 )
 echo "$OUT" | grep -v "^\["
-if echo "$OUT" | grep -qi "linux"; then
-    pass "vm shell: /proc/version contains 'Linux' (we are in the VM)"
+if echo "$OUT" | grep -q "^Linux$"; then
+    pass "vm shell: 'uname -s' returned 'Linux' (we are in the VM)"
 else
-    fail "vm shell: expected 'Linux' in /proc/version, got: $(echo "$OUT" | grep -v '^\[')"
+    fail "vm shell: expected 'Linux', got: $(echo "$OUT" | grep -v '^\[')"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`busybox --install` is not compiled into the Alpine 3.21 virt initramfs, so the boot-time symlink creation silently no-ops. Two fixes:

1. **Set `PATH` in `GuestCommand::Shell` handler** — pelagos-guest may not inherit a sane `PATH` from the init script; setting it explicitly ensures the shell can find commands that do have symlinks in `/bin`

2. **Use `/bin/busybox uname -s` in test 7a** — always works regardless of applet symlinks; removed the `busybox --install` line from the init script since it was a silent no-op

## What about making busybox applets available without prefix?

The Alpine virt initramfs doesn't compile `--install` in. Creating all symlinks explicitly at image build time is possible (enumerate via `busybox --list`) but is a separate task. For now, `/bin/busybox <cmd>` is the reliable fallback.

## Test plan

- [x] All 16 e2e tests pass (`scripts/test-e2e.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)