### PR TITLE
feat: add -i and -- CMD support to pelagos start

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -140,6 +140,12 @@ pub enum GuestCommand {
     /// Restart a stopped container; maps to `pelagos start <name>`.
     Start {
         name: String,
+        /// Run interactively with a PTY (maps to `pelagos start -i`).
+        #[serde(default)]
+        interactive: bool,
+        /// Override the command for this run only (maps to `pelagos start -- CMD`).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        cmd_override: Vec<String>,
     },
     /// Stop a running container; maps to `pelagos stop <name>`.
     Stop {
@@ -456,10 +462,32 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 )?;
                 send_response(&mut writer, &GuestResponse::Exit { exit: 0 })?;
             }
-            GuestCommand::Start { name } => {
+            GuestCommand::Start {
+                name,
+                interactive,
+                cmd_override,
+            } => {
                 let mut cmd = Command::new(pelagos_bin());
-                cmd.arg("start").arg(&name);
-                spawn_and_stream(&mut writer, cmd)?;
+                cmd.arg("start");
+                if interactive {
+                    cmd.arg("-i");
+                }
+                cmd.arg(&name);
+                if !cmd_override.is_empty() {
+                    cmd.arg("--");
+                    cmd.args(&cmd_override);
+                }
+                if interactive {
+                    log::info!("start: container={} interactive=true", name);
+                    {
+                        let mut w = FdWriter(fd);
+                        send_response(&mut w, &GuestResponse::Ready { ready: true })?;
+                    }
+                    handle_exec_tty(fd, cmd)?;
+                    return Ok(());
+                } else {
+                    spawn_and_stream(&mut writer, cmd)?;
+                }
             }
             GuestCommand::Stop { name } => {
                 let mut cmd = Command::new(pelagos_bin());

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -153,6 +153,13 @@ enum Commands {
         /// Name of the container to start
         #[arg(value_name = "CONTAINER")]
         name: String,
+        /// Run interactively with a PTY (like `pelagos run -it`)
+        #[arg(long, short = 'i')]
+        interactive: bool,
+        /// Override the command for this run only; pass after --
+        /// Example: pelagos start -i myapp -- /bin/sh
+        #[arg(last = true, value_name = "CMD")]
+        cmd: Vec<String>,
     },
     /// Stop a running container
     Stop {
@@ -358,6 +365,10 @@ enum GuestCommand {
     ContainerPrune,
     Start {
         name: String,
+        #[serde(skip_serializing_if = "is_false")]
+        interactive: bool,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        cmd_override: Vec<String>,
     },
     Stop {
         name: String,
@@ -821,15 +832,30 @@ fn main() {
             process::exit(passthrough_command(stream, GuestCommand::ContainerPrune));
         }
 
-        Commands::Start { ref name } => {
+        Commands::Start {
+            ref name,
+            interactive,
+            ref cmd,
+        } => {
             let name = name.clone();
+            let cmd_override = cmd.clone();
             let daemon_args = daemon_args_from_cli(&cli);
             if let Err(e) = daemon::ensure_running(&daemon_args) {
                 log::error!("failed to start VM daemon: {}", e);
                 process::exit(1);
             }
             let stream = connect_or_exit(&profile);
-            process::exit(passthrough_command(stream, GuestCommand::Start { name }));
+            let guest_cmd = GuestCommand::Start {
+                name,
+                interactive,
+                cmd_override,
+            };
+            if interactive {
+                let tty = unsafe { libc::isatty(libc::STDOUT_FILENO) } != 0;
+                process::exit(exec_command(stream, guest_cmd, tty));
+            } else {
+                process::exit(passthrough_command(stream, guest_cmd));
+            }
         }
 
         Commands::Stop { ref name } => {


### PR DESCRIPTION
## Summary

- Adds `-i`/`--interactive` flag to `pelagos start` to run the container with a PTY (lets you enter an exited container's saved filesystem interactively)
- Adds `-- CMD` support to override the command for the restart without modifying the saved SpawnConfig
- Updates the vsock `GuestCommand::Start` protocol to carry `interactive` and `cmd_override` fields (both backward-compatible via serde defaults)
- Interactive path routes through `exec_command` / `handle_exec_tty`, matching the behaviour of `pelagos run -it` and `pelagos exec`

**Example:**
```
pelagos start -i myapp -- /bin/sh
```

## Test plan

- [x] `pelagos start --help` shows `-i` and `[-- <CMD>...]`
- [x] `pelagos run --name overlay-test alpine:3.21 sh -c "echo 'persistent data' > /test.txt"` writes a file
- [x] `pelagos start -i overlay-test -- /bin/sh` enters the container and shows `/test.txt` with `persistent data`
- [x] Guest builds cleanly (`cargo zigbuild --target aarch64-unknown-linux-musl`)
- [x] Host builds cleanly (`cargo build --release -p pelagos-mac`)
- [x] Formula reinstalled and end-to-end test passed

Related to #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)