### PR TITLE
fix: use CONTAINER as value_name for container subcommands

### DIFF
--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -132,30 +132,35 @@ enum Commands {
     },
     /// Print container logs
     Logs {
-        /// Container name
+        /// Name of the container
+        #[arg(value_name = "CONTAINER")]
         name: String,
         /// Follow log output
         #[arg(short = 'f', long)]
         follow: bool,
     },
-    /// Print low-level JSON information about a container (delegates to `pelagos container inspect`)
+    /// Show low-level JSON details for a container
     Inspect {
-        /// Container name
+        /// Name of the container to inspect
+        #[arg(value_name = "CONTAINER")]
         name: String,
     },
     /// Restart a stopped container with its original parameters
     Start {
-        /// Container name
+        /// Name of the container to start
+        #[arg(value_name = "CONTAINER")]
         name: String,
     },
     /// Stop a running container
     Stop {
-        /// Container name
+        /// Name of the container to stop
+        #[arg(value_name = "CONTAINER")]
         name: String,
     },
     /// Remove a container
     Rm {
-        /// Container name
+        /// Name of the container to remove
+        #[arg(value_name = "CONTAINER")]
         name: String,
         /// Force remove even if running
         #[arg(short = 'f', long)]


### PR DESCRIPTION
\`logs\`, \`stop\`, \`rm\`, \`inspect\`, and \`start\` all showed \`<NAME>\` in error messages and usage lines — ambiguous for a user who doesn't know what kind of name is expected.

**Before:**
\`\`\`
error: the following required arguments were not provided:
  <NAME>
Usage: pelagos inspect <NAME>
\`\`\`

**After:**
\`\`\`
error: the following required arguments were not provided:
  <CONTAINER>
Usage: pelagos inspect <CONTAINER>
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)