### PR TITLE
fix: add 5s timeout to runner subprocess calls

### DIFF
--- a/pelagos-tui/src/runner.rs
+++ b/pelagos-tui/src/runner.rs
@@ -4,7 +4,9 @@
 //! that M5 can add a `LinuxRunner` without touching app or ui code.
 
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Output};
+use std::sync::mpsc;
+use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // Data model
@@ -45,6 +47,40 @@ pub trait Runner {
 }
 
 // ---------------------------------------------------------------------------
+// Timeout helper
+// ---------------------------------------------------------------------------
+
+/// Run a `Command` and return its output, or `None` if it does not complete
+/// within `timeout`.
+///
+/// The subprocess is spawned on a background thread.  If the timeout fires the
+/// thread is abandoned — the subprocess continues running but the caller
+/// receives `None` and can proceed without blocking.  This keeps the TUI
+/// responsive when the guest daemon is occupied (e.g. serving an interactive
+/// container over vsock).
+fn output_timeout(mut cmd: Command, timeout: Duration) -> Option<Output> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(cmd.output());
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(out)) => Some(out),
+        Ok(Err(e)) => {
+            log::debug!("output_timeout: command error: {}", e);
+            None
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            log::debug!("output_timeout: timed out after {:?}", timeout);
+            None
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => None,
+    }
+}
+
+// How long to wait for a pelagos subprocess before giving up.
+const CMD_TIMEOUT: Duration = Duration::from_secs(5);
+
+// ---------------------------------------------------------------------------
 // MacOsRunner
 // ---------------------------------------------------------------------------
 
@@ -69,7 +105,10 @@ impl Runner for MacOsRunner {
             cmd.arg("--all");
         }
 
-        let out = cmd.output()?;
+        let Some(out) = output_timeout(cmd, CMD_TIMEOUT) else {
+            log::debug!("pelagos ps timed out — VM daemon busy");
+            return Ok(Vec::new());
+        };
 
         if !out.status.success() {
             let stderr = String::from_utf8_lossy(&out.stderr);
@@ -101,12 +140,13 @@ impl Runner for MacOsRunner {
 
     fn vm_status(&self) -> bool {
         // `pelagos vm status` exits 0 when running, 1 when stopped.
-        let ok = Command::new("pelagos")
-            .arg("--profile")
+        let mut cmd = Command::new("pelagos");
+        cmd.arg("--profile")
             .arg(&self.profile)
             .arg("vm")
-            .arg("status")
-            .output()
+            .arg("status");
+
+        let ok = output_timeout(cmd, CMD_TIMEOUT)
             .map(|o| o.status.success())
             .unwrap_or(false);
         log::trace!("vm_status profile={} running={}", self.profile, ok);


### PR DESCRIPTION
## Problem

The guest daemon is single-threaded. When an interactive container holds the vsock connection open, `pelagos ps` and `pelagos vm status` block indefinitely — hanging the TUI and any new TUI instance.

## Fix

`output_timeout()` spawns each subprocess on a background thread and returns `None` after 5 seconds. The TUI shows empty/stale state (list clears, vm shows stopped) rather than freezing. The abandoned thread is cleaned up when the daemon eventually becomes free.

## Test plan

- [ ] Start an interactive container via the palette (`-i alpine:latest sh`)
- [ ] TUI stays responsive — list refreshes every 2s, may show empty while daemon is busy
- [ ] Starting a second TUI instance no longer hangs
- [ ] When the interactive session exits, the next refresh restores normal state

🤖 Generated with [Claude Code](https://claude.com/claude-code)