### PR TITLE
feat: pelagos v0.53.0 + host clock sync + fix test preflight

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -1,6 +1,6 @@
 # pelagos-mac — Ongoing Tasks
 
-*Last updated: 2026-03-16, branch fix/exec-into-container-env*
+*Last updated: 2026-03-16, branch chore/nat-diagnostics*
 
 ---
 
@@ -59,25 +59,32 @@ All sub-issues resolved:
 
 ## Remaining Work
 
-### VS Code devcontainer — ready to re-test
+### VS Code devcontainer — current state
 
 T2 integration harness (`scripts/test-devcontainer-e2e.sh`) is built and running.
-Current result: **Suites A (7/7), B (3/3), D (3/3) pass. Suite C: 1/3 pass.**
+Current result: **Suite A (7/7), B (3/3), C (1/3), D (3/3) pass.**
+
+Suite C TC-T2-10 (`devcontainer up` with node feature) now passes with pelagos v0.52.0
+and the host-clock-sync fix (VM clock injected via `clock.utc=` in kernel cmdline).
 
 Suite C TC-T2-10b/10c (`node --version`, `npm --version`) fail with
-`exec spawn failed: No such file or directory` because `pelagos run` does not
-apply the image's Dockerfile `ENV` layer to the container process environment.
+`exec spawn failed: No such file or directory` because `pelagos exec-into` does not
+apply the image's Dockerfile `ENV` layer to the exec'd process environment.
 Node is installed but `PATH` does not include `/usr/local/share/nvm/current/bin`.
 
-**Blocked on pelagos#114** — filed 2026-03-16.
+**Blocked on pelagos#115** — filed 2026-03-16.
 No workaround in the shim (CLAUDE.md: fix belongs in pelagos).
