### PR TITLE
feat: add pelagos restart command

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -145,6 +145,12 @@ pub enum GuestCommand {
     Stop {
         name: String,
     },
+    /// Stop then restart a container; maps to `pelagos restart <name>`.
+    Restart {
+        name: String,
+        #[serde(default = "default_restart_time")]
+        time: u64,
+    },
     /// Remove a container; maps to `pelagos rm [--force] <name>`.
     Rm {
         name: String,
@@ -202,6 +208,10 @@ pub enum GuestCommand {
 
 fn default_dockerfile() -> String {
     "Dockerfile".to_string()
+}
+
+fn default_restart_time() -> u64 {
+    10
 }
 
 #[derive(Debug, Serialize)]
@@ -454,6 +464,11 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
             GuestCommand::Stop { name } => {
                 let mut cmd = Command::new(pelagos_bin());
                 cmd.arg("stop").arg(&name);
+                spawn_and_stream(&mut writer, cmd)?;
+            }
+            GuestCommand::Restart { name, time } => {
+                let mut cmd = Command::new(pelagos_bin());
+                cmd.arg("restart").arg("--time").arg(time.to_string()).arg(&name);
                 spawn_and_stream(&mut writer, cmd)?;
             }
             GuestCommand::Rm { name, force } => {

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -160,6 +160,15 @@ enum Commands {
         #[arg(value_name = "CONTAINER")]
         name: String,
     },
+    /// Stop then start a container (running or exited)
+    Restart {
+        /// Name of the container
+        #[arg(value_name = "CONTAINER")]
+        name: String,
+        /// Seconds to wait for clean exit before sending SIGKILL (default: 10)
+        #[arg(long, short = 't', default_value = "10")]
+        time: u64,
+    },
     /// Remove a container
     Rm {
         /// Name of the container to remove
@@ -293,6 +302,7 @@ fn is_false(b: &bool) -> bool {
     !b
 }
 
+
 #[derive(Serialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 enum GuestCommand {
@@ -351,6 +361,10 @@ enum GuestCommand {
     },
     Stop {
         name: String,
+    },
+    Restart {
+        name: String,
+        time: u64,
     },
     Rm {
         name: String,
@@ -827,6 +841,17 @@ fn main() {
             }
             let stream = connect_or_exit(&profile);
             process::exit(passthrough_command(stream, GuestCommand::Stop { name }));
+        }
+
+        Commands::Restart { ref name, time } => {
+            let name = name.clone();
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit(&profile);
+            process::exit(passthrough_command(stream, GuestCommand::Restart { name, time }));
         }
 
         Commands::Rm { ref name, force } => {


### PR DESCRIPTION
## Summary

Adds `pelagos restart [--time N] <container>` — stop then start a container, matching `docker restart`.

- Running container: SIGTERM → wait up to `--time` seconds (default 10) → SIGKILL if needed → restart with saved SpawnConfig
- Exited container: equivalent to `pelagos start`

Backed by pelagos#132 / pelagos#133 (merged) in the Linux runtime.

## Test

```
pelagos run -d --name box alpine sleep 30
pelagos ps         # running, pid X
pelagos restart box
pelagos ps         # running, pid Y  (Y != X — confirmed new process)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)