### PR TITLE
feat: per-profile vm.conf + Ubuntu build VM provisioning

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -118,6 +118,96 @@ and verify: IDE attaches, extensions install, terminal opens inside container.
 
    **Verified:** `docker run exits` → `docker inspect` returns exit 0, `State.Status="exited"`.
 
+### Epic #119 — pelagos builder VM (in progress, PR #125)
+
+Goal: boot a standalone Ubuntu 22.04 aarch64 VM as a named profile (`--profile build`)
+that can build and test pelagos natively, without a separate Linux machine.
+
+**Completed (PR #125, branch `feat/build-vm-profile`):**
+- Per-profile `vm.conf` in Rust (`state.rs`, `main.rs`): named profiles load
+  `~/.local/share/pelagos/profiles/<name>/vm.conf` for disk/kernel/initrd/memory/cpus.
+  Precedence: CLI flag > vm.conf > compiled default.
+- `loop.ko` staged in initramfs (needed for losetup during provisioning).
+- Init script external-rootfs label check: if `/dev/vda` label ≠ `pelagos-root`,
+  init skips Alpine copy and pivots directly to Ubuntu's `/sbin/init`.
+- `scripts/build-build-image.sh`: provisions `out/build.img` inside the running
+  Alpine VM via SSH + chroot, then writes `vm.conf` for the named profile.
+- `vm-ping.sh` / `vm-restart.sh` updated for profile-aware path resolution.
+
+**Remaining steps to reach a working builder VM:**
+
+1. **Merge PR #125** and pull to master.
+
+2. **Rebuild the initramfs** (one-time, to bake in `loop.ko`):
+   ```bash
+   bash scripts/build-vm-image.sh
+   ```
+
+3. **Boot the Alpine VM** with the new image:
+   ```bash
+   bash scripts/vm-ping.sh
+   ```
+
+4. **Provision the Ubuntu build image** (takes several minutes):
+   ```bash
+   bash scripts/build-build-image.sh
+   ```
+   Creates `out/build.img` (20 GB sparse ext4), installs Ubuntu 22.04 base +
+   build-essential + Rust stable via chroot inside the Alpine VM, writes
+   `~/.local/share/pelagos/profiles/build/vm.conf`.
+
+   > **Known risk — virtiofs loop I/O:** the image file lives on the macOS
+   > virtiofs share; all `apt-get` and `tar` I/O goes virtiofs → macOS APFS →
+   > virtiofs → loop → ext4. If this causes errors or hangs, see the alternative
+   > design below.
+
+5. **Boot the Ubuntu build VM:**
+   ```bash
+   bash scripts/vm-restart.sh --profile build
+   ```
+
+6. **Verify the build environment:**
+   ```bash
+   pelagos --profile build vm ssh -- rustc --version
+   pelagos --profile build vm ssh -- git clone https://github.com/skeptomai/pelagos /root/pelagos
+   pelagos --profile build vm ssh -- bash -c 'cd /root/pelagos && cargo build --release'
+   pelagos --profile build vm ssh -- bash -c 'cd /root/pelagos && cargo test'
+   ```
+
+**virtiofs loop device — design risk and alternatives:**
+
+The current provisioning path:
+```
+mke2fs → build.img (on macOS APFS, via virtiofs) → losetup /dev/loop0 →
+mount ext4 → chroot → apt-get/tar write into ext4 → virtiofs → macOS
+```
+Every byte written during provisioning crosses virtiofs twice (once to reach
+the file, once to flush through the FUSE daemon). This is a one-time cost but
+could be slow or trigger FUSE/virtiofs bugs under heavy write load (millions
+of small files from apt and cargo).
+
+**Alternative A (preferred if virtiofs provisioning proves unreliable):**
+Pass `build.img` directly to the Alpine VM as a second virtio-blk device.
+Requires adding a `--extra-disk` flag to `daemon.rs` / `VmConfig`. The image
+gets a real block device (`/dev/vdb`) — no loop, no virtiofs in the I/O path.
+`build-build-image.sh` would restart the Alpine VM with `--extra-disk build.img`,
+provision onto `/dev/vdb`, then restart normally.
+
+**Alternative B (simplest, no new kernel path):**
+Do the provisioning entirely on macOS using `docker run --platform linux/arm64`
+with a Linux container that has the right tools. Writes ext4 into build.img from
+the container. Zero virtiofs involved. Requires Docker Desktop on macOS (violates
+the no-external-subsystem rule — reject this option).
+
+**Alternative C (deferred):**
+Add a dedicated NVMe or virtio-blk device attachment to pelagos-vz for secondary
+disks. More general than Alternative A; the right long-term answer but Significant
+Work.
+
+**Current plan:** attempt the virtiofs provisioning path first. If it fails or is
+too slow, implement Alternative A (extra virtio-blk disk for the Alpine provisioning
+session only).
+
 ### Next priorities (post-v0.1.0)
 
 - **Port forwarding** — container port → VM port → macOS `localhost`. Needed for

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -45,13 +45,13 @@ struct Cli {
     #[arg(long, env = "PELAGOS_CMDLINE", default_value = "console=hvc0")]
     cmdline: String,
 
-    /// Memory in MiB (default 4096)
-    #[arg(long, default_value = "4096")]
-    memory: usize,
+    /// Memory in MiB (default 4096; overridden by vm.conf memory= in profile)
+    #[arg(long)]
+    memory: Option<usize>,
 
-    /// Number of vCPUs (default 2)
-    #[arg(long, default_value = "2")]
-    cpus: usize,
+    /// Number of vCPUs (default 2; overridden by vm.conf cpus= in profile)
+    #[arg(long)]
+    cpus: Option<usize>,
 
     /// Bind-mount a host directory into the container: /host/path:/container/path[:ro]
     /// May be specified multiple times.
@@ -1011,12 +1011,19 @@ fn ssh_relay_proxy(port: u16) -> ! {
 }
 
 fn daemon_args_from_cli(cli: &Cli) -> daemon::DaemonArgs {
-    let kernel = cli.kernel.clone().unwrap_or_else(|| {
-        log::error!("--kernel / PELAGOS_KERNEL is required");
-        process::exit(1);
-    });
-    let disk = cli.disk.clone().unwrap_or_else(|| {
-        log::error!("--disk / PELAGOS_DISK is required");
+    // Load per-profile vm.conf as a fallback layer below CLI flags.
+    let profile_cfg = state::VmProfileConfig::load(&cli.profile).unwrap_or_default();
+
+    let kernel = cli
+        .kernel
+        .clone()
+        .or(profile_cfg.kernel)
+        .unwrap_or_else(|| {
+            log::error!("--kernel / PELAGOS_KERNEL is required (or set kernel= in vm.conf)");
+            process::exit(1);
+        });
+    let disk = cli.disk.clone().or(profile_cfg.disk).unwrap_or_else(|| {
+        log::error!("--disk / PELAGOS_DISK is required (or set disk= in vm.conf)");
         process::exit(1);
     });
 
@@ -1084,11 +1091,11 @@ fn daemon_args_from_cli(cli: &Cli) -> daemon::DaemonArgs {
 
     daemon::DaemonArgs {
         kernel,
-        initrd: cli.initrd.clone(),
+        initrd: cli.initrd.clone().or(profile_cfg.initrd),
         disk,
         cmdline,
-        memory_mib: cli.memory,
-        cpus: cli.cpus,
+        memory_mib: cli.memory.or(profile_cfg.memory).unwrap_or(4096),
+        cpus: cli.cpus.or(profile_cfg.cpus).unwrap_or(2),
         virtiofs_shares,
         port_forwards,
         profile: cli.profile.clone(),

--- a/pelagos-mac/src/state.rs
+++ b/pelagos-mac/src/state.rs
@@ -15,6 +15,71 @@ pub struct StateDir {
     pub ports_file: PathBuf,
 }
 
+// ---------------------------------------------------------------------------
+// Per-profile VM configuration
+// ---------------------------------------------------------------------------
+
+/// Per-profile VM configuration loaded from `vm.conf` in the profile state
+/// directory.  All fields are optional; absent fields fall back to CLI flags
+/// (or their own defaults).
+///
+/// File format: simple `key = value` lines; `#` comments; blank lines ignored.
+///
+/// ```text
+/// # vm.conf — written by build-build-image.sh
+/// disk   = /path/to/build.img
+/// kernel = /path/to/vmlinuz
+/// initrd = /path/to/initramfs.gz
+/// memory = 4096
+/// cpus   = 4
+/// ```
+#[derive(Debug, Default)]
+pub struct VmProfileConfig {
+    pub disk: Option<PathBuf>,
+    pub kernel: Option<PathBuf>,
+    pub initrd: Option<PathBuf>,
+    pub memory: Option<usize>,
+    pub cpus: Option<usize>,
+}
+
+impl VmProfileConfig {
+    /// Load `vm.conf` from the given profile's state directory.
+    /// Returns a zeroed config (all `None`) if the file does not exist.
+    pub fn load(profile: &str) -> io::Result<Self> {
+        let path = profile_dir(profile)?.join("vm.conf");
+        Self::load_path(&path)
+    }
+
+    fn load_path(path: &std::path::Path) -> io::Result<Self> {
+        let text = match std::fs::read_to_string(path) {
+            Ok(t) => t,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Self::default()),
+            Err(e) => return Err(e),
+        };
+        let mut cfg = Self::default();
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let Some((key, val)) = line.split_once('=') else {
+                continue;
+            };
+            let key = key.trim();
+            let val = val.trim();
+            match key {
+                "disk" => cfg.disk = Some(PathBuf::from(val)),
+                "kernel" => cfg.kernel = Some(PathBuf::from(val)),
+                "initrd" => cfg.initrd = Some(PathBuf::from(val)),
+                "memory" => cfg.memory = val.parse::<usize>().ok(),
+                "cpus" => cfg.cpus = val.parse::<usize>().ok(),
+                _ => {}
+            }
+        }
+        Ok(cfg)
+    }
+}
+
 impl StateDir {
     /// Open the default profile state directory (~/.local/share/pelagos/).
     #[allow(dead_code)]
@@ -312,6 +377,46 @@ mod tests {
             PathBuf::from("/tmp/pelagos-xdg-test/pelagos/profiles/build")
         );
         std::env::remove_var("XDG_DATA_HOME");
+    }
+
+    /// VmProfileConfig parses a vm.conf file correctly.
+    #[test]
+    fn vm_profile_config_parse() {
+        use std::io::Write;
+        let ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos();
+        let dir = std::env::temp_dir().join(format!("pelagos-conf-test-{}", ns));
+        std::fs::create_dir_all(&dir).unwrap();
+        let conf_path = dir.join("vm.conf");
+        let mut f = std::fs::File::create(&conf_path).unwrap();
+        writeln!(f, "# comment").unwrap();
+        writeln!(f, "disk   = /data/build.img").unwrap();
+        writeln!(f, "kernel = /boot/vmlinuz").unwrap();
+        writeln!(f, "initrd = /boot/initrd.gz").unwrap();
+        writeln!(f, "memory = 8192").unwrap();
+        writeln!(f, "cpus   = 4").unwrap();
+        writeln!(f, "unknown = ignored").unwrap();
+        drop(f);
+
+        let cfg = super::VmProfileConfig::load_path(&conf_path).unwrap();
+        assert_eq!(cfg.disk, Some(PathBuf::from("/data/build.img")));
+        assert_eq!(cfg.kernel, Some(PathBuf::from("/boot/vmlinuz")));
+        assert_eq!(cfg.initrd, Some(PathBuf::from("/boot/initrd.gz")));
+        assert_eq!(cfg.memory, Some(8192));
+        assert_eq!(cfg.cpus, Some(4));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// VmProfileConfig returns all-None when vm.conf is absent.
+    #[test]
+    fn vm_profile_config_missing_returns_default() {
+        let absent = PathBuf::from("/tmp/pelagos-no-such-conf-file.conf");
+        let cfg = super::VmProfileConfig::load_path(&absent).unwrap();
+        assert!(cfg.disk.is_none());
+        assert!(cfg.memory.is_none());
     }
 
     /// default and named profiles use distinct state directories.

--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -164,32 +164,37 @@ cat > "$ALPINE_VOLUMES_DIR/provision-build.sh" << OUTER_EOF
 #!/bin/sh
 # Provisioning script — runs inside the Alpine VM as root.
 # Executed by build-build-image.sh via pelagos vm ssh.
+# Uses only busybox-compatible commands (no util-linux losetup extensions).
 set -eux
 
 VOLUMES=/var/lib/pelagos/volumes
 IMG="\$VOLUMES/build.img"
 MNT=/mnt/build-provision
+LODEV=/dev/loop0
 
 echo "[provision] loading loop module"
 modprobe loop
+# Loop module doesn't auto-create device nodes without udev; create manually.
+mknod "\$LODEV" b 7 0 2>/dev/null || true
 
-# Set up loop device.
-echo "[provision] attaching loop device"
-LODEV=\$(losetup --find --show "\$IMG")
-echo "[provision] loop device: \$LODEV"
-
-# Check if we need to format.
-if blkid "\$LODEV" 2>/dev/null | grep -q 'LABEL="ubuntu-build"'; then
+# Format the image if it doesn't already have the ubuntu-build label.
+# mke2fs -F operates directly on a regular file — no loop device needed.
+if blkid "\$IMG" 2>/dev/null | grep -q 'LABEL="ubuntu-build"'; then
     echo "[provision] image already formatted as ubuntu-build — skipping format"
 else
     echo "[provision] formatting as ext4 label=ubuntu-build"
-    mke2fs -F -t ext4 -L ubuntu-build "\$LODEV"
+    /sbin/mke2fs -F -t ext4 -L ubuntu-build "\$IMG"
 fi
+
+# Attach loop device for mounting.
+losetup "\$LODEV" "\$IMG"
+echo "[provision] attached \$LODEV"
 
 mkdir -p "\$MNT"
 mount "\$LODEV" "\$MNT"
 
-# Check if Ubuntu is already extracted.
+# ---- Ubuntu base extraction ----
+
 if [ -f "\$MNT/etc/os-release" ]; then
     echo "[provision] Ubuntu base already extracted — skipping download"
 else
@@ -206,7 +211,9 @@ fi
 
 # ---- chroot provisioning ----
 
-# Bind-mount kernel filesystems into chroot.
+# Bind-mount kernel filesystems.  Create target dirs first — ubuntu-base
+# includes /proc and /sys but /dev/pts may be absent.
+mkdir -p "\$MNT/proc" "\$MNT/sys" "\$MNT/dev" "\$MNT/dev/pts"
 mount -t proc  proc   "\$MNT/proc"
 mount -t sysfs sysfs  "\$MNT/sys"
 mount --bind /dev     "\$MNT/dev"
@@ -225,11 +232,13 @@ SOURCES
 
 echo "[provision] apt-get update + install"
 chroot "\$MNT" apt-get update -qq
-chroot "\$MNT" apt-get install -y --no-install-recommends \
+chroot "\$MNT" env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential git curl wget ca-certificates \
     iproute2 nftables openssh-server \
     systemd systemd-sysv \
     pkg-config libssl-dev
+
+# ---- networking: systemd-networkd with static IP ----
 
 echo "[provision] setting up systemd-networkd for static IP"
 mkdir -p "\$MNT/etc/systemd/network"
@@ -244,30 +253,44 @@ DNS=8.8.8.8
 DNS=1.1.1.1
 NETCFG
 
-# Enable systemd-networkd and ssh.
-chroot "\$MNT" systemctl enable systemd-networkd 2>/dev/null || true
-chroot "\$MNT" systemctl enable ssh              2>/dev/null || true
+# Enable services via symlinks — systemctl enable doesn't work without running
+# systemd, but symlink creation is equivalent and always works in a chroot.
+mkdir -p "\$MNT/etc/systemd/system/multi-user.target.wants"
+ln -sf /lib/systemd/system/systemd-networkd.service \
+    "\$MNT/etc/systemd/system/multi-user.target.wants/systemd-networkd.service" 2>/dev/null || true
+ln -sf /lib/systemd/system/ssh.service \
+    "\$MNT/etc/systemd/system/multi-user.target.wants/ssh.service" 2>/dev/null || true
 
-# SSH authorized key for root.
+# ---- SSH ----
+
 mkdir -p "\$MNT/root/.ssh"
 chmod 700 "\$MNT/root/.ssh"
-echo "${PUB_KEY_CONTENT}" > "\$MNT/root/.ssh/authorized_keys"
+printf '%s\n' "${PUB_KEY_CONTENT}" > "\$MNT/root/.ssh/authorized_keys"
 chmod 600 "\$MNT/root/.ssh/authorized_keys"
 
-# Allow root login via key.
-sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' "\$MNT/etc/ssh/sshd_config" 2>/dev/null || true
+# Ubuntu default PermitRootLogin is "prohibit-password" (key auth only) — correct.
+# No sshd_config edit needed; just confirm it's not set to "no".
+sed -i 's/^PermitRootLogin no/PermitRootLogin prohibit-password/' "\$MNT/etc/ssh/sshd_config" 2>/dev/null || true
 
-echo "[provision] installing Rust toolchain"
-chroot "\$MNT" bash -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path'
+# ---- Rust toolchain ----
+
+echo "[provision] installing Rust stable toolchain"
+# HOME must be set explicitly; chroot doesn't inherit it reliably.
+chroot "\$MNT" env HOME=/root \
+    bash -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+             | sh -s -- -y --default-toolchain stable --no-modify-path'
+
+# ---- cleanup ----
 
 echo "[provision] cleaning up"
 chroot "\$MNT" apt-get clean
-umount "\$MNT/dev/pts" || true
-umount "\$MNT/dev"     || true
-umount "\$MNT/sys"     || true
-umount "\$MNT/proc"    || true
+umount "\$MNT/dev/pts" 2>/dev/null || true
+umount "\$MNT/dev"     2>/dev/null || true
+umount "\$MNT/sys"     2>/dev/null || true
+umount "\$MNT/proc"    2>/dev/null || true
 umount "\$MNT"
 losetup -d "\$LODEV"
+rmdir  "\$MNT" 2>/dev/null || true
 
 echo "[provision] done"
 OUTER_EOF

--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# build-build-image.sh — Provision a 20 GB Ubuntu 22.04 build VM image.
+#
+# Creates out/build.img: an ext4 filesystem labeled "ubuntu-build" containing
+# a minimal Ubuntu 22.04 arm64 rootfs with Rust toolchain and pelagos build
+# dependencies.  The image boots via the same kernel/initramfs as the Alpine
+# pelagos VM; the init script pivots to Ubuntu systemd when it detects the
+# "ubuntu-build" disk label instead of "pelagos-root".
+#
+# After provisioning, writes vm.conf for the named profile so
+#   pelagos --profile <name> ping
+# boots the Ubuntu VM without extra flags.
+#
+# Requirements:
+#   - Alpine VM already running: bash scripts/vm-ping.sh
+#   - out/vmlinuz, out/initramfs-custom.gz must exist
+#   - scripts/build-vm-image.sh must have been run (stages loop.ko)
+#
+# Usage:
+#   bash scripts/build-build-image.sh [--profile <name>] [--memory <mib>] [--cpus <n>]
+#
+# Options:
+#   --profile <name>   Profile name for the build VM (default: "build")
+#   --memory  <mib>    Memory for the build VM in MiB (default: 4096)
+#   --cpus    <n>      vCPU count for the build VM (default: 4)
+#   --disk-size <gb>   Disk size in GB (default: 20)
+#
+# The build VM is accessible after provisioning via:
+#   bash scripts/vm-restart.sh --profile <name>
+#   pelagos --profile <name> vm ssh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+PROFILE="build"
+MEMORY_MIB=4096
+CPUS=4
+DISK_SIZE_GB=20
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --profile)   PROFILE="$2";     shift 2 ;;
+        --memory)    MEMORY_MIB="$2";  shift 2 ;;
+        --cpus)      CPUS="$2";        shift 2 ;;
+        --disk-size) DISK_SIZE_GB="$2"; shift 2 ;;
+        *)           echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+BINARY="$REPO_ROOT/target/aarch64-apple-darwin/release/pelagos"
+KERNEL="$REPO_ROOT/out/vmlinuz"
+INITRD="$REPO_ROOT/out/initramfs-custom.gz"
+ALPINE_DISK="$REPO_ROOT/out/root.img"
+BUILD_IMG="$REPO_ROOT/out/build.img"
+
+PELAGOS_BASE="${XDG_DATA_HOME:-$HOME/.local/share}/pelagos"
+if [[ "$PROFILE" == "default" ]]; then
+    PROFILE_STATE_DIR="$PELAGOS_BASE"
+else
+    PROFILE_STATE_DIR="$PELAGOS_BASE/profiles/$PROFILE"
+fi
+
+ALPINE_VOLUMES_DIR="$PELAGOS_BASE/volumes"
+SSH_KEY_FILE="$PELAGOS_BASE/vm_key"
+UBUNTU_BASE_URL="http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04-base-arm64.tar.gz"
+UBUNTU_TARBALL_NAME="ubuntu-base-22.04-base-arm64.tar.gz"
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== build-build-image.sh ==="
+echo "  profile:   $PROFILE"
+echo "  output:    $BUILD_IMG"
+echo "  memory:    ${MEMORY_MIB} MiB"
+echo "  cpus:      $CPUS"
+echo "  disk size: ${DISK_SIZE_GB} GB"
+echo ""
+
+for f in "$KERNEL" "$INITRD" "$ALPINE_DISK" "$BINARY"; do
+    if [[ ! -f "$f" ]]; then
+        echo "ABORT: missing $f" >&2
+        echo "       Run 'bash scripts/build-vm-image.sh' and 'bash scripts/sign.sh' first." >&2
+        exit 1
+    fi
+done
+
+if [[ ! -f "$SSH_KEY_FILE" ]]; then
+    echo "ABORT: SSH key $SSH_KEY_FILE not found" >&2
+    echo "       Run 'bash scripts/build-vm-image.sh' first to generate it." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Ensure Alpine VM is running
+# ---------------------------------------------------------------------------
+
+pelagos_alpine() {
+    "$BINARY" --kernel "$KERNEL" --initrd "$INITRD" --disk "$ALPINE_DISK" "$@"
+}
+
+echo "--- pre-flight: Alpine VM ---"
+printf "  pinging Alpine VM... "
+if ! pelagos_alpine ping 2>&1 | grep -q pong; then
+    echo ""
+    echo "ABORT: Alpine VM not running." >&2
+    echo "       Run 'bash scripts/vm-ping.sh' first." >&2
+    exit 1
+fi
+echo "ok"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Create the sparse build image on macOS
+# ---------------------------------------------------------------------------
+
+DISK_SIZE_MB=$((DISK_SIZE_GB * 1024))
+
+if [[ -f "$BUILD_IMG" ]]; then
+    echo "--- reusing existing $BUILD_IMG ---"
+    echo "  (delete it to reprovision from scratch)"
+    echo ""
+else
+    echo "--- creating sparse ${DISK_SIZE_GB} GB image ---"
+    dd if=/dev/zero of="$BUILD_IMG" bs=1m count=0 seek="$DISK_SIZE_MB" 2>/dev/null
+    echo "  created: $BUILD_IMG (sparse ${DISK_SIZE_GB} GB)"
+    echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# Copy build.img to the Alpine volumes dir so the VM can see it via virtiofs.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$ALPINE_VOLUMES_DIR"
+VOLUMES_IMG="$ALPINE_VOLUMES_DIR/build.img"
+
+if [[ "$BUILD_IMG" -ef "$VOLUMES_IMG" ]]; then
+    : # same file (shouldn't happen but be safe)
+elif [[ -f "$VOLUMES_IMG" ]]; then
+    echo "--- $VOLUMES_IMG already present (skipping copy) ---"
+    echo ""
+else
+    echo "--- copying build.img to volumes dir for VM access ---"
+    cp "$BUILD_IMG" "$VOLUMES_IMG"
+    echo "  copied to $VOLUMES_IMG"
+    echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# Write the provisioning script to the volumes dir (visible in VM as
+# /var/lib/pelagos/volumes/provision-build.sh).
+# ---------------------------------------------------------------------------
+
+PUB_KEY_CONTENT="$(cat "${SSH_KEY_FILE}.pub")"
+
+cat > "$ALPINE_VOLUMES_DIR/provision-build.sh" << OUTER_EOF
+#!/bin/sh
+# Provisioning script — runs inside the Alpine VM as root.
+# Executed by build-build-image.sh via pelagos vm ssh.
+set -eux
+
+VOLUMES=/var/lib/pelagos/volumes
+IMG="\$VOLUMES/build.img"
+MNT=/mnt/build-provision
+
+echo "[provision] loading loop module"
+modprobe loop
+
+# Set up loop device.
+echo "[provision] attaching loop device"
+LODEV=\$(losetup --find --show "\$IMG")
+echo "[provision] loop device: \$LODEV"
+
+# Check if we need to format.
+if blkid "\$LODEV" 2>/dev/null | grep -q 'LABEL="ubuntu-build"'; then
+    echo "[provision] image already formatted as ubuntu-build — skipping format"
+else
+    echo "[provision] formatting as ext4 label=ubuntu-build"
+    mke2fs -F -t ext4 -L ubuntu-build "\$LODEV"
+fi
+
+mkdir -p "\$MNT"
+mount "\$LODEV" "\$MNT"
+
+# Check if Ubuntu is already extracted.
+if [ -f "\$MNT/etc/os-release" ]; then
+    echo "[provision] Ubuntu base already extracted — skipping download"
+else
+    echo "[provision] downloading Ubuntu 22.04 arm64 base tarball"
+    TARBALL="\$VOLUMES/${UBUNTU_TARBALL_NAME}"
+    if [ ! -f "\$TARBALL" ]; then
+        wget -q -O "\$TARBALL" "${UBUNTU_BASE_URL}" || \
+            curl -fsSL -o "\$TARBALL" "${UBUNTU_BASE_URL}"
+    fi
+    echo "[provision] extracting Ubuntu base"
+    tar -xzf "\$TARBALL" -C "\$MNT"
+    echo "[provision] extraction complete"
+fi
+
+# ---- chroot provisioning ----
+
+# Bind-mount kernel filesystems into chroot.
+mount -t proc  proc   "\$MNT/proc"
+mount -t sysfs sysfs  "\$MNT/sys"
+mount --bind /dev     "\$MNT/dev"
+mount --bind /dev/pts "\$MNT/dev/pts"
+
+# DNS for apt inside chroot.
+echo "nameserver 8.8.8.8"  > "\$MNT/etc/resolv.conf"
+echo "nameserver 1.1.1.1" >> "\$MNT/etc/resolv.conf"
+
+# apt sources.
+cat > "\$MNT/etc/apt/sources.list" << 'SOURCES'
+deb http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse
+deb http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse
+deb http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse
+SOURCES
+
+echo "[provision] apt-get update + install"
+chroot "\$MNT" apt-get update -qq
+chroot "\$MNT" apt-get install -y --no-install-recommends \
+    build-essential git curl wget ca-certificates \
+    iproute2 nftables openssh-server \
+    systemd systemd-sysv \
+    pkg-config libssl-dev
+
+echo "[provision] setting up systemd-networkd for static IP"
+mkdir -p "\$MNT/etc/systemd/network"
+cat > "\$MNT/etc/systemd/network/10-eth.network" << 'NETCFG'
+[Match]
+Name=en* eth*
+
+[Network]
+Address=192.168.105.2/24
+Gateway=192.168.105.1
+DNS=8.8.8.8
+DNS=1.1.1.1
+NETCFG
+
+# Enable systemd-networkd and ssh.
+chroot "\$MNT" systemctl enable systemd-networkd 2>/dev/null || true
+chroot "\$MNT" systemctl enable ssh              2>/dev/null || true
+
+# SSH authorized key for root.
+mkdir -p "\$MNT/root/.ssh"
+chmod 700 "\$MNT/root/.ssh"
+echo "${PUB_KEY_CONTENT}" > "\$MNT/root/.ssh/authorized_keys"
+chmod 600 "\$MNT/root/.ssh/authorized_keys"
+
+# Allow root login via key.
+sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' "\$MNT/etc/ssh/sshd_config" 2>/dev/null || true
+
+echo "[provision] installing Rust toolchain"
+chroot "\$MNT" bash -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path'
+
+echo "[provision] cleaning up"
+chroot "\$MNT" apt-get clean
+umount "\$MNT/dev/pts" || true
+umount "\$MNT/dev"     || true
+umount "\$MNT/sys"     || true
+umount "\$MNT/proc"    || true
+umount "\$MNT"
+losetup -d "\$LODEV"
+
+echo "[provision] done"
+OUTER_EOF
+
+chmod +x "$ALPINE_VOLUMES_DIR/provision-build.sh"
+echo "--- wrote provisioning script ---"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Execute the provisioning script inside the Alpine VM.
+# ---------------------------------------------------------------------------
+
+echo "--- running provisioning script in Alpine VM ---"
+echo "    (this will download Ubuntu and install packages; takes several minutes)"
+echo ""
+
+pelagos_alpine vm ssh -- sh /var/lib/pelagos/volumes/provision-build.sh
+
+echo ""
+echo "--- provisioning complete ---"
+
+# Clean up the provisioning script and tarball from the volumes dir.
+rm -f "$ALPINE_VOLUMES_DIR/provision-build.sh"
+rm -f "$ALPINE_VOLUMES_DIR/$UBUNTU_TARBALL_NAME"
+
+# ---------------------------------------------------------------------------
+# Move build.img from volumes dir to out/ (canonical location).
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- moving build.img to out/ ---"
+mv "$VOLUMES_IMG" "$BUILD_IMG"
+echo "  $BUILD_IMG"
+
+# ---------------------------------------------------------------------------
+# Write vm.conf for the build profile.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- writing vm.conf for profile '$PROFILE' ---"
+mkdir -p "$PROFILE_STATE_DIR"
+cat > "$PROFILE_STATE_DIR/vm.conf" << VMCONF_EOF
+# vm.conf — auto-written by build-build-image.sh
+# Profile: $PROFILE
+disk   = $BUILD_IMG
+kernel = $KERNEL
+initrd = $INITRD
+memory = $MEMORY_MIB
+cpus   = $CPUS
+VMCONF_EOF
+
+echo "  $PROFILE_STATE_DIR/vm.conf"
+echo ""
+echo "=== build VM image ready ==="
+echo ""
+echo "Boot the build VM:"
+echo "  bash scripts/vm-restart.sh --profile $PROFILE"
+echo "SSH into it:"
+echo "  pelagos --profile $PROFILE vm ssh"
+echo ""

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -496,6 +496,17 @@ if [ ! -f "$INITRAMFS_OUT" ] \
         echo "  WARNING: virtio_blk.ko not found in modloop — /dev/vda will be unavailable" >&2
     fi
 
+    # loop.ko: needed by build-build-image.sh to losetup a sparse image file
+    # inside the Alpine VM and provision an Ubuntu rootfs via chroot.
+    LOOP_KO="$NETMOD_BASE/drivers/block/loop.ko"
+    if [ -f "$LOOP_KO" ]; then
+        mkdir -p "$INITRD_TMP/lib/modules/$KVER/kernel/drivers/block"
+        cp "$LOOP_KO" "$INITRD_TMP/lib/modules/$KVER/kernel/drivers/block/loop.ko"
+        echo "  staged loop.ko"
+    else
+        echo "  WARNING: loop.ko not found in modloop — losetup will be unavailable" >&2
+    fi
+
     # ext4 filesystem module (+ jbd2 journal + mbcache deps): needed to mount /dev/vda.
     # ext4 is a module in linux-lts (not built-in).  ext4 replaces ext2 because its
     # journal makes the filesystem self-healing after unclean VM shutdowns — no more
@@ -666,6 +677,16 @@ if busybox grep -q '^rootfs / rootfs' /proc/mounts 2>/dev/null; then
         NEEDS_FORMAT=1
         NEEDS_COPY=1
     elif busybox mount -t ext4 /dev/vda /newroot 2>/dev/null; then
+        # If the disk carries a non-pelagos label (e.g. "ubuntu-build"), it is an
+        # external rootfs managed by build-build-image.sh.  Skip the Alpine copy
+        # entirely and hand off directly to the disk's own /sbin/init (systemd).
+        DISK_LABEL="\$(busybox blkid /dev/vda 2>/dev/null | busybox grep -o 'LABEL="[^"]*"' | busybox cut -d'"' -f2)"
+        if [ -n "\$DISK_LABEL" ] && [ "\$DISK_LABEL" != "pelagos-root" ]; then
+            echo "[pelagos-init] pass 1: external rootfs label='\$DISK_LABEL' — pivoting to disk's /sbin/init"
+            exec busybox switch_root /newroot /sbin/init
+            echo "[pelagos-init] FATAL: switch_root to external rootfs failed" >/dev/console 2>&1
+            exec busybox sh
+        fi
         DISK_VERSION="\$(busybox cat /newroot/etc/pelagos-root-version 2>/dev/null || true)"
         if [ "\$DISK_VERSION" = "\$EXPECTED_VERSION" ]; then
             echo "[pelagos-init] pass 1: disk root is current (version=\$EXPECTED_VERSION)"

--- a/scripts/vm-ping.sh
+++ b/scripts/vm-ping.sh
@@ -10,9 +10,13 @@
 # --profile <name>  Use a named VM profile (isolated state dir).
 #                   Default: "default" (~/.local/share/pelagos/).
 #
-# For the default profile, --kernel/--initrd/--disk are passed explicitly
-# from out/.  For named profiles that have a vm.conf, those paths are read
-# from vm.conf by the binary — do not pass flags that would override them.
+# Kernel/disk/initrd resolution (in precedence order):
+#   1. vm.conf in the profile state dir (named profiles with build images)
+#   2. out/vmlinuz, out/root.img, out/initramfs-custom.gz (default fallback)
+#
+# When a vm.conf exists for the named profile, CLI flags are NOT passed to
+# avoid overriding vm.conf values.  When no vm.conf exists (e.g. test
+# profiles), the out/ defaults are passed — same as the default profile.
 
 set -uo pipefail
 
@@ -47,9 +51,25 @@ fi
 PROFILE_ARG=()
 [[ "$PROFILE" != "default" ]] && PROFILE_ARG=(--profile "$PROFILE")
 
-# For the default profile, pass kernel/initrd/disk explicitly.
-# For named profiles, vm.conf provides them — passing CLI flags would override.
+# Determine whether the profile has a vm.conf that provides disk/kernel/initrd.
+# Named profiles with a vm.conf (e.g. build profile) must NOT get explicit
+# --kernel/--disk flags — those would override vm.conf with the wrong paths.
+# Named profiles without a vm.conf (e.g. test-vm-profiles.sh test profiles)
+# fall back to the out/ defaults, same as the default profile.
+PELAGOS_BASE="${XDG_DATA_HOME:-$HOME/.local/share}/pelagos"
 if [[ "$PROFILE" == "default" ]]; then
+    VMCONF="$PELAGOS_BASE/vm.conf"
+else
+    VMCONF="$PELAGOS_BASE/profiles/$PROFILE/vm.conf"
+fi
+
+if [[ -f "$VMCONF" ]] && [[ "$PROFILE" != "default" ]]; then
+    # Profile has a vm.conf — let the binary read kernel/disk/initrd from it.
+    exec "$BINARY" \
+        "${PROFILE_ARG[@]}" \
+        ping
+else
+    # No vm.conf (or default profile) — pass out/ defaults explicitly.
     for f in "$KERNEL" "$INITRD" "$DISK"; do
         if [[ ! -f "$f" ]]; then
             echo "Missing: $f" >&2
@@ -58,12 +78,9 @@ if [[ "$PROFILE" == "default" ]]; then
         fi
     done
     exec "$BINARY" \
+        "${PROFILE_ARG[@]}" \
         --kernel "$KERNEL" \
         --initrd "$INITRD" \
         --disk   "$DISK" \
-        ping
-else
-    exec "$BINARY" \
-        "${PROFILE_ARG[@]}" \
         ping
 fi

--- a/scripts/vm-ping.sh
+++ b/scripts/vm-ping.sh
@@ -9,6 +9,10 @@
 #
 # --profile <name>  Use a named VM profile (isolated state dir).
 #                   Default: "default" (~/.local/share/pelagos/).
+#
+# For the default profile, --kernel/--initrd/--disk are passed explicitly
+# from out/.  For named profiles that have a vm.conf, those paths are read
+# from vm.conf by the binary — do not pass flags that would override them.
 
 set -uo pipefail
 
@@ -20,11 +24,11 @@ INITRD="$REPO_ROOT/out/initramfs-custom.gz"
 DISK="$REPO_ROOT/out/root.img"
 BINARY="$REPO_ROOT/target/aarch64-apple-darwin/release/pelagos"
 
-PROFILE_ARG=()
+PROFILE="default"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --profile)
-            PROFILE_ARG=(--profile "$2")
+            PROFILE="$2"
             shift 2
             ;;
         *)
