### PR TITLE
feat: docker build, volume, and network for devcontainer support

### DIFF
--- a/pelagos-docker/src/main.rs
+++ b/pelagos-docker/src/main.rs
@@ -157,6 +157,41 @@ enum DockerCmd {
         #[arg(short = 'f', long)]
         format: Option<String>,
     },
+
+    /// Build an OCI image from a Dockerfile.
+    Build {
+        /// Image tag.
+        #[arg(short = 't', long)]
+        tag: String,
+        /// Dockerfile path inside the build context.
+        #[arg(short = 'f', long, default_value = "Dockerfile")]
+        file: String,
+        /// Build argument KEY=VALUE (repeatable).
+        #[arg(long = "build-arg")]
+        build_args: Vec<String>,
+        /// Do not use the cache.
+        #[arg(long)]
+        no_cache: bool,
+        /// Build context path (default: .).
+        #[arg(default_value = ".")]
+        context: String,
+    },
+
+    /// Manage named volumes.
+    Volume {
+        /// Subcommand: create, ls, rm.
+        sub: String,
+        /// Volume name.
+        name: Option<String>,
+    },
+
+    /// Manage named networks.
+    Network {
+        /// Subcommand: create, ls, rm, inspect.
+        sub: String,
+        /// Network name.
+        name: Option<String>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -233,6 +268,15 @@ fn main() {
         DockerCmd::Version { format } => cmd_version_with_format(format.as_deref()),
         DockerCmd::Info { format: _ } => cmd_info(),
         DockerCmd::Events { .. } => cmd_events(),
+        DockerCmd::Build {
+            tag,
+            file,
+            build_args,
+            no_cache,
+            context,
+        } => cmd_build(&cfg, &tag, &file, &build_args, no_cache, &context),
+        DockerCmd::Volume { sub, name } => cmd_volume(&cfg, &sub, name.as_deref()),
+        DockerCmd::Network { sub, name } => cmd_network(&cfg, &sub, name.as_deref()),
     };
 
     process::exit(exit_code);
@@ -863,4 +907,72 @@ fn build_ports_map(_container: &str, port_map: &[(u16, u16)]) -> HashMap<String,
         });
     }
     map
+}
+
+// ---------------------------------------------------------------------------
+// Build / Volume / Network
+// ---------------------------------------------------------------------------
+
+fn cmd_build(
+    cfg: &Config,
+    tag: &str,
+    file: &str,
+    build_args: &[String],
+    no_cache: bool,
+    context: &str,
+) -> i32 {
+    let mut sub: Vec<OsString> = args(&["build", "-t", tag, "-f", file]);
+    for arg in build_args {
+        sub.push("--build-arg".into());
+        sub.push(arg.into());
+    }
+    if no_cache {
+        sub.push("--no-cache".into());
+    }
+    sub.push(context.into());
+    match run_pelagos_inherited(cfg, &sub) {
+        Ok(s) => s.code().unwrap_or(1),
+        Err(e) => {
+            eprintln!("pelagos-docker build: {}", e);
+            1
+        }
+    }
+}
+
+fn cmd_volume(cfg: &Config, sub: &str, name: Option<&str>) -> i32 {
+    let mut a: Vec<OsString> = args(&["volume", sub]);
+    if let Some(n) = name {
+        a.push(n.into());
+    }
+    match run_pelagos_inherited(cfg, &a) {
+        Ok(s) => s.code().unwrap_or(1),
+        Err(e) => {
+            eprintln!("pelagos-docker volume: {}", e);
+            1
+        }
+    }
+}
+
+fn cmd_network(cfg: &Config, sub: &str, name: Option<&str>) -> i32 {
+    let mut a: Vec<OsString> = args(&["network", sub]);
+    // `docker network create <name>` auto-assigns a subnet; pelagos requires one explicitly.
+    // Pick 10.88.<hash>.0/24 derived from the name so repeated calls are idempotent.
+    if sub == "create" {
+        if let Some(n) = name {
+            let hash: u8 = n.bytes().fold(0u8, |acc, b| acc.wrapping_add(b));
+            let subnet = format!("10.88.{}.0/24", hash);
+            a.push("--subnet".into());
+            a.push(subnet.into());
+            a.push(n.into());
+        }
+    } else if let Some(n) = name {
+        a.push(n.into());
+    }
+    match run_pelagos_inherited(cfg, &a) {
+        Ok(s) => s.code().unwrap_or(1),
+        Err(e) => {
+            eprintln!("pelagos-docker network: {}", e);
+            1
+        }
+    }
 }

