### PR TITLE
feat: pelagos-tui M3 — command palette (r to run)

### DIFF
--- a/pelagos-tui/src/app.rs
+++ b/pelagos-tui/src/app.rs
@@ -13,6 +13,8 @@ use crate::runner::{Container, Runner};
 pub enum Mode {
     Normal,
     ProfilePicker,
+    /// Command palette: modeline becomes a `run> <input>` text field.
+    CommandPalette,
 }
 
 // ---------------------------------------------------------------------------
@@ -40,6 +42,10 @@ pub struct App {
     pub profile_picker_selected: usize,
     /// Set to true to break the event loop.
     pub should_quit: bool,
+    /// Text being typed in the command palette.
+    pub palette_input: String,
+    /// Set by the palette on Enter; main.rs drains this to execute the run.
+    pub pending_run: Option<String>,
 }
 
 impl App {
@@ -59,6 +65,8 @@ impl App {
             refresh_interval: Duration::from_secs(2),
             profile_picker_selected: picker_idx,
             should_quit: false,
+            palette_input: String::new(),
+            pending_run: None,
         }
     }
 
@@ -96,6 +104,7 @@ impl App {
         match self.mode {
             Mode::Normal => self.on_key_normal(key, runner),
             Mode::ProfilePicker => self.on_key_profile_picker(key, runner),
+            Mode::CommandPalette => self.on_key_palette(key),
         }
     }
 
@@ -136,6 +145,12 @@ impl App {
                 self.mode = Mode::ProfilePicker;
             }
 
+            // Open command palette
+            KeyCode::Char('r') => {
+                self.palette_input.clear();
+                self.mode = Mode::CommandPalette;
+            }
+
             _ => {}
         }
     }
@@ -166,6 +181,36 @@ impl App {
             // Cancel
             KeyCode::Esc | KeyCode::Char('p') => {
                 self.mode = Mode::Normal;
+            }
+
+            _ => {}
+        }
+    }
+
+    fn on_key_palette(&mut self, key: KeyEvent) {
+        match key.code {
+            // Cancel
+            KeyCode::Esc => {
+                self.palette_input.clear();
+                self.mode = Mode::Normal;
+            }
+
+            // Execute: hand off to main.rs via pending_run
+            KeyCode::Enter => {
+                let input = self.palette_input.trim().to_string();
+                if !input.is_empty() {
+                    self.pending_run = Some(input);
+                }
+                self.palette_input.clear();
+                self.mode = Mode::Normal;
+            }
+
+            // Edit input
+            KeyCode::Backspace => {
+                self.palette_input.pop();
+            }
+            KeyCode::Char(c) => {
+                self.palette_input.push(c);
             }
 
             _ => {}

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -104,10 +104,62 @@ fn run_loop(
             }
         }
 
+        // Command palette: execute pending run command.
+        if let Some(input) = app.pending_run.take() {
+            execute_run(terminal, app, &runner, &input)?;
+        }
+
         if app.should_quit {
             break;
         }
     }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Run command execution (suspends TUI, inherits stdio, then resumes)
+// ---------------------------------------------------------------------------
+
+/// Suspend the TUI, run `pelagos --profile <p> run <args>` with inherited
+/// stdio so the user sees any output, then re-enter the TUI and refresh.
+fn execute_run(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+    runner: &impl Runner,
+    input: &str,
+) -> anyhow::Result<()> {
+    // Suspend TUI — restore a normal terminal for the subprocess.
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    // Parse the user's input into image + extra args.
+    // Input is everything after "run> ", e.g. "nginx:alpine --name web".
+    let args: Vec<&str> = input.split_whitespace().collect();
+
+    log::info!("palette run: profile={} args={:?}", app.profile, args);
+
+    let status = std::process::Command::new("pelagos")
+        .arg("--profile")
+        .arg(&app.profile)
+        .arg("run")
+        .args(&args)
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => eprintln!("\npelagos run exited with status {}", s),
+        Err(e) => eprintln!("\nFailed to run pelagos: {}", e),
+    }
+
+    // Re-enter TUI.
+    enable_raw_mode()?;
+    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+    terminal.clear()?;
+
+    // Refresh so the new container (if any) appears immediately.
+    app.refresh(runner);
 
     Ok(())
 }

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -10,6 +10,9 @@ use ratatui::{
 
 use crate::app::{App, Mode};
 
+// Cursor indicator appended to the palette input line.
+const CURSOR: &str = "▏";
+
 // ---------------------------------------------------------------------------
 // Top-level render entry point
 // ---------------------------------------------------------------------------
@@ -28,7 +31,7 @@ pub fn render(f: &mut Frame, app: &App) {
         .split(area);
 
     render_table(f, app, chunks[0]);
-    render_hint_bar(f, chunks[1]);
+    render_hint_bar(f, app, chunks[1]);
     render_modeline(f, app, chunks[2]);
 
     if app.mode == Mode::ProfilePicker {
@@ -126,9 +129,12 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
 // Hint bar
 // ---------------------------------------------------------------------------
 
-fn render_hint_bar(f: &mut Frame, area: Rect) {
-    let hints = Paragraph::new("  [q]quit  [a]all  [j/k]nav  [p]profile  [?]help (M2)")
-        .style(Style::default().fg(Color::DarkGray));
+fn render_hint_bar(f: &mut Frame, app: &App, area: Rect) {
+    let text = match app.mode {
+        Mode::CommandPalette => "  [Enter]run  [Esc]cancel",
+        _ => "  [q]quit  [a]all  [j/k]nav  [p]profile  [r]run  [?]help",
+    };
+    let hints = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));
     f.render_widget(hints, area);
 }
 
@@ -137,6 +143,19 @@ fn render_hint_bar(f: &mut Frame, area: Rect) {
 // ---------------------------------------------------------------------------
 
 fn render_modeline(f: &mut Frame, app: &App, area: Rect) {
+    // In command palette mode the modeline becomes an input field.
+    if app.mode == Mode::CommandPalette {
+        let spans = vec![
+            Span::styled("  run> ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(app.palette_input.as_str(), Style::default().fg(Color::White)),
+            Span::styled(CURSOR, Style::default().fg(Color::Yellow)),
+        ];
+        let modeline = Paragraph::new(Line::from(spans))
+            .style(Style::default().bg(Color::Black).fg(Color::White));
+        f.render_widget(modeline, area);
+        return;
+    }
+
     let vm_text = if app.vm_running { "running" } else { "stopped" };
     let vm_color = if app.vm_running {
         Color::Cyan


### PR DESCRIPTION
## Summary

- Press `r` in Normal mode to open the command palette
- Modeline becomes `run> <input>` (yellow prompt, cursor indicator)
- Hint bar switches context: `[Enter]run  [Esc]cancel`
- Enter: TUI suspends, runs `pelagos --profile <p> run <args>` with inherited stdio, then resumes and refreshes
- Esc: cancel, back to Normal
- `[r]run` added to normal mode hint bar

## Related

Part of Epic #149 (pelagos TUI) — M3

## Test plan

- [ ] `cargo build -p pelagos-tui` and `cargo clippy -p pelagos-tui -- -D warnings` clean
- [ ] Press `r`: modeline changes to `run> ▏`, hint bar shows Enter/Esc hints
- [ ] Type `nginx:alpine`: appears in modeline input field
- [ ] Press Backspace: last char removed
- [ ] Press Esc: returns to Normal mode, no run executed
- [ ] Press `r`, type an image, press Enter: TUI suspends, `pelagos run` executes, TUI resumes with new container visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)