@@ -34,17 +38,32 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-for f in "$KERNEL" "$INITRD" "$DISK" "$BINARY"; do
-    if [ ! -f "$f" ]; then
-        echo "Missing: $f" >&2
-        echo "Run 'bash scripts/build-vm-image.sh' and 'bash scripts/sign.sh' first." >&2
-        exit 1
-    fi
-done
+if [[ ! -f "$BINARY" ]]; then
+    echo "Missing: $BINARY" >&2
+    echo "Run 'cargo build -p pelagos-mac --release' and 'bash scripts/sign.sh' first." >&2
+    exit 1
+fi
 
-exec "$BINARY" \
-    "${PROFILE_ARG[@]}" \
-    --kernel "$KERNEL" \
-    --initrd "$INITRD" \
-    --disk   "$DISK" \
-    ping
+PROFILE_ARG=()
+[[ "$PROFILE" != "default" ]] && PROFILE_ARG=(--profile "$PROFILE")
+
+# For the default profile, pass kernel/initrd/disk explicitly.
+# For named profiles, vm.conf provides them — passing CLI flags would override.
+if [[ "$PROFILE" == "default" ]]; then
+    for f in "$KERNEL" "$INITRD" "$DISK"; do
+        if [[ ! -f "$f" ]]; then
+            echo "Missing: $f" >&2
+            echo "Run 'bash scripts/build-vm-image.sh' first." >&2
+            exit 1
+        fi
+    done
+    exec "$BINARY" \
+        --kernel "$KERNEL" \
+        --initrd "$INITRD" \
+        --disk   "$DISK" \
+        ping
+else
+    exec "$BINARY" \
+        "${PROFILE_ARG[@]}" \
+        ping
+fi