--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -136,6 +136,36 @@ pub enum GuestCommand {
         tty: bool,
     },
     Ping,
+    /// Build an OCI image from a Dockerfile-compatible Remfile.
+    /// The build context is streamed as a gzipped tar immediately after the
+    /// JSON command line (raw bytes, no framing; length given by context_size).
+    Build {
+        tag: String,
+        #[serde(default = "default_dockerfile")]
+        dockerfile: String,
+        #[serde(default)]
+        build_args: Vec<String>,
+        #[serde(default)]
+        no_cache: bool,
+        context_size: u64,
+    },
+    /// Manage named volumes: sub is "create", "ls", or "rm".
+    Volume {
+        sub: String,
+        #[serde(default)]
+        name: Option<String>,
+    },
+    /// Manage named networks: sub is "create", "ls", "rm", or "inspect".
+    /// All remaining args (name, --subnet, etc.) are forwarded verbatim.
+    Network {
+        sub: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+}
+
+fn default_dockerfile() -> String {
+    "Dockerfile".to_string()
 }
 
 #[derive(Debug, Serialize)]
@@ -196,15 +226,23 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
     let _guard = ConnFd(fd);
 
     // FdReader/FdWriter use libc::read/write directly — no OwnedFd involved.
-    let reader = BufReader::new(FdReader(fd));
+    // Use a named BufReader (not an iterator) so it can be passed by value to
+    // handle_build, which must read the raw tar body after the JSON header line.
+    let mut reader = BufReader::new(FdReader(fd));
     let mut writer = FdWriter(fd);
 
-    for line in reader.lines() {
-        let line = line?;
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break, // EOF
+            Ok(_) => {}
+            Err(e) => return Err(e),
+        }
+        let line = line.trim_end_matches('\n').trim_end_matches('\r');
         if line.is_empty() {
             continue;
         }
-        let cmd: GuestCommand = match serde_json::from_str(&line) {
+        let cmd: GuestCommand = match serde_json::from_str(line) {
             Ok(c) => c,
             Err(e) => {
                 send_response(
@@ -302,6 +340,30 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                     handle_exec_piped(fd, cmd)?;
                 }
                 return Ok(());
+            }
+            GuestCommand::Build {
+                tag,
+                dockerfile,
+                build_args,
+                no_cache,
+                context_size,
+            } => {
+                handle_build(
+                    &mut writer,
+                    reader,
+                    &tag,
+                    &dockerfile,
+                    &build_args,
+                    no_cache,
+                    context_size,
+                )?;
+                return Ok(());
+            }
+            GuestCommand::Volume { sub, name } => {
+                handle_volume(&mut writer, &sub, name.as_deref())?;
+            }
+            GuestCommand::Network { sub, args } => {
+                handle_network(&mut writer, &sub, &args)?;
             }
         }
     }
@@ -597,6 +659,150 @@ fn run_detached(writer: &mut impl Write, mut cmd: Command) -> std::io::Result<()
 }
 
 // ---------------------------------------------------------------------------
