### PR TITLE
fix: parse_mount_as_volume must skip type=volume mounts

### DIFF
--- a/pelagos-docker/src/main.rs
+++ b/pelagos-docker/src/main.rs
@@ -386,11 +386,16 @@ struct RunOpts {
 }
 
 /// Parse `--mount type=bind,source=X,target=Y[,...]` into a `-v X:Y` string.
+/// Returns `None` for `type=volume` mounts (named volumes are not host-path
+/// virtiofs shares and are silently skipped — managed by the pelagos runtime).
 fn parse_mount_as_volume(mount_spec: &str) -> Option<String> {
+    let mut mount_type: Option<&str> = None;
     let mut source = None;
     let mut target = None;
     for part in mount_spec.split(',') {
-        if let Some(v) = part.strip_prefix("source=") {
+        if let Some(v) = part.strip_prefix("type=") {
+            mount_type = Some(v);
+        } else if let Some(v) = part.strip_prefix("source=") {
             source = Some(v);
         } else if let Some(v) = part.strip_prefix("src=") {
             source = Some(v);
@@ -401,6 +406,10 @@ fn parse_mount_as_volume(mount_spec: &str) -> Option<String> {
         } else if let Some(v) = part.strip_prefix("destination=") {
             target = Some(v);
         }
+    }
+    // Named volumes (type=volume) are not host-path shares; skip them.
+    if mount_type == Some("volume") {
+        return None;
     }
     match (source, target) {
         (Some(s), Some(t)) => Some(format!("{}:{}", s, t)),


### PR DESCRIPTION
## What

`parse_mount_as_volume` was converting `--mount type=volume,src=vscode,dst=/vscode` into `-v vscode:/vscode`. The relative path `vscode` doesn't exist on the host, so `virtiofsd` failed to start, and the VM daemon timed out after 60s.

This fix was originally in commit `c943622` but was dropped a second time when `pelagos-docker/src/main.rs` conflict was resolved by taking origin/master wholesale during the rebase.

## Impact

VS Code devcontainer CLI always passes named volume mounts (`vscode-server-*` and `vscode`) alongside the workspace bind mount. Without this fix, every "Reopen in Container" attempt hangs for 60 seconds then fails.

## Verification

- Simulated the exact `docker run` VS Code issues: daemon starts and container runs (`Container started`)
- All 39 e2e tests pass (`bash scripts/test-e2e.sh --cold`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)