+(pelagos#114 fixed `run` PATH; #115 is the same fix needed for `exec-into`.)
 
-This branch (fix/exec-into-container-env) also contains:
+Changes in this branch (chore/nat-diagnostics):
 - `exec-into` `-w`/`--workdir` support (container working directory)
 - `devcontainer up` probe detection fix for CLI 0.84+ built-in keepalive
 - `RUST_LOG=debug` removed from VM init script (was causing output noise)
 - Default VM memory increased to 2048 MiB (OOM fix for Node.js nvm install)
 - Persistent disk increased to 8192 MiB
+- pelagos v0.52.0 integrated
+- VM clock synced from host at boot via `clock.utc=` kernel cmdline parameter
+  (removes NTP from the critical startup path)
 
 ### VS Code full extension integration test (#91)
 

--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -1356,8 +1356,8 @@ fn handle_exec_into(
     // Order: net/uts/ipc first, pid before mnt (so /proc stays readable).
     // After all setns calls, fchdir+chroot into the container's rootfs so that
     // absolute paths resolve through the container filesystem, not the guest root.
-    let workdir_owned: Option<std::ffi::CString> = workdir
-        .and_then(|w| std::ffi::CString::new(w.as_bytes()).ok());
+    let workdir_owned: Option<std::ffi::CString> =
+        workdir.and_then(|w| std::ffi::CString::new(w.as_bytes()).ok());
     unsafe {
         cmd.pre_exec(move || {
             for &ns_fd in &ns_fds {

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -907,11 +907,49 @@ fn daemon_args_from_cli(cli: &Cli) -> daemon::DaemonArgs {
 
     let port_forwards = parse_ports(&cli.ports);
 
+    // Embed the current host UTC time so the guest init can set the system clock
+    // instantly without NTP (avoids TLS cert failures on first-boot).
+    // Passed as clock.utc=YYYY-MM-DDTHH:MM:SS (ISO 8601, no spaces — cmdline safe).
+    // init reads it and calls: busybox date -s "YYYY-MM-DD HH:MM:SS".
+    // Skip injection if clock.utc is already present (e.g., inside vm-daemon-internal
+    // subprocess which receives the cmdline forwarded from the parent process).
+    let cmdline = if cli.cmdline.contains("clock.utc=") {
+        cli.cmdline.clone()
+    } else {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let secs = now % 60;
+        let mins = (now / 60) % 60;
+        let hours = (now / 3600) % 24;
+        let days_since_epoch = now / 86400;
+        // Compute year/month/day from days_since_epoch using proleptic Gregorian calendar.
+        let (year, month, day) = {
+            let z = days_since_epoch as i64 + 719468;
+            let era = if z >= 0 { z } else { z - 146096 } / 146097;
+            let doe = z - era * 146097;
+            let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+            let y = yoe + era * 400;
+            let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+            let mp = (5 * doy + 2) / 153;
+            let d = doy - (153 * mp + 2) / 5 + 1;
+            let m = if mp < 10 { mp + 3 } else { mp - 9 };
+            let y = if m <= 2 { y + 1 } else { y };
+            (y as u64, m as u64, d as u64)
+        };
+        let clock_utc = format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+            year, month, day, hours, mins, secs
+        );
+        format!("{} clock.utc={}", cli.cmdline, clock_utc)
+    };
+
     daemon::DaemonArgs {
         kernel,
         initrd: cli.initrd.clone(),
         disk,
-        cmdline: cli.cmdline.clone(),
+        cmdline,
         memory_mib: cli.memory,
         cpus: cli.cpus,
         virtiofs_shares,

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -49,7 +49,7 @@ DISK_IMG="$OUT/root.img"
 INITRAMFS_OUT="$OUT/initramfs-custom.gz"
 KERNEL_OUT="$OUT/vmlinuz"
 
-PELAGOS_VERSION="0.51.0"
+PELAGOS_VERSION="0.53.0"
 PELAGOS_BIN="$WORK/pelagos-${PELAGOS_VERSION}-aarch64-linux"
 PELAGOS_URL="https://github.com/skeptomai/pelagos/releases/download/v${PELAGOS_VERSION}/pelagos-aarch64-linux"
 # If a local build exists (from /Users/cb/Projects/pelagos), use it instead of downloading.
@@ -697,10 +697,17 @@ while [ \$i -lt 15 ]; do
     i=\$((i+1))
 done
 
-# Sync clock via NTP.  The VM starts at epoch; TLS cert validation will fail
-# until the clock is correct.  Run ntpd in one-shot (-q) mode; timeout 10s.
-busybox timeout 10 busybox ntpd -n -q -p pool.ntp.org 2>/dev/null || true
-echo "[pelagos-init] clock: \$(busybox date -u)"
+# Sync clock from the host UTC time embedded in the kernel cmdline by pelagos-mac.
+# Format: clock.utc=YYYY-MM-DDTHH:MM:SS — busybox date -s accepts "YYYY-MM-DD HH:MM:SS".
+_utc=\$(busybox cat /proc/cmdline | busybox tr ' ' '\n' | busybox grep '^clock\.utc=' | busybox head -1 | busybox cut -d= -f2)
+if [ -n "\$_utc" ]; then
+    _utc_space=\$(echo "\$_utc" | busybox tr 'T' ' ')
+    busybox date -s "\$_utc_space" >/dev/null 2>&1 && \
+        echo "[pelagos-init] clock set from host: \$(busybox date -u)" || \
+        echo "[pelagos-init] WARNING: date -s failed (utc=\$_utc)" >&2
+else
+    echo "[pelagos-init] WARNING: clock.utc not in cmdline, clock may be wrong" >&2
+fi
 
 # Mount virtiofs shares from the kernel cmdline (virtiofs.tags=tag0,tag1,...).
 CMDLINE=\$(busybox cat /proc/cmdline)

--- a/scripts/test-devcontainer-e2e.sh
+++ b/scripts/test-devcontainer-e2e.sh
@@ -173,7 +173,7 @@ fi
 echo "  [OK]   devcontainer $(devcontainer --version 2>/dev/null)"
 
 # Check VM is up.
-PING_OUT=$(pelagos ping 2>&1)
+PING_OUT=$("$BINARY" --kernel "$KERNEL" --initrd "$INITRD" --disk "$DISK" ping 2>&1)
 if echo "$PING_OUT" | grep -q pong; then
     echo "  [OK]   VM responsive"
 else


### PR DESCRIPTION
## Summary

- Upgrades pelagos to v0.53.0 which fixes `exec-into` not applying image `ENV` (issue #115) and `run` PATH clobbering (issue #114) — TC-T2-10b/10c now pass (`node --version`, `npm --version`)
- Replaces NTP startup sync with instant host clock injection via `clock.utc=` kernel cmdline parameter — no network dependency on startup path
- Fixes test preflight: `pelagos ping` was called bare (not on PATH); now uses `$BINARY --kernel/--initrd/--disk ping`
- VM memory 2048 MiB, persistent disk 8192 MiB (OOM fix for Node.js nvm install)
- Removes `RUST_LOG=debug` from VM init (was polluting output)

## Test plan

- [x] Suite A/B/C/D: 16/16 PASS (`bash scripts/test-devcontainer-e2e.sh`)
- [x] `node --version` → v24.14.0, `npm --version` → 11.9.0 inside devcontainer

Closes #115 (via pelagos v0.53.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)