### PR TITLE
fix: bind-mount /etc/resolv.conf for working DNS in containers

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -399,6 +399,9 @@ fn run_container(
     if detach {
         cmd.arg("--detach");
     }
+    // Bind-mount the VM's /etc/resolv.conf so containers get working DNS.
+    // Workaround until the pelagos runtime handles this automatically (issue #60).
+    cmd.arg("-v").arg("/etc/resolv.conf:/etc/resolv.conf");
     // Pass each virtiofs guest-side path as a -v bind mount to pelagos run.
     for mount in mounts {
         let guest_mnt = format!("/mnt/{}", mount.tag);

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -265,7 +265,10 @@ echo "  (using repo bundle: $CA_BUNDLE)"
 # ---------------------------------------------------------------------------
 echo "[7/8] Building custom initramfs"
 # ---------------------------------------------------------------------------
-if [ ! -f "$INITRAMFS_OUT" ]; then
+if [ ! -f "$INITRAMFS_OUT" ] \
+    || [ "$GUEST_BIN"   -nt "$INITRAMFS_OUT" ] \
+    || [ "$PELAGOS_BIN" -nt "$INITRAMFS_OUT" ] \
+    || [ "$0"           -nt "$INITRAMFS_OUT" ]; then
     KVER="6.12.1-3-virt"
 
     # --- Extract vsock modules from the modloop squashfs ---

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -362,6 +362,28 @@ pelagos vm stop > /dev/null 2>&1 || true
 sleep 1
 
 # ---------------------------------------------------------------------------
+# Test 7f: Ubuntu 24.04 container with apt-get (glibc + DNS)
+#
+# Verifies that glibc containers work and that DNS is functional inside them
+# (pelagos-guest bind-mounts /etc/resolv.conf from the VM).
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== test 7f: Ubuntu 24.04 apt-get (glibc + DNS) ==="
+OUT=$("$BINARY" \
+    --kernel  "$KERNEL" \
+    --initrd  "$INITRD" \
+    --disk    "$DISK" \
+    --cmdline "$CMDLINE" \
+    run public.ecr.aws/docker/library/ubuntu:24.04 \
+    /bin/bash -c "apt-get update -qq && echo apt-ok" 2>&1)
+if echo "$OUT" | grep -q "apt-ok"; then
+    pass "ubuntu 24.04: apt-get update succeeded (glibc + DNS working)"
+else
+    fail "ubuntu 24.04: apt-get update failed; output: $(echo "$OUT" | grep -v '^\[')"
+fi
+
+# ---------------------------------------------------------------------------
 # Tests 8-13: container lifecycle (ps, logs, stop, rm, --name, --detach)
 #
 # Requires the daemon to be running without mounts; restarts clean after


### PR DESCRIPTION
## Summary

- `pelagos-guest` now passes `-v /etc/resolv.conf:/etc/resolv.conf` to every `pelagos run` invocation, propagating the VM's nameservers (`8.8.8.8`, `8.8.4.4`) into the container mount namespace
- This is a workaround; the permanent fix is tracked in issue #60 (pelagos runtime should handle this automatically)
- Fixes `build-vm-image.sh` initramfs cache: previously only rebuilt if the output file was absent; now also invalidates when `pelagos-guest`, the pelagos binary, or the script itself is newer

## Test plan

- [ ] `bash scripts/test-e2e.sh` — 20 e2e tests pass including new test 7f (`apt-get update` in `ubuntu:24.04` exits 0)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)