--- a/scripts/vm-restart.sh
+++ b/scripts/vm-restart.sh
@@ -46,8 +46,4 @@ if [[ "$NUKE" -eq 1 ]]; then
     dd if=/dev/zero of="$REPO_ROOT/out/root.img" bs=1m count=0 seek=8192
 fi
 
-PING_ARGS=()
-if [[ "$PROFILE" != "default" ]]; then
-    PING_ARGS=(--profile "$PROFILE")
-fi
-exec bash "$SCRIPT_DIR/vm-ping.sh" "${PING_ARGS[@]}"
+exec bash "$SCRIPT_DIR/vm-ping.sh" --profile "$PROFILE"


### PR DESCRIPTION
## Summary

- **Per-profile vm.conf** (`state.rs`, `main.rs`): named profiles load `~/.local/share/pelagos/profiles/<name>/vm.conf` for `disk`, `kernel`, `initrd`, `memory`, `cpus`. Precedence: CLI flag > vm.conf > compiled default. Unblocks named profiles that need different VM images (e.g. a 20 GB Ubuntu build disk instead of the 8 GB Alpine root.img).

- **`scripts/build-build-image.sh`**: provisions a 20 GB Ubuntu 22.04 arm64 build VM image (`out/build.img`) inside the running Alpine VM via SSH. Installs build-essential, git, curl, openssh-server, iproute2, systemd, and Rust stable. Writes `vm.conf` for the named profile (default: `build`).

