### PR TITLE
feat: port forwarding end-to-end (-p HOST:CONTAINER)

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -112,6 +112,9 @@ pub enum GuestCommand {
         /// Labels KEY=VALUE forwarded to `pelagos run --label`.
         #[serde(default)]
         labels: Vec<String>,
+        /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
+        #[serde(default)]
+        publish: Vec<String>,
     },
     Exec {
         image: String,
@@ -254,6 +257,9 @@ pub struct ContainerSnapshot {
     pub started_at: String,
     #[serde(default)]
     pub exit_code: Option<i32>,
+    /// Port mappings from `pelagos run -p HOST:CONTAINER` (e.g. `["8080:80"]`).
+    #[serde(default)]
+    pub ports: Vec<String>,
 }
 
 /// Events streamed over a Subscribe connection (NDJSON, one per line).
@@ -466,6 +472,7 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 name,
                 detach,
                 labels,
+                publish,
             } => {
                 run_container(
                     &mut writer,
@@ -476,6 +483,7 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                     name.as_deref(),
                     detach,
                     &labels,
+                    &publish,
                 )?;
             }
             GuestCommand::Exec {
@@ -860,6 +868,7 @@ fn run_container(
     name: Option<&str>,
     detach: bool,
     labels: &[String],
+    publish: &[String],
 ) -> std::io::Result<()> {
     let pelagos = pelagos_bin();
 
@@ -905,6 +914,9 @@ fn run_container(
     }
     for label in labels {
         cmd.arg("--label").arg(label);
+    }
+    for port_spec in publish {
+        cmd.arg("--publish").arg(port_spec);
     }
     cmd.arg(image);
     if !args.is_empty() {
@@ -2136,6 +2148,17 @@ fn read_container_states() -> Vec<ContainerSnapshot> {
             .get("exit_code")
             .and_then(|v| v.as_i64())
             .map(|c| c as i32);
+        // publish is nested under spawn_config in state.json.
+        let ports: Vec<String> = val
+            .get("spawn_config")
+            .and_then(|sc| sc.get("publish"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
         out.push(ContainerSnapshot {
             name,
             status,
@@ -2143,6 +2166,7 @@ fn read_container_states() -> Vec<ContainerSnapshot> {
             rootfs,
             started_at,
             exit_code,
+            ports,
         });
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));
@@ -2416,6 +2440,19 @@ mod tests {
                 assert!(mounts.is_empty());
                 assert!(name.is_none());
                 assert!(!detach);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_with_publish_deserializes() {
+        let json = r#"{"cmd":"run","image":"nginx","args":[],"publish":["8080:80","443:443"]}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::Run { image, publish, .. } => {
+                assert_eq!(image, "nginx");
+                assert_eq!(publish, vec!["8080:80", "443:443"]);
             }
             other => panic!("unexpected: {:?}", other),
         }

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -343,6 +343,9 @@ enum GuestCommand {
         env: std::collections::HashMap<String, String>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         labels: Vec<String>,
+        /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        publish: Vec<String>,
     },
     Exec {
         image: String,
@@ -748,6 +751,21 @@ fn main() {
                 log::error!("failed to start VM daemon: {}", e);
                 process::exit(1);
             }
+            // Start host-side port proxies for foreground runs so that
+            // localhost:HOST_PORT is forwarded to VM:HOST_PORT via the relay.
+            // These threads are tied to the CLI process lifetime — they stop
+            // when the container exits and the CLI process exits.
+            // For detached runs the daemon-level port_forwards handle host-side
+            // forwarding (configured at daemon startup via -p global flag).
+            if !cli.ports.is_empty() && !detach {
+                for spec in &cli.ports {
+                    if let Some(pf) = daemon::parse_port_spec(spec) {
+                        let hp = pf.host_port;
+                        let cp = pf.host_port; // relay to VM host_port (pelagos proxy listens there)
+                        std::thread::spawn(move || daemon::port_forward_loop(hp, cp));
+                    }
+                }
+            }
             let stream = connect_or_exit(&profile);
             process::exit(passthrough_command(
                 stream,
@@ -759,6 +777,7 @@ fn main() {
                     detach,
                     env: env_map,
                     labels,
+                    publish: cli.ports.clone(),
                 },
             ));
         }
@@ -2627,6 +2646,7 @@ mod tests {
             detach: false,
             env: std::collections::HashMap::new(),
             labels: vec![],
+            publish: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -2648,6 +2668,7 @@ mod tests {
             detach: true,
             env: std::collections::HashMap::new(),
             labels: vec![],
+            publish: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -2670,6 +2691,7 @@ mod tests {
             detach: false,
             env: std::collections::HashMap::new(),
             labels: vec![],
+            publish: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -17,8 +17,11 @@ mod app;
 mod runner;
 mod ui;
 
+use std::collections::HashMap;
 use std::io;
-use std::sync::mpsc;
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
 use std::time::Duration;
 
 use crossterm::{
@@ -240,12 +243,16 @@ fn run_loop(
     sub_rx: mpsc::Receiver<SubscriptionMsg>,
 ) -> anyhow::Result<()> {
     let tick = Duration::from_millis(250);
+    let mut proxy_mgr = PortProxyManager::new();
 
     loop {
         // Drain all pending subscription events (non-blocking).
         loop {
             match sub_rx.try_recv() {
-                Ok(msg) => app.apply_subscription(msg),
+                Ok(msg) => {
+                    proxy_mgr.handle(&msg);
+                    app.apply_subscription(msg);
+                }
                 Err(mpsc::TryRecvError::Empty) => break,
                 Err(mpsc::TryRecvError::Disconnected) => break,
             }
@@ -312,6 +319,7 @@ fn run_loop(
         }
 
         if app.should_quit {
+            proxy_mgr.stop_all();
             break;
         }
     }
@@ -536,6 +544,216 @@ fn send_status(tx: &Option<mpsc::SyncSender<String>>, msg: String) {
     if let Some(tx) = tx {
         let _ = tx.try_send(msg);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Port proxy manager (TUI lifecycle)
+// ---------------------------------------------------------------------------
+
+/// Manages host-side TCP proxies for container port mappings.
+///
+/// Proxies are started when a container with ports appears in the subscription
+/// stream and stopped when that container exits or is removed.  Each proxy
+/// uses a non-blocking accept loop so it can be signalled to stop without
+/// blocking the caller.
+struct PortProxyManager {
+    /// host_port → stop token
+    proxies: HashMap<u16, Arc<AtomicBool>>,
+}
+
+/// Relay proxy port (must match `pelagos_vz::nat_relay::RELAY_PROXY_PORT`).
+const RELAY_PROXY_PORT: u16 = 17900;
+
+impl PortProxyManager {
+    fn new() -> Self {
+        Self {
+            proxies: HashMap::new(),
+        }
+    }
+
+    /// Apply a subscription event: start/stop proxies to match container state.
+    fn handle(&mut self, msg: &SubscriptionMsg) {
+        match msg {
+            SubscriptionMsg::Snapshot {
+                containers,
+                vm_running,
+                ..
+            } => {
+                if !vm_running {
+                    self.stop_all();
+                    return;
+                }
+                // Collect ports of currently-running containers.
+                let mut wanted: HashMap<u16, u16> = HashMap::new();
+                for c in containers {
+                    if c.status == "running" {
+                        for spec in &c.ports {
+                            if let Some(pf) = parse_port_spec(spec) {
+                                wanted.insert(pf.0, pf.1);
+
+                            }
+                        }
+                    }
+                }
+                // Stop proxies no longer wanted.
+                let stale: Vec<u16> = self
+                    .proxies
+                    .keys()
+                    .filter(|p| !wanted.contains_key(p))
+                    .copied()
+                    .collect();
+                for port in stale {
+                    self.stop_proxy(port);
+                }
+                // Start new proxies.
+                for (host_port, container_port) in wanted {
+                    self.start(host_port, container_port);
+                }
+            }
+            SubscriptionMsg::ContainerStarted { container } => {
+                for spec in &container.ports {
+                    if let Some(pf) = parse_port_spec(spec) {
+                        self.start(pf.0, pf.1);
+                    }
+                }
+            }
+            SubscriptionMsg::ContainerExited { .. } => {
+                // The next Snapshot will clean up stale proxies.
+            }
+            SubscriptionMsg::Disconnected => {
+                self.stop_all();
+            }
+            _ => {}
+        }
+    }
+
+    fn start(&mut self, host_port: u16, container_port: u16) {
+        if self.proxies.contains_key(&host_port) {
+            return;
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+        self.proxies.insert(host_port, stop.clone());
+        std::thread::Builder::new()
+            .name(format!("port-proxy-{}", host_port))
+            .spawn(move || {
+                port_forward_loop_stoppable(host_port, container_port, stop);
+            })
+            .expect("spawn port proxy");
+        log::info!("port proxy started: {}→{}", host_port, container_port);
+    }
+
+    fn stop_proxy(&mut self, host_port: u16) {
+        if let Some(stop) = self.proxies.remove(&host_port) {
+            stop.store(true, Ordering::Relaxed);
+            log::info!("port proxy stopped: {}", host_port);
+        }
+    }
+
+    fn stop_all(&mut self) {
+        for (_, stop) in self.proxies.drain() {
+            stop.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Parse `"host:container"` or `"port"` into `(host_port, container_port)`.
+fn parse_port_spec(spec: &str) -> Option<(u16, u16)> {
+    let parts: Vec<&str> = spec.splitn(2, ':').collect();
+    if parts.len() == 2 {
+        let h = parts[0].parse::<u16>().ok()?;
+        let c = parts[1].parse::<u16>().ok()?;
+        Some((h, c))
+    } else {
+        let p = spec.parse::<u16>().ok()?;
+        Some((p, p))
+    }
+}
+
+/// Accept TCP connections on `host_port`, relay each to `container_port` via
+/// the smoltcp NAT relay at `127.0.0.1:RELAY_PROXY_PORT`.  Returns when
+/// `stop` is set to true.
+fn port_forward_loop_stoppable(host_port: u16, container_port: u16, stop: Arc<AtomicBool>) {
+    use std::io::Write;
+
+    let listener = match TcpListener::bind(("0.0.0.0", host_port)) {
+        Ok(l) => l,
+        Err(e) => {
+            log::error!("port forward bind 0.0.0.0:{}: {}", host_port, e);
+            return;
+        }
+    };
+    listener
+        .set_nonblocking(true)
+        .expect("set_nonblocking on port forward listener");
+
+    log::info!(
+        "port forward active: 0.0.0.0:{} → VM:{} (relay :{})",
+        host_port,
+        container_port,
+        RELAY_PROXY_PORT
+    );
+
+    while !stop.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((client, _)) => {
+                // Client connections must be blocking for io::copy.
+                client.set_nonblocking(false).ok();
+                let stop2 = stop.clone();
+                std::thread::Builder::new()
+                    .name(format!("port-fwd-conn-{}", host_port))
+                    .spawn(move || {
+                        let relay_addr =
+                            std::net::SocketAddr::from(([127, 0, 0, 1], RELAY_PROXY_PORT));
+                        let mut server = match TcpStream::connect_timeout(
+                            &relay_addr,
+                            Duration::from_secs(5),
+                        ) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                log::warn!(
+                                    "port forward connect relay:{}: {}",
+                                    RELAY_PROXY_PORT,
+                                    e
+                                );
+                                return;
+                            }
+                        };
+                        if server.write_all(&container_port.to_be_bytes()).is_err() {
+                            return;
+                        }
+                        drop(stop2);
+                        tcp_proxy_tui(client, server);
+                    })
+                    .ok();
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                log::warn!("port forward accept: {}", e);
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+    log::info!("port forward loop exited: 0.0.0.0:{}", host_port);
+}
+
+fn tcp_proxy_tui(client: TcpStream, server: TcpStream) {
+    let mut client_read = client;
+    let mut server_read = server;
+    let mut client_write = client_read.try_clone().expect("tcp clone");
+    let mut server_write = server_read.try_clone().expect("tcp clone");
+
+    let t1 = std::thread::spawn(move || {
+        let _ = std::io::copy(&mut client_read, &mut server_write);
+        let _ = server_write.shutdown(std::net::Shutdown::Write);
+    });
+    let t2 = std::thread::spawn(move || {
+        let _ = std::io::copy(&mut server_read, &mut client_write);
+        let _ = client_write.shutdown(std::net::Shutdown::Write);
+    });
+    let _ = t1.join();
+    let _ = t2.join();
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-tui/src/runner.rs
+++ b/pelagos-tui/src/runner.rs
@@ -29,6 +29,9 @@ pub struct Container {
     #[serde(default)]
     #[allow(dead_code)]
     pub command: Vec<String>,
+    /// Port mappings from `pelagos run -p HOST:CONTAINER` (e.g. `["8080:80"]`).
+    #[serde(default)]
+    pub ports: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -48,6 +48,7 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
         Cell::from("NAME").style(Style::default().add_modifier(Modifier::BOLD)),
         Cell::from("STATUS").style(Style::default().add_modifier(Modifier::BOLD)),
         Cell::from("IMAGE").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("PORTS").style(Style::default().add_modifier(Modifier::BOLD)),
         Cell::from("UPTIME").style(Style::default().add_modifier(Modifier::BOLD)),
     ])
     .height(1);
@@ -74,10 +75,19 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
                 Cell::from(c.name.as_str())
             };
 
+            // Format ports as "8080→80, 443→443".
+            let ports_str = c
+                .ports
+                .iter()
+                .map(|s| s.replacen(':', "→", 1))
+                .collect::<Vec<_>>()
+                .join(", ");
+
             Row::new(vec![
                 name_cell,
                 Cell::from(c.status.as_str()).style(status_style),
                 Cell::from(c.rootfs.as_str()),
+                Cell::from(ports_str).style(Style::default().fg(Color::Cyan)),
                 Cell::from(uptime),
             ])
             .height(1)
@@ -99,10 +109,11 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
     let table = Table::new(
         rows,
         [
-            Constraint::Percentage(25), // NAME
-            Constraint::Percentage(12), // STATUS
-            Constraint::Percentage(43), // IMAGE
-            Constraint::Percentage(20), // UPTIME
+            Constraint::Percentage(23), // NAME
+            Constraint::Percentage(10), // STATUS
+            Constraint::Percentage(37), // IMAGE
+            Constraint::Percentage(15), // PORTS
+            Constraint::Percentage(15), // UPTIME
         ],
     )
     .header(header)


### PR DESCRIPTION
## Summary

- **`pelagos-guest`**: Adds `publish: Vec<String>` to `GuestCommand::Run`; passes `--publish` args to `pelagos run` inside the container; exposes `ports` field in `ContainerSnapshot` (read from `state.json spawn_config.publish`); adds deserialization test
- **`pelagos-mac`**: Wires `cli.ports` through to the vsock `GuestCommand::Run` message; starts host-side proxy threads for foreground `-p` runs; fixes 3 test struct literals
- **`pelagos-tui`**: Adds `Container.ports` field; PORTS column in table; `PortProxyManager` that starts/stops non-blocking TCP proxies (via smoltcp NAT relay at `127.0.0.1:17900`) in response to subscription events

## How it works

```
curl localhost:8080
  → host: port_forward_loop (pelagos-mac daemon or TUI PortProxyManager)
  → relay: 127.0.0.1:17900 + 2-byte container port header (pelagos-vz nat_relay)
  → VM: 192.168.105.2:80 (container nginx)
```

The VM daemon must be started with `-p HOST:CONTAINER` (`pelagos vm start -p 8080:80`) so the host-side relay thread is active.

## Test plan

- [x] `cargo test -p pelagos-tui -p pelagos-mac` — 89 tests pass
- [x] `cargo clippy -p pelagos-mac -p pelagos-tui -- -D warnings` — clean
- [x] Cross-compiled new `pelagos-guest` (musl/aarch64) and installed in running VM
- [x] `pelagos vm start -p 8080:80 && pelagos run -d -p 8080:80 nginx:alpine` → `curl localhost:8080` → **HTTP 200**
- [x] `pelagos inspect nginx-ports-v2` → `publish: ["8080:80"]` in spawn_config (--publish passed through vsock to container)
- [x] `pelagos subscribe` snapshot → `ports: ["8080:80"]` on the container entry

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)