+// Build handler
+// ---------------------------------------------------------------------------
+
+/// Receive a gzipped tar build context over vsock, extract it, and run
+/// `pelagos build`.  The raw tar bytes follow immediately after the JSON
+/// command line; their length is given by `context_size`.
+fn handle_build(
+    writer: &mut impl Write,
+    mut reader: BufReader<FdReader>,
+    tag: &str,
+    dockerfile: &str,
+    build_args: &[String],
+    no_cache: bool,
+    context_size: u64,
+) -> std::io::Result<()> {
+    let build_id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros();
+    let ctx_dir = format!("/tmp/pelagos-build-{}", build_id);
+    std::fs::create_dir_all(&ctx_dir)?;
+
+    // Pipe exactly context_size bytes from the vsock reader into `tar xzf -`.
+    {
+        let mut tar_proc = match Command::new("tar")
+            .arg("xzf")
+            .arg("-")
+            .arg("-C")
+            .arg(&ctx_dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+        {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&ctx_dir);
+                send_response(
+                    writer,
+                    &GuestResponse::Error {
+                        error: format!("tar spawn failed: {}", e),
+                    },
+                )?;
+                return Ok(());
+            }
+        };
+        let tar_stdin = tar_proc.stdin.take().unwrap();
+        let tar_stderr = tar_proc.stderr.take().unwrap();
+
+        // Drain tar stderr concurrently so the pipe never fills.
+        let stderr_thread = std::thread::spawn(move || {
+            let mut s = String::new();
+            let _ = BufReader::new(tar_stderr).read_to_string(&mut s);
+            s
+        });
+
+        let copy_result = {
+            let mut sink = tar_stdin;
+            let mut limited = (&mut reader).take(context_size);
+            std::io::copy(&mut limited, &mut sink)
+        }; // sink dropped here → EOF to tar
+
+        let tar_status = tar_proc.wait()?;
+        let tar_stderr_str = stderr_thread.join().unwrap_or_default();
+
+        if copy_result.is_err() || !tar_status.success() {
+            let _ = std::fs::remove_dir_all(&ctx_dir);
+            send_response(
+                writer,
+                &GuestResponse::Error {
+                    error: format!(
+                        "build context extract failed (exit {}): {}",
+                        tar_status.code().unwrap_or(-1),
+                        tar_stderr_str.trim()
+                    ),
+                },
+            )?;
+            return Ok(());
+        }
+    }
+
+    // Pre-pull the base image declared in the first FROM line.
+    let dockerfile_path = format!("{}/{}", ctx_dir, dockerfile);
+    if let Ok(content) = std::fs::read_to_string(&dockerfile_path) {
+        for line in content.lines() {
+            if line.trim().to_ascii_uppercase().starts_with("FROM") {
+                let base = line.split_whitespace().nth(1).unwrap_or("").to_string();
+                if !base.is_empty()
+                    && !base.eq_ignore_ascii_case("scratch")
+                    && !pull_image(writer, &base)?
+                {
+                    let _ = std::fs::remove_dir_all(&ctx_dir);
+                    return Ok(());
+                }
+                break;
+            }
+        }
+    }
+
+    // Run pelagos build.
+    // Use --network none: the VM's minimal kernel has no bridge/veth modules or
+    // pasta binary, so the default "auto" mode (bridge) fails. Network access
+    // during RUN steps requires kernel bridge support; revisit when kernel is extended.
+    let mut cmd = Command::new(pelagos_bin());
+    cmd.arg("build")
+        .arg("-t")
+        .arg(tag)
+        .arg("-f")
+        .arg(&dockerfile_path)
+        .arg("--network")
+        .arg("none");
+    for arg in build_args {
+        cmd.arg("--build-arg").arg(arg);
+    }
+    if no_cache {
+        cmd.arg("--no-cache");
+    }
+    cmd.arg(&ctx_dir);
+
+    let result = spawn_and_stream(writer, cmd);
+    let _ = std::fs::remove_dir_all(&ctx_dir);
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Volume and network passthrough handlers
+// ---------------------------------------------------------------------------
+
+fn handle_volume(writer: &mut impl Write, sub: &str, name: Option<&str>) -> std::io::Result<()> {
+    let mut cmd = Command::new(pelagos_bin());
+    cmd.arg("volume").arg(sub);
+    if let Some(n) = name {
+        cmd.arg(n);
+    }
+    spawn_and_stream(writer, cmd)
+}
+
+fn handle_network(writer: &mut impl Write, sub: &str, args: &[String]) -> std::io::Result<()> {
+    let mut cmd = Command::new(pelagos_bin());
+    cmd.arg("network").arg(sub).args(args);
+    spawn_and_stream(writer, cmd)
+}
+
+// ---------------------------------------------------------------------------
 // Exec handler
 // ---------------------------------------------------------------------------
 
