### PR TITLE
feat: upgrade to pelagos v0.25.0 with native DNS injection

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -523,9 +523,6 @@ fn run_container(
     if detach {
         cmd.arg("--detach");
     }
-    // Bind-mount the VM's /etc/resolv.conf so containers get working DNS.
-    // Workaround until the pelagos runtime handles this automatically (issue #60).
-    cmd.arg("-v").arg("/etc/resolv.conf:/etc/resolv.conf");
     // Pass each virtiofs guest-side path as a -v bind mount to pelagos run.
     for mount in mounts {
         let guest_mnt = format!("/mnt/{}", mount.tag);

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -41,7 +41,7 @@ DISK_IMG="$OUT/root.img"
 INITRAMFS_OUT="$OUT/initramfs-custom.gz"
 KERNEL_OUT="$OUT/vmlinuz"
 
-PELAGOS_VERSION="0.24.0"
+PELAGOS_VERSION="0.25.0"
 PELAGOS_BIN="$WORK/pelagos-aarch64-linux"
 PELAGOS_URL="https://github.com/skeptomai/pelagos/releases/download/v${PELAGOS_VERSION}/pelagos-aarch64-linux"
 


### PR DESCRIPTION
## Summary

- Bumps `PELAGOS_VERSION` in `build-vm-image.sh` from `0.24.0` → `0.25.0`
- Removes the explicit `resolv.conf` bind-mount workaround from `run_container()` in `pelagos-guest/src/main.rs` — pelagos v0.25.0 handles DNS natively via skeptomai/pelagos#89

## Test plan

- [x] All 36 e2e tests pass (`bash scripts/test-e2e.sh`)
- [x] Test 7f (Ubuntu 24.04 apt-get) confirms DNS works in containers without the workaround

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)