### PR TITLE
feat: add `pelagos vm start` subcommand

### DIFF
--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -245,6 +245,8 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum VmCommands {
+    /// Start the persistent VM daemon (no-op if already running)
+    Start,
     /// Stop the persistent VM daemon
     Stop,
     /// Show persistent VM daemon status
@@ -449,6 +451,16 @@ fn main() {
             daemon::run(args); // -> !
         }
 
+        Commands::Vm {
+            sub: VmCommands::Start,
+        } => {
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            println!("running");
+        }
         Commands::Vm {
             sub: VmCommands::Stop,
         } => vm_stop(&profile),


### PR DESCRIPTION
Explicit counterpart to \`pelagos vm stop\`.

- Boots the VM daemon if not already running; no-op if already running
- Prints \`running\` in both cases
- Container commands continue to auto-start the VM implicitly — this adds a named pre-warm hook for scripts and shell rc files

\`\`\`
$ pelagos vm start   # cold boot
running
$ pelagos vm start   # already up — no-op
running
$ pelagos vm status
running (pid 43965)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)