@@ -779,8 +985,8 @@ fn open_ns_fds(pid: u32) -> std::io::Result<[libc::c_int; 5]> {
         // No O_CLOEXEC: fd must survive into pre_exec (before exec).
         let fd = unsafe { libc::open(cpath.as_ptr(), libc::O_RDONLY) };
         if fd < 0 {
-            for j in 0..i {
-                unsafe { libc::close(fds[j]) };
+            for fd in fds.iter().take(i) {
+                unsafe { libc::close(*fd) };
             }
             return Err(std::io::Error::last_os_error());
         }
@@ -1340,6 +1546,82 @@ mod tests {
         let json = serde_json::to_string(&resp).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["error"]["error"], "oops");
+    }
+
+    #[test]
+    fn build_deserializes() {
+        let json =
+            r#"{"cmd":"build","tag":"myapp:latest","dockerfile":"Dockerfile","context_size":1234}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::Build {
+                tag,
+                dockerfile,
+                build_args,
+                no_cache,
+                context_size,
+            } => {
+                assert_eq!(tag, "myapp:latest");
+                assert_eq!(dockerfile, "Dockerfile");
+                assert!(build_args.is_empty());
+                assert!(!no_cache);
+                assert_eq!(context_size, 1234);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn build_deserializes_with_build_args() {
+        let json = r#"{"cmd":"build","tag":"myapp:1.0","dockerfile":"Dockerfile.prod","build_args":["KEY=VAL"],"no_cache":true,"context_size":9999}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::Build {
+                tag,
+                build_args,
+                no_cache,
+                ..
+            } => {
+                assert_eq!(tag, "myapp:1.0");
+                assert_eq!(build_args, vec!["KEY=VAL"]);
+                assert!(no_cache);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn volume_deserializes() {
+        let json = r#"{"cmd":"volume","sub":"create","name":"myvol"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::Volume { sub, name } => {
+                assert_eq!(sub, "create");
+                assert_eq!(name.as_deref(), Some("myvol"));
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn volume_ls_deserializes() {
+        let json = r#"{"cmd":"volume","sub":"ls"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        assert!(matches!(cmd, GuestCommand::Volume { ref sub, name: None } if sub == "ls"));
+    }
+
+    #[test]
+    fn network_deserializes() {
+        let json = r#"{"cmd":"network","sub":"create","args":["--subnet","10.88.1.0/24","mynet"]}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::Network { sub, args } => {
+                assert_eq!(sub, "create");
+                assert_eq!(args[2], "mynet");
+                assert_eq!(args[0], "--subnet");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
     }
 
     #[test]

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -135,6 +135,39 @@ enum Commands {
     },
     /// Ping the guest daemon (readiness check)
     Ping,
+    /// Build an OCI image from a Dockerfile (Remfile) inside the VM
+    Build {
+        /// Image tag (e.g. myapp:latest)
+        #[arg(short = 't', long)]
+        tag: String,
+        /// Path to the Dockerfile/Remfile inside the build context (default: Dockerfile)
+        #[arg(short = 'f', long, default_value = "Dockerfile")]
+        file: String,
+        /// Build argument (KEY=VALUE); may be repeated
+        #[arg(long = "build-arg")]
+        build_args: Vec<String>,
+        /// Do not use the cache
+        #[arg(long)]
+        no_cache: bool,
+        /// Build context path (default: .)
+        #[arg(default_value = ".")]
+        context: String,
+    },
+    /// Manage named volumes inside the VM
+    Volume {
+        /// Subcommand: create, ls, rm
+        sub: String,
+        /// Volume name (for create/rm)
+        name: Option<String>,
+    },
+    /// Manage named networks inside the VM
+    Network {
+        /// Subcommand: create, ls, rm, inspect
+        sub: String,
+        /// Remaining args forwarded verbatim (name, flags like --subnet, etc.)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Persistent VM management
     Vm {
         #[command(subcommand)]
@@ -232,6 +265,26 @@ enum GuestCommand {
         force: bool,
     },
     Ping,
+    Build {
+        tag: String,
+        dockerfile: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        build_args: Vec<String>,
+        #[serde(skip_serializing_if = "is_false")]
+        no_cache: bool,
+        context_size: u64,
+    },
+    Volume {
+        sub: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
+    Network {
+        sub: String,
+        /// All remaining args forwarded verbatim (name, --subnet, etc.).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+    },
 }
 
 #[derive(Deserialize, Debug)]
@@ -565,6 +618,63 @@ fn main() {
                 GuestCommand::Rm { name, force },
             ));
         }
+
+        Commands::Build {
+            ref tag,
+            ref file,
+            ref build_args,
+            no_cache,
+            ref context,
+        } => {
+            let tag = tag.clone();
+            let file = file.clone();
+            let build_args = build_args.clone();
+            let context = std::path::PathBuf::from(context);
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit();
+            process::exit(build_command(
+                stream,
+                &tag,
+                &file,
+                &build_args,
+                no_cache,
+                &context,
+            ));
+        }
+
+        Commands::Volume { ref sub, ref name } => {
+            let sub = sub.clone();
+            let name = name.clone();
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit();
+            process::exit(passthrough_command(
+                stream,
+                GuestCommand::Volume { sub, name },
+            ));
+        }
+
+        Commands::Network { ref sub, ref args } => {
+            let sub = sub.clone();
+            let args = args.clone();
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit();
+            process::exit(passthrough_command(
+                stream,
+                GuestCommand::Network { sub, args },
+            ));
+        }
     }
 }
 
@@ -709,6 +819,119 @@ fn passthrough_command(stream: UnixStream, cmd: GuestCommand) -> i32 {
         return 1;
     }
 
+    let mut exit_code = 1;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<GuestResponse>(trimmed) {
+            Ok(GuestResponse::Stream { stream, data }) => {
+                if stream == "stderr" {
+                    eprint!("{}", data);
+                } else {
+                    print!("{}", data);
+                }
+            }
+            Ok(GuestResponse::Exit { exit }) => {
+                exit_code = exit;
+                break;
+            }
+            Ok(GuestResponse::Error { error }) => {
+                log::error!("guest error: {}", error);
+                break;
+            }
+            Ok(resp) => {
+                log::warn!("unexpected response: {:?}", resp);
+            }
+            Err(e) => {
+                log::error!("parse error: {} (line: {:?})", e, trimmed);
+                break;
+            }
+        }
+    }
+    exit_code
+}
+
+/// Tar up the build context, send it to the guest, and relay build output.
+fn build_command(
+    stream: UnixStream,
+    tag: &str,
+    dockerfile: &str,
+    build_args: &[String],
+    no_cache: bool,
+    context: &std::path::Path,
+) -> i32 {
+    // Write a gzipped tar of the context to a temp file so we know its size.
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros();
+    let tar_path = std::env::temp_dir().join(format!("pelagos-ctx-{}.tar.gz", ts));
+
+    let tar_status = std::process::Command::new("tar")
+        .arg("czf")
+        .arg(&tar_path)
+        .arg("-C")
+        .arg(context)
+        .arg(".")
+        .status();
+    match tar_status {
+        Err(e) => {
+            log::error!("tar: {}", e);
+            return 1;
+        }
+        Ok(s) if !s.success() => {
+            log::error!("tar failed (exit {})", s.code().unwrap_or(-1));
+            return 1;
+        }
+        Ok(_) => {}
+    }
+
+    let context_size = match std::fs::metadata(&tar_path) {
+        Ok(m) => m.len(),
+        Err(e) => {
+            log::error!("tar metadata: {}", e);
+            let _ = std::fs::remove_file(&tar_path);
+            return 1;
+        }
+    };
+
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut writer = stream;
+
+    // Send JSON header with context_size.
+    let cmd = GuestCommand::Build {
+        tag: tag.to_string(),
+        dockerfile: dockerfile.to_string(),
+        build_args: build_args.to_vec(),
+        no_cache,
+        context_size,
+    };
+    let mut msg = serde_json::to_string(&cmd).unwrap();
+    msg.push('\n');
+    if let Err(e) = writer.write_all(msg.as_bytes()) {
+        log::error!("build: write header: {}", e);
+        let _ = std::fs::remove_file(&tar_path);
+        return 1;
+    }
+
+    // Stream the tar bytes immediately after the header.
+    let result =
+        std::fs::File::open(&tar_path).and_then(|mut f| std::io::copy(&mut f, &mut writer));
+    let _ = std::fs::remove_file(&tar_path);
+    if let Err(e) = result {
+        log::error!("build: send context: {}", e);
+        return 1;
+    }
+
+    // Read streaming build output.
     let mut exit_code = 1;
     let mut line = String::new();
     loop {
@@ -1146,9 +1369,10 @@ fn read_winsize() -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        recv_frame, send_frame, GuestCommand, GuestMount, GuestResponse, FRAME_EXIT, FRAME_RESIZE,
-        FRAME_STDIN, FRAME_STDOUT,
+        recv_frame, send_frame, Cli, Commands, GuestCommand, GuestMount, GuestResponse, FRAME_EXIT,
+        FRAME_RESIZE, FRAME_STDIN, FRAME_STDOUT,
     };
+    use clap::Parser as _;
     use std::io::Cursor;
 
     #[test]
@@ -1429,5 +1653,110 @@ mod tests {
         let (frame_type, data) = recv_frame(&mut cursor).unwrap();
         assert_eq!(frame_type, FRAME_STDOUT);
         assert!(data.is_empty());
+    }
+
+    #[test]
+    fn build_command_serializes() {
+        let cmd = GuestCommand::Build {
+            tag: "myapp:latest".into(),
+            dockerfile: "Dockerfile".into(),
+            build_args: vec!["KEY=VAL".into()],
+            no_cache: true,
+            context_size: 4096,
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "build");
+        assert_eq!(v["tag"], "myapp:latest");
+        assert_eq!(v["dockerfile"], "Dockerfile");
+        assert_eq!(v["build_args"][0], "KEY=VAL");
+        assert_eq!(v["no_cache"], true);
+        assert_eq!(v["context_size"], 4096);
+    }
+
+    #[test]
+    fn build_command_omits_defaults() {
+        let cmd = GuestCommand::Build {
+            tag: "x".into(),
+            dockerfile: "Dockerfile".into(),
+            build_args: vec![],
+            no_cache: false,
+            context_size: 0,
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        // build_args omitted when empty; no_cache omitted when false
+        assert!(v["build_args"].is_null());
+        assert!(v["no_cache"].is_null());
+    }
+
+    #[test]
+    fn volume_command_serializes() {
+        let cmd = GuestCommand::Volume {
+            sub: "create".into(),
+            name: Some("myvol".into()),
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "volume");
+        assert_eq!(v["sub"], "create");
+        assert_eq!(v["name"], "myvol");
+    }
+
+    #[test]
+    fn network_command_serializes() {
+        let cmd = GuestCommand::Network {
+            sub: "ls".into(),
+            args: vec![],
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "network");
+        assert_eq!(v["sub"], "ls");
+        // args omitted when empty
+        assert!(v["args"].is_null());
+    }
+
+    #[test]
+    fn network_clap_parses_subnet_flag() {
+        // Verify that clap's trailing_var_arg actually captures --subnet into args
+        let cli = Cli::try_parse_from([
+            "pelagos",
+            "--kernel",
+            "/dev/null",
+            "--initrd",
+            "/dev/null",
+            "--disk",
+            "/dev/null",
+            "--cmdline",
+            "console=hvc0",
+            "network",
+            "create",
+            "--subnet",
+            "10.88.1.0/24",
+            "testnet",
+        ])
+        .expect("parse failed");
+        match cli.command {
+            Commands::Network { sub, args } => {
+                assert_eq!(sub, "create");
+                assert_eq!(args, vec!["--subnet", "10.88.1.0/24", "testnet"]);
+            }
+            _ => panic!("unexpected command variant"),
+        }
+    }
+
+    #[test]
+    fn network_command_with_args_serializes() {
+        let cmd = GuestCommand::Network {
+            sub: "create".into(),
+            args: vec!["--subnet".into(), "10.88.1.0/24".into(), "mynet".into()],
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize failed");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "network");
+        assert_eq!(v["sub"], "create");
+        assert_eq!(v["args"][0], "--subnet");
+        assert_eq!(v["args"][2], "mynet");
     }
 }

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -553,6 +553,66 @@ else
     fail "docker info: unexpected output: $OUT"
 fi
 
+# ---------------------------------------------------------------------------
+# Test 7r: docker build (Dockerfile → OCI image via pelagos build)
+#
+# Creates a minimal Dockerfile (FROM alpine + RUN echo), tars the context,
+# sends it to the guest, and verifies the build succeeds.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== test 7r: docker build ==="
+# Stop daemon so build test gets a fresh one (no conflicting mounts).
+"$BINARY" vm stop > /dev/null 2>&1 || true
+sleep 1
+BUILD_CTX=$(mktemp -d)
+cat > "$BUILD_CTX/Dockerfile" <<'DOCKERFILE'
+FROM public.ecr.aws/docker/library/alpine:latest
+RUN echo build-ok
+CMD ["/bin/sh"]
+DOCKERFILE
+BUILD_TAG="pelagos-e2e-build-$$:latest"
+OUT=$(shim build -t "$BUILD_TAG" "$BUILD_CTX" 2>&1)
+BUILD_EXIT=$?
+rm -rf "$BUILD_CTX"
+if [ "$BUILD_EXIT" -eq 0 ]; then
+    pass "docker build: exited 0"
+else
+    fail "docker build: exit $BUILD_EXIT; output: $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7s: docker volume create / ls / rm round-trip
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== test 7s: docker volume create/ls/rm ==="
+VOL_NAME="pelagos-e2e-vol-$$"
+shim volume create "$VOL_NAME" > /dev/null 2>&1; CREATE_EXIT=$?
+LS_OUT=$(shim volume ls 2>&1)
+shim volume rm "$VOL_NAME" > /dev/null 2>&1; RM_EXIT=$?
+if [ "$CREATE_EXIT" -eq 0 ] && echo "$LS_OUT" | grep -q "$VOL_NAME" && [ "$RM_EXIT" -eq 0 ]; then
+    pass "docker volume: create/ls/rm round-trip succeeded"
+else
+    fail "docker volume: create=$CREATE_EXIT rm=$RM_EXIT ls_output=$LS_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7t: docker network create / ls / rm round-trip
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== test 7t: docker network create/ls/rm ==="
+NET_NAME="e2enet$$"
+shim network create "$NET_NAME" > /dev/null 2>&1; CREATE_EXIT=$?
+LS_OUT=$(shim network ls 2>&1)
+shim network rm "$NET_NAME" > /dev/null 2>&1; RM_EXIT=$?
+if [ "$CREATE_EXIT" -eq 0 ] && echo "$LS_OUT" | grep -q "$NET_NAME" && [ "$RM_EXIT" -eq 0 ]; then
+    pass "docker network: create/ls/rm round-trip succeeded"
+else
+    fail "docker network: create=$CREATE_EXIT rm=$RM_EXIT ls_output=$LS_OUT"
+fi
+
 # Stop daemon before lifecycle tests.
 pelagos vm stop > /dev/null 2>&1 || true
 sleep 1


### PR DESCRIPTION
## Summary

- Adds `docker build` command: streams gzipped tar build context over vsock, pre-pulls base image FROM Dockerfile, runs `pelagos build --network none` in guest
- Adds `docker volume create/ls/rm`: forwarded verbatim to `pelagos volume` in guest
- Adds `docker network create/ls/rm`: auto-assigns `/24` subnet via name hash (required by pelagos), forwarded to `pelagos network` in guest
- Extends `GuestCommand` protocol with `Build`, `Volume`, `Network` variants
- pelagos-docker shim handles Docker CLI translation for all three

Closes #68

## Test plan

- [x] 34/34 e2e tests pass (new: test 7r docker build, 7s docker volume, 7t docker network)
- [x] `cargo test` passes for pelagos-mac and pelagos-guest (49 + 22 unit tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live test: `pelagos network create/ls/rm`, `pelagos volume create/ls/rm`, `docker build` all verified in running VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)