- **`scripts/build-vm-image.sh`**: stages `loop.ko` (needed to `losetup` the build image inside Alpine) and adds an external-rootfs label check in the init script — when `/dev/vda` has a label other than `pelagos-root`, init skips the Alpine copy and pivots directly to `/sbin/init` (Ubuntu systemd).

- **`scripts/vm-ping.sh`**: for named profiles, no longer passes `--kernel/--initrd/--disk` on the CLI (which would override vm.conf). Default profile behaviour unchanged.

## Usage

```bash
# One-time: ensure Alpine VM is running, then provision
bash scripts/vm-ping.sh
bash scripts/build-build-image.sh          # takes several minutes

# Boot the Ubuntu build VM
bash scripts/vm-restart.sh --profile build
pelagos --profile build vm ssh
```

## Test plan

- [ ] `cargo test -p pelagos-mac` — 61 tests pass (including two new `VmProfileConfig` tests)
- [ ] `cargo clippy -p pelagos-mac --release -- -D warnings` — clean
- [ ] `bash scripts/vm-ping.sh` — default profile still works (regression)
- [ ] `bash scripts/build-build-image.sh` — provisions build.img, writes vm.conf
- [ ] `bash scripts/vm-restart.sh --profile build` — boots Ubuntu VM, responds to ping
- [ ] `pelagos --profile build vm ssh -- rustc --version` — Rust toolchain available

Part of #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)