### PR TITLE
feat: pelagos-tui M1 — live container list TUI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "pelagos-guest",
     "pelagos-mac",
     "pelagos-docker",
+    "pelagos-tui",
 ]
 resolver = "2"
 

--- a/docs/TUI_PLAN.md
+++ b/docs/TUI_PLAN.md
@@ -1,0 +1,270 @@
+# pelagos-tui — Implementation Plan
+
+**Epic:** [#149](https://github.com/skeptomai/pelagos-mac/issues/149)
+**Approach:** Alternative A — Rust + ratatui + crossterm
+**Status:** M1 in progress
+
+---
+
+## Design Decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Library | ratatui + crossterm | Pure Rust, fits workspace, same stack |
+| Data source | `pelagos ps --json` subprocess | Works identically on macOS and Linux |
+| Interaction model | Monitoring-first, operational later | M1–M2 read-only; M3+ adds write ops |
+| Run/create UX | Command palette (not modal form) | Developers know the flags; lower design cost |
+| Profile UX | Modeline shows current; `p` opens picker overlay | Emacs-modeline inspired; close at hand, out of main panel |
+| Exec into container | Not in scope (any milestone) | Dropped by design |
+| Platform | macOS first; Linux via Runner trait swap | Runner abstraction makes Linux a single new struct |
+
+---
+
+## Layout
+
+```
+┌─ pelagos ─────────────────────────────────────────────────┐
+│                                                           │
+│  NAME          STATUS    IMAGE                  UPTIME    │
+│ ▶ webserver    running   nginx:alpine            2m 14s   │
+│   worker       running   myapp:latest            18m 02s  │
+│   dbmigrate    exited    postgres:16             1h 04m   │
+│                                                           │
+│                                                           │
+│  [q]quit  [a]all  [j/k]nav  [p]profile  [?]help          │
+├───────────────────────────────────────────────────────────┤
+│  default │ VM: running │ 3 containers │ ↻ 1s ago          │
+└───────────────────────────────────────────────────────────┘
+```
+
+- **Main panel:** container table, fills available height
+- **Hint bar:** one line above modeline, static keybind legend
+- **Modeline:** always-visible bottom bar (emacs-inspired): profile | VM status | container count | last refresh age
+- **Overlays:** profile picker, help — centered popups rendered over main panel
+
+---
+
+## Crate Structure
+
+New crate `pelagos-tui` added to the workspace at `pelagos-tui/`.
+
+```
+pelagos-tui/
+  src/
+    main.rs       — terminal setup/teardown, top-level event loop
+    app.rs        — App state struct, update logic, Mode enum
+    ui.rs         — ratatui layout and rendering (panel + modeline + overlays)
+    runner.rs     — Runner trait + MacOsRunner impl
+  Cargo.toml
+```
+
+Add to workspace `Cargo.toml` members list: `"pelagos-tui"`.
+
+### Cargo.toml dependencies
+
+```toml
+[package]
+name = "pelagos-tui"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+ratatui = "0.29"
+crossterm = "0.28"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+log.workspace = true
+env_logger.workspace = true
+anyhow = "1"
+```
+
+---
+
+## Data Model
+
+### `runner.rs`
+
+```rust
+pub trait Runner {
+    fn ps(&self, all: bool) -> anyhow::Result<Vec<Container>>;
+    fn vm_status(&self) -> bool;
+    fn profiles(&self) -> Vec<String>;
+    // M2+:
+    // fn stop(&self, name: &str) -> anyhow::Result<()>;
+    // fn rm(&self, name: &str, force: bool) -> anyhow::Result<()>;
+    // fn logs(&self, name: &str) -> anyhow::Result<impl BufRead>;
+}
+
+pub struct MacOsRunner {
+    pub profile: String,
+}
+
+impl Runner for MacOsRunner {
+    fn ps(&self, all: bool) -> anyhow::Result<Vec<Container>> {
+        // spawn: pelagos --profile <profile> ps --json [--all]
+        // parse stdout as serde_json::from_str::<Vec<Container>>
+    }
+
+    fn vm_status(&self) -> bool {
+        // spawn: pelagos --profile <profile> vm status
+        // exit code 0 = running, non-zero = stopped
+    }
+
+    fn profiles(&self) -> Vec<String> {
+        // read dir: ~/.local/share/pelagos/profiles/
+        // return subdirectory names; always include "default"
+        // see pelagos-mac/src/state.rs profile_dir() for the path
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Container {
+    pub name: String,
+    pub status: String,          // "running" | "exited"
+    pub pid: Option<u32>,
+    pub rootfs: String,          // image reference
+    pub started_at: Option<String>,
+}
+```
+
+Note: `Container` fields match `pelagos ps --json` output. Check `pelagos/src/cli/ps.rs`
+and `pelagos/src/cli/mod.rs` (`ContainerState`) for exact field names and types.
+
+### `app.rs`
+
+```rust
+pub enum Mode {
+    Normal,
+    ProfilePicker,
+    // M3: CommandPalette { input: String },
+    // M2: Help,
+}
+
+pub struct App {
+    pub mode: Mode,
+    pub containers: Vec<Container>,
+    pub selected: usize,
+    pub show_all: bool,
+    pub profile: String,
+    pub profiles: Vec<String>,
+    pub vm_running: bool,
+    pub last_refresh: std::time::Instant,
+    pub refresh_interval: std::time::Duration,
+    pub profile_picker_selected: usize,
+}
+
+impl App {
+    pub fn new(profile: String, profiles: Vec<String>) -> Self { ... }
+    pub fn refresh(&mut self, runner: &impl Runner) { ... }
+    pub fn on_key(&mut self, key: KeyEvent, runner: &impl Runner) { ... }
+    pub fn selected_container(&self) -> Option<&Container> { ... }
+}
+```
+
+---
+
+## Event Loop (`main.rs`)
+
+```
+setup terminal (raw mode, alternate screen)
+
+loop:
+  if tick elapsed (2s):
+    app.refresh(runner)        // ps --json + vm status
+
+  if crossterm event available:
+    match event:
+      KeyEvent → app.on_key(key, runner)
+      Resize   → terminal.autoresize()
+
+  terminal.draw(|f| ui::render(f, &app))
+
+  if app.should_quit: break
+
+restore terminal
+```
+
+---
+
+## Keybindings — M1
+
+| Key | Mode | Action |
+|---|---|---|
+| `j` / `↓` | Normal | select next container |
+| `k` / `↑` | Normal | select previous container |
+| `a` | Normal | toggle `--all`, immediate refresh |
+| `p` | Normal | open profile picker overlay |
+| `j` / `↓` | ProfilePicker | next profile |
+| `k` / `↑` | ProfilePicker | previous profile |
+| `Enter` | ProfilePicker | switch to selected profile |
+| `Esc` / `p` | ProfilePicker | close without switching |
+| `q` / `Ctrl-C` | Normal | quit |
+
+Keys shown in hint bar but not yet wired (M2+): `s` stop, `d` delete, `l` logs, `r` run, `?` help.
+
+---
+
+## Rendering (`ui.rs`)
+
+Three layers composed with ratatui:
+
+1. **Main layout** — vertical split: `[table][hint_bar][modeline]`
+2. **Table** — ratatui `Table` widget, columns: NAME / STATUS / IMAGE / UPTIME
+   - Running rows: green status text
+   - Exited rows: dim/red status text
+   - Selected row: highlighted (reversed)
+3. **Modeline** — single `Paragraph` line:
+   `  {profile}  │  VM: {running|stopped}  │  {n} containers  │  ↻ {age}  `
+4. **Profile picker overlay** (when `mode == ProfilePicker`):
+   - Centered `Block` with border, lists profiles, highlights selected
+   - Rendered last so it appears on top
+
+---
+
+## Milestones
+
+| Milestone | Scope |
+|---|---|
+| **M1** (current) | Container list, modeline, profile picker, `j/k/a/p/q` |
+| **M2** | Log viewer (bottom split pane, follow mode), `s` stop, `d` rm |
+| **M3** | Command palette — `r` turns modeline into input for `pelagos run ...` |
+| **M4** | Image list tab (`i`), volume list tab (`v`) — needs pelagos JSON output |
+| **M5** | Linux runner (`LinuxRunner`), cross-platform build + test |
+
+---
+
+## M1 Definition of Done
+
+- [ ] `pelagos-tui` crate builds cleanly in workspace (`cargo build -p pelagos-tui`)
+- [ ] Container list renders and live-refreshes every 2s
+- [ ] `j`/`k` navigate, `a` toggles `--all`, `q` quits
+- [ ] Modeline shows profile, VM status, container count, refresh age
+- [ ] Profile picker opens with `p`, switches profile on `Enter`, closes on `Esc`
+- [ ] Switching profile immediately refreshes container list
+- [ ] Empty state (VM stopped, no containers) renders gracefully — no crash
+- [ ] Terminal fully restored on quit (no leftover artifacts, no raw mode leak)
+- [ ] `cargo clippy -p pelagos-tui -- -D warnings` clean
+- [ ] Tested live with VM running and at least one container
+
+---
+
+## Key References in Codebase
+
+| What | Where |
+|---|---|
+| Profile directory path | `pelagos-mac/src/state.rs` → `profile_dir()`, `pelagos_base()` |
+| `pelagos ps --json` output shape | `pelagos/src/cli/mod.rs` → `ContainerState` struct |
+| `pelagos ps` JSON flag wire format | `pelagos-mac/pelagos-guest/src/main.rs` → `GuestCommand::Ps` |
+| VM status check | `pelagos-mac/src/state.rs` → `StateDir::is_daemon_alive()` |
+| Workspace Cargo.toml | `/Users/christopherbrown/Projects/pelagos-mac/Cargo.toml` |
+
+---
+
+## Notes
+
+- Do not use `eprintln!`/`println!` for diagnostics — use `log::` macros (project rule).
+- `pelagos-tui` is macOS-only for M1–M4; add `[target.'cfg(target_os = "macos")']`
+  if needed, but the Runner abstraction means the crate itself is platform-agnostic.
+- The TUI must handle the case where the pelagos binary is not in PATH gracefully.
+- Refresh should not block the UI — consider spawning refresh in a thread and
+  communicating via a channel, or accept the brief block for M1 (ps is fast).

--- a/pelagos-tui/Cargo.toml
+++ b/pelagos-tui/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pelagos-tui"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "pelagos-tui"
+path = "src/main.rs"
+
+[dependencies]
+ratatui = "0.29"
+crossterm = "0.28"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+log.workspace = true
+env_logger.workspace = true
+anyhow = "1"

--- a/pelagos-tui/src/app.rs
+++ b/pelagos-tui/src/app.rs
@@ -1,0 +1,189 @@
+//! Application state and update logic.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::time::{Duration, Instant};
+
+use crate::runner::{Container, Runner};
+
+// ---------------------------------------------------------------------------
+// Mode
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Mode {
+    Normal,
+    ProfilePicker,
+}
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+
+pub struct App {
+    pub mode: Mode,
+    pub containers: Vec<Container>,
+    /// Index of the highlighted row in Normal mode.
+    pub selected: usize,
+    /// Whether to pass `--all` to `pelagos ps`.
+    pub show_all: bool,
+    /// Currently active profile name.
+    pub profile: String,
+    /// All known profiles (populated at startup and on profile change).
+    pub profiles: Vec<String>,
+    /// Whether the VM daemon is running (last known state).
+    pub vm_running: bool,
+    /// When the last successful refresh completed.
+    pub last_refresh: Instant,
+    /// How often to auto-refresh.
+    pub refresh_interval: Duration,
+    /// Highlighted row index inside the profile picker overlay.
+    pub profile_picker_selected: usize,
+    /// Set to true to break the event loop.
+    pub should_quit: bool,
+}
+
+impl App {
+    pub fn new(profile: String, profiles: Vec<String>) -> Self {
+        // Pre-select the index of the current profile in the picker.
+        let picker_idx = profiles.iter().position(|p| p == &profile).unwrap_or(0);
+
+        Self {
+            mode: Mode::Normal,
+            containers: Vec::new(),
+            selected: 0,
+            show_all: false,
+            profile,
+            profiles,
+            vm_running: false,
+            last_refresh: Instant::now(),
+            refresh_interval: Duration::from_secs(2),
+            profile_picker_selected: picker_idx,
+            should_quit: false,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Data refresh
+    // -----------------------------------------------------------------------
+
+    /// Fetch containers and VM status from the runner.  Errors are swallowed
+    /// (logged at debug level) so a stopped VM never crashes the TUI.
+    pub fn refresh(&mut self, runner: &impl Runner) {
+        self.vm_running = runner.vm_status();
+
+        match runner.ps(self.show_all) {
+            Ok(containers) => {
+                self.containers = containers;
+                // Clamp selected index in case the list shrank.
+                if !self.containers.is_empty() && self.selected >= self.containers.len() {
+                    self.selected = self.containers.len() - 1;
+                }
+            }
+            Err(e) => {
+                log::debug!("refresh: ps failed: {}", e);
+                self.containers.clear();
+            }
+        }
+
+        self.last_refresh = Instant::now();
+    }
+
+    // -----------------------------------------------------------------------
+    // Key handling
+    // -----------------------------------------------------------------------
+
+    pub fn on_key(&mut self, key: KeyEvent, runner: &impl Runner) {
+        match self.mode {
+            Mode::Normal => self.on_key_normal(key, runner),
+            Mode::ProfilePicker => self.on_key_profile_picker(key, runner),
+        }
+    }
+
+    fn on_key_normal(&mut self, key: KeyEvent, runner: &impl Runner) {
+        match key.code {
+            // Quit
+            KeyCode::Char('q') => {
+                self.should_quit = true;
+            }
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.should_quit = true;
+            }
+
+            // Navigation
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !self.containers.is_empty() {
+                    self.selected = (self.selected + 1).min(self.containers.len() - 1);
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.selected = self.selected.saturating_sub(1);
+            }
+
+            // Toggle --all
+            KeyCode::Char('a') => {
+                self.show_all = !self.show_all;
+                self.refresh(runner);
+            }
+
+            // Open profile picker
+            KeyCode::Char('p') => {
+                // Sync picker selection to current profile.
+                self.profile_picker_selected = self
+                    .profiles
+                    .iter()
+                    .position(|p| p == &self.profile)
+                    .unwrap_or(0);
+                self.mode = Mode::ProfilePicker;
+            }
+
+            _ => {}
+        }
+    }
+
+    fn on_key_profile_picker(&mut self, key: KeyEvent, runner: &impl Runner) {
+        match key.code {
+            // Navigate
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !self.profiles.is_empty() {
+                    self.profile_picker_selected =
+                        (self.profile_picker_selected + 1).min(self.profiles.len() - 1);
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.profile_picker_selected = self.profile_picker_selected.saturating_sub(1);
+            }
+
+            // Confirm selection
+            KeyCode::Enter => {
+                if let Some(chosen) = self.profiles.get(self.profile_picker_selected).cloned() {
+                    log::debug!("profile switch: {} -> {}", self.profile, chosen);
+                    self.profile = chosen;
+                }
+                self.mode = Mode::Normal;
+                self.refresh(runner);
+            }
+
+            // Cancel
+            KeyCode::Esc | KeyCode::Char('p') => {
+                self.mode = Mode::Normal;
+            }
+
+            _ => {}
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    // Used in M2+ (log viewer, stop/rm actions).
+    #[allow(dead_code)]
+    pub fn selected_container(&self) -> Option<&Container> {
+        self.containers.get(self.selected)
+    }
+
+    /// How many seconds (rounded) since the last refresh.
+    pub fn refresh_age_secs(&self) -> u64 {
+        self.last_refresh.elapsed().as_secs()
+    }
+}

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -1,0 +1,135 @@
+//! pelagos-tui — terminal UI for the pelagos container runtime.
+//!
+//! Entry point: sets up the terminal, runs the event loop, restores on exit.
+
+mod app;
+mod runner;
+mod ui;
+
+use std::io;
+use std::time::Duration;
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{backend::CrosstermBackend, Terminal};
+
+use app::App;
+use runner::{MacOsRunner, Runner};
+
+fn main() -> anyhow::Result<()> {
+    // Initialise env_logger.  RUST_LOG controls verbosity; default is warn so
+    // the TUI screen is not polluted by log output.
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
+
+    // Determine the initial profile.  Accept `--profile <name>` or
+    // `PELAGOS_PROFILE` env var; fall back to "default".
+    let profile = resolve_profile();
+
+    // Build runner and collect initial profile list.
+    let runner = MacOsRunner::new(&profile);
+    let profiles = runner.profiles();
+
+    // Initialise app state.
+    let mut app = App::new(profile, profiles);
+
+    // Set up terminal.
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Run the event loop; capture the result so we can restore the terminal
+    // even if the loop returns an error.
+    let result = run_loop(&mut terminal, &mut app);
+
+    // Restore terminal unconditionally.
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Event loop
+// ---------------------------------------------------------------------------
+
+fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+) -> anyhow::Result<()> {
+    // Do an immediate refresh so the screen is populated on first draw.
+    let runner = MacOsRunner::new(&app.profile);
+    app.refresh(&runner);
+
+    let tick = Duration::from_millis(250); // poll interval
+
+    loop {
+        // Rebuild runner from current profile (may have changed via picker).
+        let runner = MacOsRunner::new(&app.profile);
+
+        // Auto-refresh when the interval has elapsed.
+        if app.last_refresh.elapsed() >= app.refresh_interval {
+            app.refresh(&runner);
+        }
+
+        // Draw.
+        terminal.draw(|f| ui::render(f, app))?;
+
+        // Poll for events with a short timeout so we keep refreshing.
+        if event::poll(tick)? {
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    // Ctrl-C is handled inside on_key, but also intercept here
+                    // as a safety net in case the app struct misses it.
+                    if key.code == KeyCode::Char('c')
+                        && key
+                            .modifiers
+                            .contains(crossterm::event::KeyModifiers::CONTROL)
+                    {
+                        app.should_quit = true;
+                    } else {
+                        app.on_key(key, &runner);
+                    }
+                }
+                Event::Resize(_, _) => {
+                    // crossterm handles resize automatically; we just need to
+                    // redraw on the next tick, which we always do.
+                }
+                _ => {}
+            }
+        }
+
+        if app.should_quit {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Profile resolution
+// ---------------------------------------------------------------------------
+
+fn resolve_profile() -> String {
+    // Simple arg parse: look for --profile <name> in argv.
+    let args: Vec<String> = std::env::args().collect();
+    let mut iter = args.iter().skip(1).peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--profile" || arg == "-p" {
+            if let Some(val) = iter.next() {
+                return val.clone();
+            }
+        } else if let Some(val) = arg.strip_prefix("--profile=") {
+            return val.to_string();
+        }
+    }
+
+    // Fall back to env var, then "default".
+    std::env::var("PELAGOS_PROFILE").unwrap_or_else(|_| "default".to_string())
+}

--- a/pelagos-tui/src/runner.rs
+++ b/pelagos-tui/src/runner.rs
@@ -1,0 +1,149 @@
+//! Runner trait and platform implementations.
+//!
+//! The Runner trait abstracts over the underlying pelagos binary invocation so
+//! that M5 can add a `LinuxRunner` without touching app or ui code.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+/// Mirrors the JSON shape emitted by `pelagos ps --format json`.
+///
+/// Field names match `ContainerState` in pelagos/src/cli/mod.rs exactly.
+/// Optional fields use `#[serde(default)]` for forward/backward compatibility.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Container {
+    pub name: String,
+    pub rootfs: String,
+    pub status: String, // "running" | "exited"
+    // pid, exit_code, and command are part of the wire format and may be used in M2+.
+    #[allow(dead_code)]
+    pub pid: i32,
+    pub started_at: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub exit_code: Option<i32>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub command: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Runner trait
+// ---------------------------------------------------------------------------
+
+pub trait Runner {
+    /// List containers.  `all` maps to `--all` flag.
+    fn ps(&self, all: bool) -> anyhow::Result<Vec<Container>>;
+    /// Return true when the VM daemon is alive.
+    fn vm_status(&self) -> bool;
+    /// Enumerate available profiles from the on-disk state directory.
+    fn profiles(&self) -> Vec<String>;
+}
+
+// ---------------------------------------------------------------------------
+// MacOsRunner
+// ---------------------------------------------------------------------------
+
+pub struct MacOsRunner {
+    pub profile: String,
+}
+
+impl MacOsRunner {
+    pub fn new(profile: impl Into<String>) -> Self {
+        Self {
+            profile: profile.into(),
+        }
+    }
+}
+
+impl Runner for MacOsRunner {
+    fn ps(&self, all: bool) -> anyhow::Result<Vec<Container>> {
+        let mut cmd = Command::new("pelagos");
+        cmd.arg("--profile").arg(&self.profile);
+        cmd.arg("ps").arg("--json");
+        if all {
+            cmd.arg("--all");
+        }
+
+        let out = cmd.output()?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            log::debug!("pelagos ps failed: {}", stderr.trim());
+            // VM likely stopped — return empty list rather than error.
+            return Ok(Vec::new());
+        }
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let trimmed = stdout.trim();
+
+        if trimmed.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // pelagos ps --format json outputs a JSON array.
+        match serde_json::from_str::<Vec<Container>>(trimmed) {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                log::debug!(
+                    "pelagos ps JSON parse error: {} — output was: {}",
+                    e,
+                    trimmed
+                );
+                Ok(Vec::new())
+            }
+        }
+    }
+
+    fn vm_status(&self) -> bool {
+        // `pelagos vm status` exits 0 when running, 1 when stopped.
+        let ok = Command::new("pelagos")
+            .arg("--profile")
+            .arg(&self.profile)
+            .arg("vm")
+            .arg("status")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        log::trace!("vm_status profile={} running={}", self.profile, ok);
+        ok
+    }
+
+    fn profiles(&self) -> Vec<String> {
+        let mut result = vec!["default".to_string()];
+
+        // Replicate pelagos_base() / profile_dir() from state.rs using std only.
+        let base = if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+            PathBuf::from(xdg).join("pelagos")
+        } else if let Ok(home) = std::env::var("HOME") {
+            PathBuf::from(home).join(".local/share/pelagos")
+        } else {
+            log::warn!("profiles: neither XDG_DATA_HOME nor HOME is set");
+            return result;
+        };
+
+        let profiles_dir = base.join("profiles");
+        let Ok(entries) = std::fs::read_dir(&profiles_dir) else {
+            // profiles/ dir simply doesn't exist yet — only "default" is available.
+            return result;
+        };
+
+        for entry in entries.flatten() {
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                if let Some(name) = entry.file_name().to_str() {
+                    let name = name.to_string();
+                    if name != "default" {
+                        result.push(name);
+                    }
+                }
+            }
+        }
+
+        result.sort();
+        result
+    }
+}

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -1,0 +1,392 @@
+//! ratatui rendering: table, hint bar, modeline, profile picker overlay.
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState},
+    Frame,
+};
+
+use crate::app::{App, Mode};
+
+// ---------------------------------------------------------------------------
+// Top-level render entry point
+// ---------------------------------------------------------------------------
+
+pub fn render(f: &mut Frame, app: &App) {
+    let area = f.area();
+
+    // Vertical split: [table area] [hint bar] [modeline]
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(3),    // table (all remaining space)
+            Constraint::Length(1), // hint bar
+            Constraint::Length(1), // modeline
+        ])
+        .split(area);
+
+    render_table(f, app, chunks[0]);
+    render_hint_bar(f, chunks[1]);
+    render_modeline(f, app, chunks[2]);
+
+    if app.mode == Mode::ProfilePicker {
+        render_profile_picker(f, app, area);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Container table
+// ---------------------------------------------------------------------------
+
+fn render_table(f: &mut Frame, app: &App, area: Rect) {
+    let header = Row::new(vec![
+        Cell::from("NAME").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("STATUS").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("IMAGE").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("UPTIME").style(Style::default().add_modifier(Modifier::BOLD)),
+    ])
+    .height(1);
+
+    let rows: Vec<Row> = app
+        .containers
+        .iter()
+        .map(|c| {
+            let status_style = match c.status.as_str() {
+                "running" => Style::default().fg(Color::Green),
+                _ => Style::default().fg(Color::Red).add_modifier(Modifier::DIM),
+            };
+
+            let uptime = format_uptime(&c.started_at);
+
+            Row::new(vec![
+                Cell::from(c.name.as_str()),
+                Cell::from(c.status.as_str()).style(status_style),
+                Cell::from(c.rootfs.as_str()),
+                Cell::from(uptime),
+            ])
+            .height(1)
+        })
+        .collect();
+
+    // Build a TableState so ratatui knows which row to highlight.
+    let mut table_state = TableState::default();
+    if !app.containers.is_empty() {
+        table_state.select(Some(app.selected));
+    }
+
+    let title = if app.show_all {
+        " pelagos — all containers "
+    } else {
+        " pelagos "
+    };
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(25), // NAME
+            Constraint::Percentage(12), // STATUS
+            Constraint::Percentage(43), // IMAGE
+            Constraint::Percentage(20), // UPTIME
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::ALL).title(title))
+    .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+    .highlight_symbol("▶ ");
+
+    f.render_stateful_widget(table, area, &mut table_state);
+
+    // Empty state message when no containers are present.
+    if app.containers.is_empty() {
+        let msg = if app.vm_running {
+            if app.show_all {
+                "No containers found. Use 'pelagos run' to start one."
+            } else {
+                "No containers running. Press 'a' to show all, or use 'pelagos run'."
+            }
+        } else {
+            "VM is stopped. Use 'pelagos vm start' to start it."
+        };
+
+        // Centre the message inside the table block (subtract borders).
+        let inner = Rect {
+            x: area.x + 1,
+            y: area.y + area.height / 2,
+            width: area.width.saturating_sub(2),
+            height: 1,
+        };
+        let p = Paragraph::new(msg).style(Style::default().fg(Color::DarkGray));
+        f.render_widget(p, inner);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hint bar
+// ---------------------------------------------------------------------------
+
+fn render_hint_bar(f: &mut Frame, area: Rect) {
+    let hints = Paragraph::new("  [q]quit  [a]all  [j/k]nav  [p]profile  [?]help (M2)")
+        .style(Style::default().fg(Color::DarkGray));
+    f.render_widget(hints, area);
+}
+
+// ---------------------------------------------------------------------------
+// Modeline
+// ---------------------------------------------------------------------------
+
+fn render_modeline(f: &mut Frame, app: &App, area: Rect) {
+    let vm_text = if app.vm_running { "running" } else { "stopped" };
+    let vm_color = if app.vm_running {
+        Color::Cyan
+    } else {
+        Color::Red
+    };
+
+    let age = app.refresh_age_secs();
+    let age_str = if age == 0 {
+        "just now".to_string()
+    } else if age == 1 {
+        "1s ago".to_string()
+    } else {
+        format!("{}s ago", age)
+    };
+
+    let total = app.containers.len();
+    let running = app
+        .containers
+        .iter()
+        .filter(|c| c.status == "running")
+        .count();
+    let container_str = format!("{}/{} running", running, total);
+    let container_color = if total == 0 || running == 0 {
+        Color::DarkGray
+    } else if running == total {
+        Color::White
+    } else {
+        Color::Yellow
+    };
+
+    let spans = vec![
+        Span::styled(
+            format!("  {} ", app.profile),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" │ ", Style::default().fg(Color::White)),
+        Span::styled("vm ", Style::default().fg(Color::Gray)),
+        Span::styled(vm_text, Style::default().fg(vm_color)),
+        Span::styled(" │ ", Style::default().fg(Color::White)),
+        Span::styled(container_str, Style::default().fg(container_color)),
+        Span::styled(" │ ", Style::default().fg(Color::White)),
+        Span::styled(
+            format!("↻ {}  ", age_str),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ];
+
+    let modeline = Paragraph::new(Line::from(spans))
+        .style(Style::default().bg(Color::Black).fg(Color::White));
+    f.render_widget(modeline, area);
+}
+
+// ---------------------------------------------------------------------------
+// Profile picker overlay
+// ---------------------------------------------------------------------------
+
+fn render_profile_picker(f: &mut Frame, app: &App, area: Rect) {
+    // Determine popup dimensions.
+    let max_name_len = app.profiles.iter().map(|p| p.len()).max().unwrap_or(10);
+    let popup_width = (max_name_len as u16 + 6).max(24).min(area.width - 4);
+    let popup_height = (app.profiles.len() as u16 + 4).min(area.height - 4);
+
+    // Centre the popup.
+    let popup_x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let popup_y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
+
+    // Erase the area under the popup before drawing.
+    f.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Switch profile ");
+    let inner = block.inner(popup_area);
+    f.render_widget(block, popup_area);
+
+    // Render profile list rows.
+    let rows: Vec<Row> = app
+        .profiles
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let style = if i == app.profile_picker_selected {
+                Style::default().add_modifier(Modifier::REVERSED)
+            } else if name == &app.profile {
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            Row::new(vec![Cell::from(name.as_str())]).style(style)
+        })
+        .collect();
+
+    let mut picker_state = TableState::default();
+    picker_state.select(Some(app.profile_picker_selected));
+
+    let picker_table = Table::new(rows, [Constraint::Percentage(100)])
+        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("▶ ");
+
+    f.render_stateful_widget(picker_table, inner, &mut picker_state);
+}
+
+// ---------------------------------------------------------------------------
+// Uptime formatting
+// ---------------------------------------------------------------------------
+
+/// Format an ISO 8601 timestamp as a human-readable uptime string.
+///
+/// Parses the subset `YYYY-MM-DDTHH:MM:SSZ` that `pelagos` always emits.
+/// Falls back to the raw string on any parse error.
+fn format_uptime(started_at: &str) -> String {
+    if let Some(secs) = parse_iso8601_secs(started_at) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let elapsed = now.saturating_sub(secs);
+        format_duration(elapsed)
+    } else {
+        started_at.to_string()
+    }
+}
+
+/// Parse `YYYY-MM-DDTHH:MM:SSZ` into Unix seconds.  Returns None on any error.
+fn parse_iso8601_secs(s: &str) -> Option<u64> {
+    // Expected: 20 chars minimum: "YYYY-MM-DDTHH:MM:SSZ"
+    let s = s.trim_end_matches('Z');
+    let (date_part, time_part) = s.split_once('T')?;
+    let mut d = date_part.split('-');
+    let year: u64 = d.next()?.parse().ok()?;
+    let month: u64 = d.next()?.parse().ok()?;
+    let day: u64 = d.next()?.parse().ok()?;
+
+    let mut t = time_part.split(':');
+    let hour: u64 = t.next()?.parse().ok()?;
+    let min: u64 = t.next()?.parse().ok()?;
+    let sec: u64 = t.next()?.parse().ok()?;
+
+    // Days from epoch to start of year (Gregorian calendar, no chrono needed).
+    let days = days_from_epoch(year, month, day)?;
+    let secs = days * 86400 + hour * 3600 + min * 60 + sec;
+    Some(secs)
+}
+
+/// Convert a Gregorian date to days since 1970-01-01.
+fn days_from_epoch(year: u64, month: u64, day: u64) -> Option<u64> {
+    if year < 1970 || !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    // Days in each month (non-leap year).
+    const DAYS: [u64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+    let mut days: u64 = (year - 1970) * 365;
+    // Leap years between 1970 and year-1.
+    days += leap_years_between(1970, year);
+    for m in 1..month {
+        days += DAYS[(m - 1) as usize];
+        // Add a day for February if current year is a leap year.
+        if m == 2 && is_leap(year) {
+            days += 1;
+        }
+    }
+    days += day - 1;
+    Some(days)
+}
+
+fn is_leap(y: u64) -> bool {
+    (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
+}
+
+/// Count leap years in [from, to).
+fn leap_years_between(from: u64, to: u64) -> u64 {
+    if to <= from {
+        return 0;
+    }
+    let count = |y: u64| -> u64 { y / 4 - y / 100 + y / 400 };
+    count(to - 1) - count(from - 1)
+}
+
+fn format_duration(secs: u64) -> String {
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m {:02}s", secs / 60, secs % 60)
+    } else if secs < 86400 {
+        let h = secs / 3600;
+        let m = (secs % 3600) / 60;
+        format!("{}h {:02}m", h, m)
+    } else {
+        let d = secs / 86400;
+        let h = (secs % 86400) / 3600;
+        format!("{}d {:02}h", d, h)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_duration_seconds() {
+        assert_eq!(format_duration(0), "0s");
+        assert_eq!(format_duration(59), "59s");
+    }
+
+    #[test]
+    fn format_duration_minutes() {
+        assert_eq!(format_duration(90), "1m 30s");
+        assert_eq!(format_duration(3599), "59m 59s");
+    }
+
+    #[test]
+    fn format_duration_hours() {
+        assert_eq!(format_duration(3600), "1h 00m");
+        assert_eq!(format_duration(3661), "1h 01m");
+    }
+
+    #[test]
+    fn format_duration_days() {
+        assert_eq!(format_duration(86400), "1d 00h");
+        assert_eq!(format_duration(90061), "1d 01h");
+    }
+
+    #[test]
+    fn parse_iso8601_known_epoch() {
+        // 1970-01-01T00:00:00Z = 0
+        assert_eq!(parse_iso8601_secs("1970-01-01T00:00:00Z"), Some(0));
+    }
+
+    #[test]
+    fn parse_iso8601_known_date() {
+        // 2026-01-01T00:00:00Z — pre-computed: 20454 days from epoch.
+        let secs = parse_iso8601_secs("2026-01-01T00:00:00Z").expect("parse");
+        let days = secs / 86400;
+        assert_eq!(days, 20454);
+    }
+
+    #[test]
+    fn parse_iso8601_bad_input() {
+        assert!(parse_iso8601_secs("not-a-date").is_none());
+        assert!(parse_iso8601_secs("").is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `pelagos-tui` crate: a ratatui-based terminal UI for pelagos
- Live-refreshing container table (NAME / STATUS / IMAGE / UPTIME columns, 2s interval)
- Emacs-style modeline: active profile | vm status | container count | refresh age
- Profile picker overlay (`p` key) with j/k navigation
- `a` key toggles `--all` (show stopped containers)
- `Runner` trait abstracts subprocess invocation — Linux support (M5) is just adding `LinuxRunner`
- 7 unit tests (duration formatting + ISO 8601 parsing, no chrono dependency)

## Related

Part of Epic #149 (pelagos TUI)

## Test plan

- [ ] `cargo test -p pelagos-tui` — all 7 tests pass
- [ ] `cargo clippy -p pelagos-tui -- -D warnings` — clean
- [ ] Run `pelagos-tui` with VM started: container list appears, refreshes every 2s
- [ ] Press `a`: stopped containers appear
- [ ] Press `p`: profile picker opens; j/k navigate; Enter switches profile; Esc cancels
- [ ] Press `q` or Ctrl-C: exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)