### PR TITLE
feat: add --json flag to pelagos ps

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -124,6 +124,9 @@ pub enum GuestCommand {
     Ps {
         #[serde(default)]
         all: bool,
+        /// Request JSON output; maps to `pelagos ps --format json`.
+        #[serde(default)]
+        json: bool,
     },
     /// Print container logs; maps to `pelagos logs [--follow] <name>`.
     Logs {
@@ -375,12 +378,15 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 handle_exec_into(fd, &container, &args, &env, tty, workdir.as_deref())?;
                 return Ok(());
             }
-            GuestCommand::Ps { all } => {
-                log::debug!("ps all={}", all);
+            GuestCommand::Ps { all, json } => {
+                log::debug!("ps all={} json={}", all, json);
                 let mut cmd = Command::new(pelagos_bin());
                 cmd.arg("ps");
                 if all {
                     cmd.arg("--all");
+                }
+                if json {
+                    cmd.arg("--format").arg("json");
                 }
                 spawn_and_stream(&mut writer, cmd)?;
             }
@@ -496,7 +502,10 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
             }
             GuestCommand::Restart { name, time } => {
                 let mut cmd = Command::new(pelagos_bin());
-                cmd.arg("restart").arg("--time").arg(time.to_string()).arg(&name);
+                cmd.arg("restart")
+                    .arg("--time")
+                    .arg(time.to_string())
+                    .arg(&name);
                 spawn_and_stream(&mut writer, cmd)?;
             }
             GuestCommand::Rm { name, force } => {
@@ -1486,12 +1495,7 @@ fn handle_exec_into(
     tty: bool,
     workdir: Option<&str>,
 ) -> std::io::Result<()> {
-    log::info!(
-        "exec: container={} tty={} args={:?}",
-        container,
-        tty,
-        args
-    );
+    log::info!("exec: container={} tty={} args={:?}", container, tty, args);
     if args.is_empty() {
         let mut w = FdWriter(fd);
         let _ = send_response(
@@ -2143,14 +2147,39 @@ mod tests {
     fn ps_deserializes() {
         let json = r#"{"cmd":"ps","all":true}"#;
         let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
-        assert!(matches!(cmd, GuestCommand::Ps { all: true }));
+        assert!(matches!(
+            cmd,
+            GuestCommand::Ps {
+                all: true,
+                json: false
+            }
+        ));
     }
 
     #[test]
     fn ps_defaults_all_false() {
         let json = r#"{"cmd":"ps"}"#;
         let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
-        assert!(matches!(cmd, GuestCommand::Ps { all: false }));
+        assert!(matches!(
+            cmd,
+            GuestCommand::Ps {
+                all: false,
+                json: false
+            }
+        ));
+    }
+
+    #[test]
+    fn ps_json_flag_deserializes() {
+        let wire = r#"{"cmd":"ps","all":true,"json":true}"#;
+        let cmd: GuestCommand = serde_json::from_str(wire).expect("parse failed");
+        assert!(matches!(
+            cmd,
+            GuestCommand::Ps {
+                all: true,
+                json: true
+            }
+        ));
     }
 
     #[test]

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -131,6 +131,9 @@ enum Commands {
         /// Show all containers, including exited
         #[arg(short = 'a', long)]
         all: bool,
+        /// Output as JSON array (one object per container)
+        #[arg(long)]
+        json: bool,
     },
     /// Print container logs
     Logs {
@@ -355,6 +358,8 @@ enum GuestCommand {
     Ps {
         #[serde(skip_serializing_if = "is_false")]
         all: bool,
+        #[serde(skip_serializing_if = "is_false")]
+        json: bool,
     },
     Logs {
         name: String,
@@ -774,7 +779,7 @@ fn main() {
             process::exit(ping_command(stream));
         }
 
-        Commands::Ps { all } => {
+        Commands::Ps { all, json } => {
             // `ps` must not start the daemon: if no daemon is running, there are
             // no containers.  If the daemon is alive (possibly with different
             // mounts), just connect and ask.  This allows `docker ps` (called by
@@ -792,7 +797,7 @@ fn main() {
                 process::exit(0);
             }
             let stream = connect_or_exit(&profile);
-            process::exit(passthrough_command(stream, GuestCommand::Ps { all }));
+            process::exit(passthrough_command(stream, GuestCommand::Ps { all, json }));
         }
 
         Commands::Logs { ref name, follow } => {
@@ -2548,7 +2553,10 @@ mod tests {
 
     #[test]
     fn ps_command_serializes() {
-        let cmd = GuestCommand::Ps { all: true };
+        let cmd = GuestCommand::Ps {
+            all: true,
+            json: false,
+        };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["cmd"], "ps");


### PR DESCRIPTION
## Summary

- Adds `json: bool` to the `GuestCommand::Ps` wire protocol with `#[serde(default)]` for backward compatibility — old guests that don't know the field will safely default to `false`
- When `json: true`, the guest passes `--format json` to `pelagos ps`, which outputs a JSON array of `ContainerState` objects
- Exposes `--json` on the `pelagos ps` CLI subcommand (`pelagos ps --json`, `pelagos ps -a --json`)

Closes #98. Unblocks Epic #135 (pelagos-ui container list).

## Test plan

- [ ] `cargo test -p pelagos-mac -p pelagos-guest` passes (102 tests, 0 failures)
- [ ] `cargo clippy -p pelagos-mac -p pelagos-guest -- -D warnings` clean
- [ ] `pelagos ps` still works without `--json` (backward compat)
- [ ] `pelagos ps --json` outputs a JSON array when containers exist
- [ ] Old guest binary (without `json` field) still accepts `{"cmd":"ps","all":true}` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)