### PR TITLE
fix: reject interactive flags in command palette

### DIFF
--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -136,6 +136,16 @@ fn execute_run(
     let args: Vec<&str> = input.split_whitespace().collect();
     log::info!("palette run: profile={} args={:?}", app.profile, args);
 
+    // Refuse interactive flags — .output() blocks the event loop and the TUI
+    // cannot provide a usable stdin.  Use the CLI directly for interactive runs.
+    let interactive = args
+        .iter()
+        .any(|a| *a == "-i" || *a == "--interactive" || *a == "-it" || *a == "-ti");
+    if interactive {
+        app.status_message = Some("interactive containers: use the CLI (pelagos run -i ...)".into());
+        return Ok(());
+    }
+
     let result = std::process::Command::new("pelagos")
         .arg("--profile")
         .arg(&app.profile)


### PR DESCRIPTION
## Summary

Attempting `pelagos run -i alpine:latest /bin/sh` via the palette would block
the event loop forever — `.output()` waits for exit and the TUI cannot provide
a usable stdin. Detect `-i`, `--interactive`, `-it`, `-ti` before spawning and
show a modeline message directing the user to the CLI instead.

## Test plan

- [ ] `r` → `-i alpine:latest` → Enter: modeline shows `! interactive containers: use the CLI (pelagos run -i ...)`
- [ ] `r` → `alpine:latest` → Enter: runs normally, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)