### PR TITLE
fix: enable ip_forward in VM init for port forwarding

### DIFF
--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -1,6 +1,6 @@
 # pelagos-mac — Ongoing Tasks
 
-*Last updated: 2026-03-22 — **v0.4.0 released** (SHA f6433d3); build VM full test suite verified*
+*Last updated: 2026-03-24 — port forwarding e2e verified; ip_forward fix shipped; pelagos bugs documented*
 
 ---
 
@@ -22,6 +22,7 @@ in ~16s; full console replay works.
 | `pelagos exec` (piped + PTY) | ✅ | PR #38 |
 | `pelagos ps / logs / stop / rm` | ✅ | PR #37 |
 | `pelagos run --detach --name` | ✅ | PR #37 |
+| `pelagos run -p HOST:CONTAINER` (port forwarding) | ✅ | PR #146 + this session |
 | `pelagos vm shell` | ✅ | PR #45 |
 | Busybox applet symlinks in VM | ✅ | PR #47 |
 | Persistent OCI image cache (`/dev/vda` ext4) | ✅ | PR #50/#107 |
@@ -96,8 +97,17 @@ to any client connecting at any time. `pelagos vm console [--profile build]` wor
 
 - **Epic #135 — pelagos-ui** — Tauri + Svelte macOS management GUI (new). M1: container list. Blocked on #98 (JSON ps output).
 - **Release CI workflow (#118)** — self-hosted runner + `release.yml` to build, sign, and publish binaries on tag push.
-- **Port forwarding** — container port → VM port → macOS `localhost`. Currently
-  workaround: direct VM IP is routable from macOS host via smoltcp NAT.
+- **Port forwarding** ✅ — `pelagos run -p 8080:80 nginx:alpine` + `curl http://localhost:8080/`
+  works end-to-end via smoltcp relay + DNAT. Two **pelagos bugs** remain that prevent it
+  from working cleanly out of the box without manual intervention:
+  - **pelagos#bug: ip_forward not set** — `enable_port_forwards` installs DNAT rules but
+    does not enable `ip_forward`. DNAT'd packets can't traverse eth0→pelagos0 bridge
+    without it. Workaround in pelagos-mac: init script sets `ip_forward=1` unconditionally.
+  - **pelagos#bug: stale DNAT rules accumulate** — `enable_port_forwards` evicts stale
+    entries by checking if `/run/netns/{name}` exists, but pelagos doesn't remove the
+    netns file when a container dies uncleanly. Result: stale IPs from prior runs stay in
+    PREROUTING and match before the current container's rule. Fix needed in pelagos:
+    eviction should check if the container watcher process is alive, not just the netns file.
 - **`docker volume inspect`** — `create/ls/rm` works; `inspect` not implemented.
 - **Dynamic virtiofs shares** (#74) — current per-path shares require knowing all
   paths at VM start time.

--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -112,6 +112,9 @@ pub enum GuestCommand {
         /// Labels KEY=VALUE forwarded to `pelagos run --label`.
         #[serde(default)]
         labels: Vec<String>,
+        /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
+        #[serde(default)]
+        publish: Vec<String>,
     },
     Exec {
         image: String,
@@ -254,6 +257,9 @@ pub struct ContainerSnapshot {
     pub started_at: String,
     #[serde(default)]
     pub exit_code: Option<i32>,
+    /// Port mappings from `pelagos run -p HOST:CONTAINER` (e.g. `["8080:80"]`).
+    #[serde(default)]
+    pub ports: Vec<String>,
 }
 
 /// Events streamed over a Subscribe connection (NDJSON, one per line).
@@ -466,6 +472,7 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 name,
                 detach,
                 labels,
+                publish,
             } => {
                 run_container(
                     &mut writer,
@@ -476,6 +483,7 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                     name.as_deref(),
                     detach,
                     &labels,
+                    &publish,
                 )?;
             }
             GuestCommand::Exec {
@@ -860,6 +868,7 @@ fn run_container(
     name: Option<&str>,
     detach: bool,
     labels: &[String],
+    publish: &[String],
 ) -> std::io::Result<()> {
     let pelagos = pelagos_bin();
 
@@ -905,6 +914,9 @@ fn run_container(
     }
     for label in labels {
         cmd.arg("--label").arg(label);
+    }
+    for port_spec in publish {
+        cmd.arg("--publish").arg(port_spec);
     }
     cmd.arg(image);
     if !args.is_empty() {
@@ -2136,6 +2148,17 @@ fn read_container_states() -> Vec<ContainerSnapshot> {
             .get("exit_code")
             .and_then(|v| v.as_i64())
             .map(|c| c as i32);
+        // publish is nested under spawn_config in state.json.
+        let ports: Vec<String> = val
+            .get("spawn_config")
+            .and_then(|sc| sc.get("publish"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
         out.push(ContainerSnapshot {
             name,
             status,
@@ -2143,6 +2166,7 @@ fn read_container_states() -> Vec<ContainerSnapshot> {
             rootfs,
             started_at,
             exit_code,
+            ports,
         });
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));
@@ -2416,6 +2440,19 @@ mod tests {
                 assert!(mounts.is_empty());
                 assert!(name.is_none());
                 assert!(!detach);
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_with_publish_deserializes() {
+        let json = r#"{"cmd":"run","image":"nginx","args":[],"publish":["8080:80","443:443"]}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::Run { image, publish, .. } => {
+                assert_eq!(image, "nginx");
+                assert_eq!(publish, vec!["8080:80", "443:443"]);
             }
             other => panic!("unexpected: {:?}", other),
         }

--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -164,24 +164,8 @@ pub fn ensure_running(args: &DaemonArgs) -> io::Result<()> {
                  run 'pelagos vm stop' first, then retry",
             ));
         }
-        // Verify that any explicitly requested port forwards are active.
-        // Requesting no ports (-p not given) always succeeds even if the daemon
-        // has active forwards (the proxies are already running).
-        if !args.port_forwards.is_empty() {
-            let running_ports = state.read_ports()?;
-            for pf in &args.port_forwards {
-                if !running_ports.contains(pf) {
-                    return Err(io::Error::new(
-                        io::ErrorKind::AlreadyExists,
-                        format!(
-                            "port {}:{} is not forwarded by the running daemon; \
-                             run 'pelagos vm stop' first, then retry",
-                            pf.host_port, pf.container_port
-                        ),
-                    ));
-                }
-            }
-        }
+        // Ports are managed dynamically via DaemonCmd::RegisterPort; no
+        // static port-list validation is needed here (issue #170).
         return Ok(());
     }
 
@@ -276,15 +260,13 @@ pub fn run(args: DaemonArgs) -> ! {
         log::error!("write pid: {}", e);
     });
 
-    // Persist mount, port, and extra-disk configuration.
+    // Persist mount and extra-disk configuration (validated on reconnect).
+    // Port forwards are managed dynamically via DaemonCmd — no static list to persist.
     state
         .write_mounts(&args.virtiofs_shares)
         .unwrap_or_else(|e| {
             log::error!("write mounts: {}", e);
         });
-    state.write_ports(&args.port_forwards).unwrap_or_else(|e| {
-        log::error!("write ports: {}", e);
-    });
     state
         .write_extra_disks(&args.extra_disks)
         .unwrap_or_else(|e| {
@@ -309,6 +291,13 @@ pub fn run(args: DaemonArgs) -> ! {
     }
 
     log::info!("daemon listening on {}", state.sock_file.display());
+
+    // Spawn the subscription watcher: auto-deregisters ports when containers exit.
+    start_subscription_watcher(
+        Arc::clone(&vm),
+        Arc::clone(&dispatcher),
+        Arc::clone(&port_state),
+    );
 
     // Install SIGTERM handler: sets flag, SIGINT terminates immediately.
     let shutdown = Arc::new(AtomicBool::new(false));
@@ -551,6 +540,160 @@ fn handle_daemon_cmd(
     let mut resp_str = serde_json::to_string(&response).unwrap_or_default();
     resp_str.push('\n');
     let _ = unix.write_all(resp_str.as_bytes());
+}
+
+// ---------------------------------------------------------------------------
+// Subscription watcher — auto-deregisters ports when containers exit (#169)
+// ---------------------------------------------------------------------------
+
+/// Minimal wire-format types for the `pelagos subscribe` NDJSON stream.
+/// Must match `GuestEvent` in pelagos-guest (`#[serde(tag = "type", rename_all = "snake_case")]`).
+#[derive(serde::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum WatchEvent {
+    Snapshot {
+        containers: Vec<WatchContainer>,
+    },
+    ContainerStarted {
+        container: WatchContainer,
+    },
+    ContainerExited {
+        name: String,
+    },
+    /// Catch-all for heartbeats and any future event types.
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(serde::Deserialize)]
+struct WatchContainer {
+    name: String,
+    #[serde(default)]
+    ports: Vec<String>,
+}
+
+/// Spawn the subscription watcher thread.  The thread connects to vsock,
+/// subscribes to container lifecycle events, and automatically removes port
+/// forwards from `PortDispatcher` / `PortState` when a container exits.
+fn start_subscription_watcher(
+    vm: Arc<Vm>,
+    dispatcher: Arc<PortDispatcher>,
+    port_state: Arc<Mutex<PortState>>,
+) {
+    std::thread::Builder::new()
+        .name("port-sub-watcher".into())
+        .spawn(move || subscription_watcher_loop(vm, dispatcher, port_state))
+        .expect("spawn port-sub-watcher");
+}
+
+fn subscription_watcher_loop(
+    vm: Arc<Vm>,
+    dispatcher: Arc<PortDispatcher>,
+    port_state: Arc<Mutex<PortState>>,
+) {
+    use std::io::BufRead;
+
+    // Local map: container name → port specs (e.g. ["8080:80"]).
+    // Updated on every Snapshot and ContainerStarted event so that a later
+    // ContainerExited can look up which ports belong to that container.
+    let mut container_ports: HashMap<String, Vec<String>> = HashMap::new();
+
+    loop {
+        // Connect to vsock (retry until the VM guest is ready).
+        let vsock_fd = loop {
+            match vm.connect_vsock() {
+                Ok(fd) => break fd,
+                Err(_) => {
+                    std::thread::sleep(Duration::from_secs(2));
+                }
+            }
+        };
+
+        // Send {"cmd":"subscribe"}\n — the GuestCommand::Subscribe wire format.
+        const SUBSCRIBE_LINE: &[u8] = b"{\"cmd\":\"subscribe\"}\n";
+        let vsock_raw = vsock_fd.into_raw_fd();
+        {
+            // SAFETY: vsock_raw is valid; mem::forget prevents double-close.
+            let mut f = unsafe { std::fs::File::from_raw_fd(vsock_raw) };
+            let ok = f.write_all(SUBSCRIBE_LINE).is_ok();
+            std::mem::forget(f);
+            if !ok {
+                // SAFETY: we prevented the File from closing it; close manually.
+                unsafe { libc::close(vsock_raw) };
+                log::warn!("port-sub-watcher: failed to send subscribe command");
+                std::thread::sleep(Duration::from_secs(5));
+                continue;
+            }
+        }
+
+        // Read NDJSON events until the connection closes.
+        let f = unsafe { std::fs::File::from_raw_fd(vsock_raw) };
+        let mut reader = std::io::BufReader::new(f);
+        let mut line = String::new();
+        log::info!("port-sub-watcher: subscribed to container events");
+
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+            let trimmed = line.trim_end();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<WatchEvent>(trimmed) {
+                Ok(WatchEvent::Snapshot { containers }) => {
+                    container_ports.clear();
+                    for c in containers {
+                        if !c.ports.is_empty() {
+                            container_ports.insert(c.name, c.ports);
+                        }
+                    }
+                    log::debug!(
+                        "port-sub-watcher: snapshot — tracking {} containers with ports",
+                        container_ports.len()
+                    );
+                }
+                Ok(WatchEvent::ContainerStarted { container }) => {
+                    if !container.ports.is_empty() {
+                        log::debug!(
+                            "port-sub-watcher: {} started with ports {:?}",
+                            container.name,
+                            container.ports
+                        );
+                        container_ports.insert(container.name, container.ports);
+                    }
+                }
+                Ok(WatchEvent::ContainerExited { name }) => {
+                    if let Some(ports) = container_ports.remove(&name) {
+                        let mut ps = port_state.lock().unwrap();
+                        for spec in &ports {
+                            if let Some(pf) = parse_port_spec(spec) {
+                                if ps.active.remove(&pf.host_port).is_some() {
+                                    dispatcher.send(DispatchCmd::Remove {
+                                        host_port: pf.host_port,
+                                    });
+                                    log::info!(
+                                        "port-sub-watcher: {} exited — unregistered port {}",
+                                        name,
+                                        pf.host_port
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                Ok(WatchEvent::Unknown) => {}
+                Err(_) => {
+                    log::trace!("port-sub-watcher: unparseable line: {}", trimmed);
+                }
+            }
+        }
+
+        log::info!("port-sub-watcher: subscribe connection closed — reconnecting in 5s");
+        std::thread::sleep(Duration::from_secs(5));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1182,5 +1325,109 @@ mod tests {
             .position(|a| a == "--profile")
             .expect("--profile missing");
         assert_eq!(v[idx + 1], std::ffi::OsStr::new("build"));
+    }
+
+    // -----------------------------------------------------------------------
+    // DaemonCmd / DaemonResponse serialization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn daemon_cmd_register_port_roundtrip() {
+        use super::{DaemonCmd, DaemonResponse};
+        let cmd = DaemonCmd::RegisterPort {
+            host_port: 8080,
+            container_port: 80,
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["RegisterPort"]["host_port"], 8080);
+        assert_eq!(v["RegisterPort"]["container_port"], 80);
+
+        let resp_ok = DaemonResponse::Ok;
+        let r = serde_json::to_string(&resp_ok).unwrap();
+        assert!(r.contains("\"ok\""));
+
+        let resp_err = DaemonResponse::Err {
+            message: "port 8080 is already registered".into(),
+        };
+        let e = serde_json::to_string(&resp_err).unwrap();
+        assert!(e.contains("\"err\""));
+        assert!(e.contains("already registered"));
+    }
+
+    #[test]
+    fn daemon_cmd_unregister_port_roundtrip() {
+        use super::DaemonCmd;
+        let cmd = DaemonCmd::UnregisterPort { host_port: 8080 };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["UnregisterPort"]["host_port"], 8080);
+    }
+
+    // -----------------------------------------------------------------------
+    // WatchEvent deserialization (validates wire-format match with pelagos-guest)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn watch_event_snapshot_deserializes() {
+        use super::WatchEvent;
+        let json = r#"{"type":"snapshot","containers":[{"name":"nginx","status":"running","rootfs":"alpine","pid":1,"started_at":"2024-01-01","ports":["8080:80"]}],"vm_running":true}"#;
+        match serde_json::from_str::<WatchEvent>(json).unwrap() {
+            WatchEvent::Snapshot { containers } => {
+                assert_eq!(containers.len(), 1);
+                assert_eq!(containers[0].name, "nginx");
+                assert_eq!(containers[0].ports, vec!["8080:80"]);
+            }
+            other => panic!("unexpected: {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn watch_event_container_started_deserializes() {
+        use super::WatchEvent;
+        let json = r#"{"type":"container_started","container":{"name":"redis","status":"running","rootfs":"redis","pid":2,"started_at":"2024-01-01","ports":["6379:6379"]}}"#;
+        match serde_json::from_str::<WatchEvent>(json).unwrap() {
+            WatchEvent::ContainerStarted { container } => {
+                assert_eq!(container.name, "redis");
+                assert_eq!(container.ports, vec!["6379:6379"]);
+            }
+            other => panic!("unexpected: {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn watch_event_container_exited_deserializes() {
+        use super::WatchEvent;
+        let json = r#"{"type":"container_exited","name":"nginx","exit_code":0}"#;
+        match serde_json::from_str::<WatchEvent>(json).unwrap() {
+            WatchEvent::ContainerExited { name } => {
+                assert_eq!(name, "nginx");
+            }
+            other => panic!("unexpected: {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn watch_event_heartbeat_is_unknown() {
+        use super::WatchEvent;
+        let json = r#"{"type":"heartbeat","ts":1234567890}"#;
+        // heartbeats are caught by the Unknown variant
+        assert!(matches!(
+            serde_json::from_str::<WatchEvent>(json).unwrap(),
+            WatchEvent::Unknown
+        ));
+    }
+
+    #[test]
+    fn watch_event_snapshot_no_ports_ignored() {
+        use super::WatchEvent;
+        // containers without ports → empty ports vec
+        let json = r#"{"type":"snapshot","containers":[{"name":"busybox","status":"running","rootfs":"busybox","pid":3,"started_at":"2024-01-01"}],"vm_running":true}"#;
+        match serde_json::from_str::<WatchEvent>(json).unwrap() {
+            WatchEvent::Snapshot { containers } => {
+                assert_eq!(containers[0].ports, Vec::<String>::new());
+            }
+            _ => panic!("expected Snapshot"),
+        }
     }
 }

--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -11,20 +11,20 @@
 //!      bidirectionally proxies bytes between the Unix stream and the vsock fd.
 //!   4. On SIGTERM the daemon stops the VM, removes state files, and exits.
 
-use std::io;
-use std::net::{TcpListener, TcpStream};
+use std::collections::HashMap;
+use std::io::{self, Read, Write};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-
-use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
 use pelagos_vz::vm::{Vm, VmConfig};
 
+use crate::port_dispatcher::{DispatchCmd, PortDispatcher};
 use crate::state::StateDir;
 
 // ---------------------------------------------------------------------------
@@ -73,6 +73,42 @@ pub struct VirtiofsShare {
     pub read_only: bool,
     /// Absolute path inside the container where the share is mounted.
     pub container_path: String,
+}
+
+/// Commands sent directly to the daemon (not proxied to vsock).
+///
+/// The daemon peeks at the first JSON line of each connection; if it
+/// deserialises as `DaemonCmd` it is handled locally and the connection is
+/// closed.  Any other first line is forwarded to the guest via vsock.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum DaemonCmd {
+    /// Start listening on `host_port` and relay connections to `container_port`.
+    RegisterPort { host_port: u16, container_port: u16 },
+    /// Stop listening on `host_port`.  Active connections are not affected.
+    UnregisterPort { host_port: u16 },
+}
+
+/// One-line JSON response to a `DaemonCmd`.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DaemonResponse {
+    Ok,
+    Err { message: String },
+}
+
+/// Live port-forward state shared between connection handler threads and (in a
+/// future PR) the subscription watcher thread.
+struct PortState {
+    /// Maps host_port → container_port for every currently active forward.
+    active: HashMap<u16, u16>,
+}
+
+impl PortState {
+    fn new() -> Self {
+        Self {
+            active: HashMap::new(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -255,13 +291,21 @@ pub fn run(args: DaemonArgs) -> ! {
             log::error!("write extra_disks: {}", e);
         });
 
-    // Start a TCP proxy thread for each requested port forward.
-    for pf in &args.port_forwards {
-        let host_port = pf.host_port;
-        let container_port = pf.container_port;
-        std::thread::spawn(move || {
-            port_forward_loop(host_port, container_port);
-        });
+    // Spawn the single-threaded port-forward dispatcher (O(1) listener threads
+    // regardless of how many ports or containers are active).
+    let dispatcher = Arc::new(PortDispatcher::spawn());
+    let port_state = Arc::new(Mutex::new(PortState::new()));
+
+    // Pre-register any ports requested at daemon startup via `vm start -p`.
+    {
+        let mut ps = port_state.lock().unwrap();
+        for pf in &args.port_forwards {
+            dispatcher.send(DispatchCmd::Add {
+                host_port: pf.host_port,
+                container_port: pf.container_port,
+            });
+            ps.active.insert(pf.host_port, pf.container_port);
+        }
     }
 
     log::info!("daemon listening on {}", state.sock_file.display());
@@ -284,6 +328,8 @@ pub fn run(args: DaemonArgs) -> ! {
     loop {
         if shutdown.load(Ordering::Relaxed) {
             log::info!("shutdown requested, stopping VM...");
+            dispatcher.send(DispatchCmd::Shutdown);
+            drop(dispatcher);
             // Drop the Arc. If no proxy threads are active, Vm::drop runs stop().
             // If threads still hold clones the VM will stop when the last clone
             // drops. Either way the process exits immediately after cleanup.
@@ -318,19 +364,10 @@ pub fn run(args: DaemonArgs) -> ! {
         // blocked while waiting for the guest daemon to start (which can take
         // up to ~45 s during the ping-gate phase).
         let vm2 = Arc::clone(&vm);
+        let disp2 = Arc::clone(&dispatcher);
+        let ps2 = Arc::clone(&port_state);
         std::thread::spawn(move || {
-            let conn_id = std::thread::current().id();
-            log::info!("[{conn_id:?}] client connected");
-            let vsock_fd = match vm2.connect_vsock() {
-                Ok(fd) => fd,
-                Err(e) => {
-                    log::error!("[{conn_id:?}] vsock connect: {}", e);
-                    return; // unix stream dropped → EOF on CLI side
-                }
-            };
-            drop(vm2); // release Arc before entering the proxy loop
-            proxy(unix, vsock_fd, conn_id);
-            log::info!("[{conn_id:?}] client disconnected");
+            handle_connection(unix, vm2, disp2, ps2);
         });
     }
 }
@@ -390,81 +427,130 @@ fn proxy(unix: UnixStream, vsock: OwnedFd, conn_id: std::thread::ThreadId) {
 }
 
 // ---------------------------------------------------------------------------
-// Port forwarding
+// Connection handler
 // ---------------------------------------------------------------------------
 
-/// Accept TCP connections on `host_port` and proxy each one to the VM container
-/// port via the smoltcp NAT relay proxy (127.0.0.1:RELAY_PROXY_PORT).
+/// Handle one accepted Unix socket connection.
 ///
-/// Protocol: connect to relay, send 2-byte big-endian container_port, then
-/// use the socket as a bidirectional stream into the VM.  This avoids needing
-/// a macOS route to 192.168.105.2 (which no longer exists without vmnet).
-pub(crate) fn port_forward_loop(host_port: u16, container_port: u16) {
-    use std::io::Write;
-    const RELAY_PROXY_PORT: u16 = pelagos_vz::nat_relay::RELAY_PROXY_PORT;
+/// Peeks at the first newline-terminated JSON line:
+/// - If it is a `DaemonCmd`: handle locally (port registration / removal) and return.
+/// - Otherwise: open a vsock channel to the guest and bidirectionally proxy all bytes.
+fn handle_connection(
+    mut unix: UnixStream,
+    vm: Arc<Vm>,
+    dispatcher: Arc<PortDispatcher>,
+    port_state: Arc<Mutex<PortState>>,
+) {
+    let conn_id = std::thread::current().id();
+    log::info!("[{conn_id:?}] client connected");
 
-    let listener = match TcpListener::bind(("0.0.0.0", host_port)) {
-        Ok(l) => l,
+    // Read the first line byte-by-byte so we never consume more than one line
+    // into a buffer that could then be lost when we hand the stream to proxy().
+    let mut first_line: Vec<u8> = Vec::with_capacity(256);
+    let mut byte = [0u8; 1];
+    loop {
+        match unix.read(&mut byte) {
+            Ok(0) | Err(_) => {
+                log::debug!("[{conn_id:?}] connection closed before first line");
+                return;
+            }
+            Ok(_) => {
+                first_line.push(byte[0]);
+                if byte[0] == b'\n' {
+                    break;
+                }
+                if first_line.len() > 64 * 1024 {
+                    log::warn!("[{conn_id:?}] first line exceeds 64 KiB — dropping connection");
+                    return;
+                }
+            }
+        }
+    }
+
+    let trimmed = String::from_utf8_lossy(&first_line);
+    let trimmed = trimmed.trim_end();
+
+    // If the first line is a DaemonCmd, handle it locally (no vsock needed).
+    if let Ok(cmd) = serde_json::from_str::<DaemonCmd>(trimmed) {
+        handle_daemon_cmd(cmd, &mut unix, &dispatcher, &port_state, conn_id);
+        return;
+    }
+
+    // Not a DaemonCmd — proxy to vsock.  Connect inside this thread so the
+    // accept loop is not blocked while waiting for the guest to start.
+    let vsock_fd = match vm.connect_vsock() {
+        Ok(fd) => fd,
         Err(e) => {
-            log::error!("port forward bind 0.0.0.0:{}: {}", host_port, e);
+            log::error!("[{conn_id:?}] vsock connect: {}", e);
             return;
         }
     };
-    log::info!(
-        "port forward active: 0.0.0.0:{} → VM:{}  (via relay :{})",
-        host_port,
-        container_port,
-        RELAY_PROXY_PORT
-    );
-    for incoming in listener.incoming() {
-        let client = match incoming {
-            Ok(s) => s,
-            Err(e) => {
-                log::warn!("port forward accept: {}", e);
-                continue;
-            }
-        };
-        std::thread::spawn(move || {
-            let relay_addr = std::net::SocketAddr::from(([127, 0, 0, 1], RELAY_PROXY_PORT));
-            let mut server =
-                match TcpStream::connect_timeout(&relay_addr, std::time::Duration::from_secs(5)) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        log::warn!("port forward connect relay:{}: {}", RELAY_PROXY_PORT, e);
-                        return;
-                    }
-                };
-            // Send 2-byte big-endian container port.
-            if server.write_all(&container_port.to_be_bytes()).is_err() {
-                return;
-            }
-            tcp_proxy(client, server);
-        });
+    drop(vm);
+
+    // Replay the peeked line to vsock before entering the bidirectional proxy.
+    let vsock_raw = vsock_fd.into_raw_fd();
+    {
+        // SAFETY: vsock_raw is valid.  mem::forget prevents the File from
+        // closing it so we can hand it to proxy() below.
+        let mut f = unsafe { std::fs::File::from_raw_fd(vsock_raw) };
+        let ok = f.write_all(&first_line).is_ok();
+        std::mem::forget(f);
+        if !ok {
+            log::warn!("[{conn_id:?}] failed to replay first line to vsock");
+            unsafe { libc::close(vsock_raw) };
+            return;
+        }
     }
+    let vsock_owned = unsafe { OwnedFd::from_raw_fd(vsock_raw) };
+    proxy(unix, vsock_owned, conn_id);
+    log::info!("[{conn_id:?}] client disconnected");
 }
 
-/// Bidirectionally proxy two TCP streams.  Returns when either side closes.
-fn tcp_proxy(client: TcpStream, server: TcpStream) {
-    let mut client_read = client;
-    let mut server_read = server;
-    let mut client_write = client_read.try_clone().expect("tcp clone");
-    let mut server_write = server_read.try_clone().expect("tcp clone");
+/// Execute a `DaemonCmd` locally and write a `DaemonResponse` back to the caller.
+fn handle_daemon_cmd(
+    cmd: DaemonCmd,
+    unix: &mut UnixStream,
+    dispatcher: &PortDispatcher,
+    port_state: &Mutex<PortState>,
+    conn_id: std::thread::ThreadId,
+) {
+    let response = match cmd {
+        DaemonCmd::RegisterPort {
+            host_port,
+            container_port,
+        } => {
+            let mut ps = port_state.lock().unwrap();
+            if let std::collections::hash_map::Entry::Vacant(e) = ps.active.entry(host_port) {
+                dispatcher.send(DispatchCmd::Add {
+                    host_port,
+                    container_port,
+                });
+                e.insert(container_port);
+                log::info!(
+                    "[{conn_id:?}] registered port {}:{}",
+                    host_port,
+                    container_port
+                );
+                DaemonResponse::Ok
+            } else {
+                let msg = format!("port {} is already registered", host_port);
+                log::warn!("[{conn_id:?}] register port: {}", msg);
+                DaemonResponse::Err { message: msg }
+            }
+        }
+        DaemonCmd::UnregisterPort { host_port } => {
+            let mut ps = port_state.lock().unwrap();
+            if ps.active.remove(&host_port).is_some() {
+                dispatcher.send(DispatchCmd::Remove { host_port });
+                log::info!("[{conn_id:?}] unregistered port {}", host_port);
+            }
+            DaemonResponse::Ok
+        }
+    };
 
-    // client → server
-    let t1 = std::thread::spawn(move || {
-        let _ = std::io::copy(&mut client_read, &mut server_write);
-        // Signal server that client is done sending.
-        let _ = server_write.shutdown(std::net::Shutdown::Write);
-    });
-
-    // server → client
-    let t2 = std::thread::spawn(move || {
-        let _ = std::io::copy(&mut server_read, &mut client_write);
-        let _ = client_write.shutdown(std::net::Shutdown::Write);
-    });
-
-    let _ = t1.join();
-    let _ = t2.join();
+    let mut resp_str = serde_json::to_string(&response).unwrap_or_default();
+    resp_str.push('\n');
+    let _ = unix.write_all(resp_str.as_bytes());
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -15,6 +15,7 @@ use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 
 mod daemon;
+mod port_dispatcher;
 mod state;
 
 // ---------------------------------------------------------------------------
@@ -751,23 +752,25 @@ fn main() {
                 log::error!("failed to start VM daemon: {}", e);
                 process::exit(1);
             }
-            // Start host-side port proxies for foreground runs so that
-            // localhost:HOST_PORT is forwarded to VM:HOST_PORT via the relay.
-            // These threads are tied to the CLI process lifetime — they stop
-            // when the container exits and the CLI process exits.
-            // For detached runs the daemon-level port_forwards handle host-side
-            // forwarding (configured at daemon startup via -p global flag).
-            if !cli.ports.is_empty() && !detach {
-                for spec in &cli.ports {
-                    if let Some(pf) = daemon::parse_port_spec(spec) {
-                        let hp = pf.host_port;
-                        let cp = pf.host_port; // relay to VM host_port (pelagos proxy listens there)
-                        std::thread::spawn(move || daemon::port_forward_loop(hp, cp));
+            // Register port forwards with the daemon.  The daemon's
+            // PortDispatcher (one listener thread for all ports) manages TCP
+            // listeners; conflict detection returns an error immediately.
+            for spec in &cli.ports {
+                if let Some(pf) = daemon::parse_port_spec(spec) {
+                    if let Err(e) = send_daemon_cmd(
+                        &profile,
+                        daemon::DaemonCmd::RegisterPort {
+                            host_port: pf.host_port,
+                            container_port: pf.container_port,
+                        },
+                    ) {
+                        log::error!("port registration failed: {}", e);
+                        process::exit(1);
                     }
                 }
             }
             let stream = connect_or_exit(&profile);
-            process::exit(passthrough_command(
+            let exit_code = passthrough_command(
                 stream,
                 GuestCommand::Run {
                     image,
@@ -779,7 +782,25 @@ fn main() {
                     labels,
                     publish: cli.ports.clone(),
                 },
-            ));
+            );
+            // For foreground containers the CLI process stays alive until the
+            // container exits; deregister ports now.  For detached containers
+            // the caller has already returned (passthrough exits immediately)
+            // and deregistration will be handled by the subscription watcher
+            // (issue #169).
+            if !detach {
+                for spec in &cli.ports {
+                    if let Some(pf) = daemon::parse_port_spec(spec) {
+                        let _ = send_daemon_cmd(
+                            &profile,
+                            daemon::DaemonCmd::UnregisterPort {
+                                host_port: pf.host_port,
+                            },
+                        );
+                    }
+                }
+            }
+            process::exit(exit_code);
         }
 
         Commands::Exec {
@@ -1117,15 +1138,20 @@ fn main() {
 /// macOS and forwards each accepted connection to `192.168.105.2:VM`.
 /// Runs until the process is killed (SIGTERM from the shim on container stop/rm).
 fn cmd_port_proxy(ports: &[String]) {
+    use port_dispatcher::{DispatchCmd, PortDispatcher};
+
     if ports.is_empty() {
         log::warn!("port-proxy: no ports specified, exiting immediately");
         return;
     }
+    let dispatcher = PortDispatcher::spawn();
     for spec in ports {
         match daemon::parse_port_spec(spec) {
             Some(pf) => {
-                let (hp, cp) = (pf.host_port, pf.container_port);
-                std::thread::spawn(move || daemon::port_forward_loop(hp, cp));
+                dispatcher.send(DispatchCmd::Add {
+                    host_port: pf.host_port,
+                    container_port: pf.container_port,
+                });
             }
             None => {
                 log::error!("port-proxy: invalid port spec {:?}", spec);
@@ -1439,6 +1465,32 @@ fn connect_or_exit(profile: &str) -> UnixStream {
         log::error!("connect to VM daemon: {}", e);
         process::exit(1);
     })
+}
+
+/// Send a `DaemonCmd` to the running daemon and return the response.
+///
+/// Connects to `vm.sock`, writes one JSON line, reads one JSON response line,
+/// then closes.  Returns `Err` if the daemon reports a port conflict or the
+/// connection fails.
+fn send_daemon_cmd(profile: &str, cmd: daemon::DaemonCmd) -> io::Result<()> {
+    let mut stream = daemon::connect(profile)?;
+    let mut msg =
+        serde_json::to_string(&cmd).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    msg.push('\n');
+    stream.write_all(msg.as_bytes())?;
+
+    // Read the one-line response.
+    let mut line = String::new();
+    let mut reader = BufReader::new(stream);
+    reader.read_line(&mut line)?;
+
+    match serde_json::from_str::<daemon::DaemonResponse>(line.trim()) {
+        Ok(daemon::DaemonResponse::Ok) => Ok(()),
+        Ok(daemon::DaemonResponse::Err { message }) => {
+            Err(io::Error::new(io::ErrorKind::AlreadyExists, message))
+        }
+        Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -343,6 +343,9 @@ enum GuestCommand {
         env: std::collections::HashMap<String, String>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         labels: Vec<String>,
+        /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        publish: Vec<String>,
     },
     Exec {
         image: String,
@@ -748,6 +751,21 @@ fn main() {
                 log::error!("failed to start VM daemon: {}", e);
                 process::exit(1);
             }
+            // Start host-side port proxies for foreground runs so that
+            // localhost:HOST_PORT is forwarded to VM:HOST_PORT via the relay.
+            // These threads are tied to the CLI process lifetime — they stop
+            // when the container exits and the CLI process exits.
+            // For detached runs the daemon-level port_forwards handle host-side
+            // forwarding (configured at daemon startup via -p global flag).
+            if !cli.ports.is_empty() && !detach {
+                for spec in &cli.ports {
+                    if let Some(pf) = daemon::parse_port_spec(spec) {
+                        let hp = pf.host_port;
+                        let cp = pf.host_port; // relay to VM host_port (pelagos proxy listens there)
+                        std::thread::spawn(move || daemon::port_forward_loop(hp, cp));
+                    }
+                }
+            }
             let stream = connect_or_exit(&profile);
             process::exit(passthrough_command(
                 stream,
@@ -759,6 +777,7 @@ fn main() {
                     detach,
                     env: env_map,
                     labels,
+                    publish: cli.ports.clone(),
                 },
             ));
         }
@@ -2627,6 +2646,7 @@ mod tests {
             detach: false,
             env: std::collections::HashMap::new(),
             labels: vec![],
+            publish: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -2648,6 +2668,7 @@ mod tests {
             detach: true,
             env: std::collections::HashMap::new(),
             labels: vec![],
+            publish: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -2670,6 +2691,7 @@ mod tests {
             detach: false,
             env: std::collections::HashMap::new(),
             labels: vec![],
+            publish: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/pelagos-mac/src/port_dispatcher.rs
+++ b/pelagos-mac/src/port_dispatcher.rs
@@ -248,7 +248,7 @@ fn add_listener(listeners: &mut HashMap<u16, ListenerEntry>, host_port: u16, con
     }
 }
 
-fn spawn_connection_handler(client: TcpStream, host_port: u16, container_port: u16) {
+fn spawn_connection_handler(client: TcpStream, host_port: u16, _container_port: u16) {
     std::thread::Builder::new()
         .name(format!("port-conn-{}", host_port))
         .spawn(move || {
@@ -260,8 +260,10 @@ fn spawn_connection_handler(client: TcpStream, host_port: u16, container_port: u
                     return;
                 }
             };
-            // Send 2-byte big-endian container port to the relay.
-            if server.write_all(&container_port.to_be_bytes()).is_err() {
+            // Send 2-byte big-endian host port to the relay.
+            // The relay connects to VM:host_port where pelagos's TCP proxy
+            // is listening (bound on host_port, not container_port).
+            if server.write_all(&host_port.to_be_bytes()).is_err() {
                 return;
             }
             proxy_bidirectional(client, server);

--- a/pelagos-mac/src/port_dispatcher.rs
+++ b/pelagos-mac/src/port_dispatcher.rs
@@ -1,0 +1,357 @@
+//! Single-threaded port-forward dispatcher using `libc::poll`.
+//!
+//! One `PortDispatcher` thread manages arbitrarily many `TcpListener`s via a
+//! single `poll(2)` call.  This keeps the listener thread count constant at 1
+//! regardless of how many ports or containers are active.
+//!
+//! Each accepted connection spawns two threads (one per direction of
+//! `io::copy`) for the duration of that connection.  See the tokio issue (#165)
+//! for the planned upgrade to O(1) connection threads.
+//!
+//! # Protocol
+//!
+//! Callers interact with the dispatcher via a `mpsc::SyncSender<DispatchCmd>`.
+//! When a command is sent, a byte is written to a wakeup pipe; the poll loop
+//! wakes up, drains the command channel, and adds/removes listeners before
+//! returning to `poll`.
+//!
+//! # Relay protocol
+//!
+//! Each accepted connection is forwarded to the smoltcp NAT relay at
+//! `127.0.0.1:RELAY_PROXY_PORT`.  The caller writes a 2-byte big-endian
+//! container port number immediately after connecting; the relay then
+//! bidirectionally streams to `VM_IP:container_port`.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use pelagos_vz::nat_relay::RELAY_PROXY_PORT;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Commands sent to the dispatcher thread.
+#[derive(Debug)]
+pub enum DispatchCmd {
+    /// Start listening on `host_port`; relay accepted connections to `container_port`.
+    Add { host_port: u16, container_port: u16 },
+    /// Stop listening on `host_port`.  Active connections are not affected.
+    Remove { host_port: u16 },
+    /// Shut down the dispatcher; all listeners are closed.
+    Shutdown,
+}
+
+/// Handle to the background dispatcher thread.
+///
+/// Dropping this handle does NOT shut down the thread — send `DispatchCmd::Shutdown`
+/// explicitly before dropping, or the thread will run until the process exits.
+pub struct PortDispatcher {
+    cmd_tx: mpsc::SyncSender<DispatchCmd>,
+    /// Write end of the wakeup pipe (read end is in the dispatcher thread).
+    wake_tx: RawFd,
+}
+
+impl PortDispatcher {
+    /// Spawn the dispatcher thread and return a handle.
+    pub fn spawn() -> Self {
+        let (cmd_tx, cmd_rx) = mpsc::sync_channel::<DispatchCmd>(64);
+        let mut pipe_fds: [libc::c_int; 2] = [-1; 2];
+        // SAFETY: pipe() is a safe, well-defined syscall.
+        let rc = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "pipe failed: {}", std::io::Error::last_os_error());
+        // Set O_CLOEXEC on both ends so they don't leak into child processes.
+        unsafe {
+            libc::fcntl(pipe_fds[0], libc::F_SETFD, libc::FD_CLOEXEC);
+            libc::fcntl(pipe_fds[1], libc::F_SETFD, libc::FD_CLOEXEC);
+        };
+        let wake_rx = pipe_fds[0];
+        let wake_tx = pipe_fds[1];
+
+        std::thread::Builder::new()
+            .name("port-dispatcher".into())
+            .spawn(move || dispatcher_loop(cmd_rx, wake_rx))
+            .expect("spawn port-dispatcher");
+
+        Self { cmd_tx, wake_tx }
+    }
+
+    /// Send a command to the dispatcher and wake it up.
+    pub fn send(&self, cmd: DispatchCmd) {
+        // Best-effort: if the channel is full or the thread is gone, log and move on.
+        if self.cmd_tx.try_send(cmd).is_err() {
+            log::warn!("port-dispatcher: command channel full or closed");
+            return;
+        }
+        // Wake the poll loop by writing one byte to the pipe.
+        let byte: [u8; 1] = [1];
+        // SAFETY: write to a valid pipe fd.
+        unsafe { libc::write(self.wake_tx, byte.as_ptr() as *const libc::c_void, 1) };
+    }
+}
+
+impl Drop for PortDispatcher {
+    fn drop(&mut self) {
+        // Close the write end of the wakeup pipe.  The dispatcher thread will
+        // see EOF on the read end and exit its loop.
+        // SAFETY: closing a valid fd.
+        unsafe { libc::close(self.wake_tx) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher thread
+// ---------------------------------------------------------------------------
+
+struct ListenerEntry {
+    listener: TcpListener,
+    container_port: u16,
+}
+
+fn dispatcher_loop(cmd_rx: mpsc::Receiver<DispatchCmd>, wake_rx: RawFd) {
+    // host_port → entry
+    let mut listeners: HashMap<u16, ListenerEntry> = HashMap::new();
+    // Reusable poll-fds vec; rebuilt each iteration.
+    let mut pollfds: Vec<libc::pollfd> = Vec::new();
+
+    loop {
+        // Build the pollfd array: wakeup pipe first, then all listener fds.
+        pollfds.clear();
+        pollfds.push(libc::pollfd {
+            fd: wake_rx,
+            events: libc::POLLIN,
+            revents: 0,
+        });
+        for entry in listeners.values() {
+            pollfds.push(libc::pollfd {
+                fd: entry.listener.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            });
+        }
+
+        // Block until at least one fd is ready (no timeout).
+        // SAFETY: pollfds is valid for the duration of the call.
+        let rc = unsafe {
+            libc::poll(
+                pollfds.as_mut_ptr(),
+                pollfds.len() as libc::nfds_t,
+                -1, // infinite timeout
+            )
+        };
+        if rc < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            log::error!("port-dispatcher: poll error: {}", err);
+            break;
+        }
+
+        // Check wakeup pipe (index 0).
+        if pollfds[0].revents & libc::POLLIN != 0 {
+            // Drain the pipe.
+            let mut buf = [0u8; 64];
+            // SAFETY: read from a valid pipe fd.
+            unsafe { libc::read(wake_rx, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+
+            // Process all pending commands.
+            loop {
+                match cmd_rx.try_recv() {
+                    Ok(DispatchCmd::Add {
+                        host_port,
+                        container_port,
+                    }) => {
+                        add_listener(&mut listeners, host_port, container_port);
+                    }
+                    Ok(DispatchCmd::Remove { host_port }) => {
+                        if listeners.remove(&host_port).is_some() {
+                            log::info!("port-dispatcher: stopped listener 0.0.0.0:{}", host_port);
+                        }
+                    }
+                    Ok(DispatchCmd::Shutdown) => {
+                        log::info!(
+                            "port-dispatcher: shutting down ({} listeners)",
+                            listeners.len()
+                        );
+                        // Dropping listeners closes the TcpListeners.
+                        listeners.clear();
+                        // SAFETY: closing the read end of the pipe.
+                        unsafe { libc::close(wake_rx) };
+                        return;
+                    }
+                    Err(mpsc::TryRecvError::Empty) => break,
+                    Err(mpsc::TryRecvError::Disconnected) => {
+                        log::info!("port-dispatcher: command channel closed, exiting");
+                        // SAFETY: closing the read end of the pipe.
+                        unsafe { libc::close(wake_rx) };
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Check each listener fd (indices 1..).  Collect ready host_ports to
+        // avoid borrowing `listeners` mutably while iterating values.
+        let ready_ports: Vec<u16> = listeners
+            .iter()
+            .zip(pollfds.iter().skip(1))
+            .filter(|(_, pfd)| pfd.revents & libc::POLLIN != 0)
+            .map(|((&port, _), _)| port)
+            .collect();
+
+        for host_port in ready_ports {
+            if let Some(entry) = listeners.get(&host_port) {
+                match entry.listener.accept() {
+                    Ok((client, peer)) => {
+                        log::debug!("port-dispatcher: accepted {} → 0.0.0.0:{}", peer, host_port);
+                        let container_port = entry.container_port;
+                        spawn_connection_handler(client, host_port, container_port);
+                    }
+                    Err(e) => {
+                        log::warn!("port-dispatcher: accept on {}: {}", host_port, e);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn add_listener(listeners: &mut HashMap<u16, ListenerEntry>, host_port: u16, container_port: u16) {
+    if listeners.contains_key(&host_port) {
+        log::debug!("port-dispatcher: listener already active on {}", host_port);
+        return;
+    }
+    match TcpListener::bind(("0.0.0.0", host_port)) {
+        Ok(listener) => {
+            log::info!(
+                "port-dispatcher: listening 0.0.0.0:{} → VM:{} (relay :{})",
+                host_port,
+                container_port,
+                RELAY_PROXY_PORT
+            );
+            listeners.insert(
+                host_port,
+                ListenerEntry {
+                    listener,
+                    container_port,
+                },
+            );
+        }
+        Err(e) => {
+            log::error!("port-dispatcher: bind 0.0.0.0:{} failed: {}", host_port, e);
+        }
+    }
+}
+
+fn spawn_connection_handler(client: TcpStream, host_port: u16, container_port: u16) {
+    std::thread::Builder::new()
+        .name(format!("port-conn-{}", host_port))
+        .spawn(move || {
+            let relay_addr = std::net::SocketAddr::from(([127, 0, 0, 1], RELAY_PROXY_PORT));
+            let mut server = match TcpStream::connect_timeout(&relay_addr, Duration::from_secs(5)) {
+                Ok(s) => s,
+                Err(e) => {
+                    log::warn!("port-dispatcher: connect relay:{}: {}", RELAY_PROXY_PORT, e);
+                    return;
+                }
+            };
+            // Send 2-byte big-endian container port to the relay.
+            if server.write_all(&container_port.to_be_bytes()).is_err() {
+                return;
+            }
+            proxy_bidirectional(client, server);
+        })
+        .ok();
+}
+
+/// Bidirectionally proxy two TCP streams; returns when either side closes.
+fn proxy_bidirectional(client: TcpStream, server: TcpStream) {
+    let mut client_read = client;
+    let mut server_read = server;
+    let mut client_write = client_read.try_clone().expect("tcp clone");
+    let mut server_write = server_read.try_clone().expect("tcp clone");
+
+    let t1 = std::thread::spawn(move || {
+        let _ = std::io::copy(&mut client_read, &mut server_write);
+        let _ = server_write.shutdown(std::net::Shutdown::Write);
+    });
+    let t2 = std::thread::spawn(move || {
+        let _ = std::io::copy(&mut server_read, &mut client_write);
+        let _ = client_write.shutdown(std::net::Shutdown::Write);
+    });
+    let _ = t1.join();
+    let _ = t2.join();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn free_port() -> u16 {
+        // Bind port 0 to get an OS-assigned free port, then release it.
+        let l = TcpListener::bind("127.0.0.1:0").unwrap();
+        l.local_addr().unwrap().port()
+    }
+
+    #[test]
+    fn dispatcher_binds_on_add() {
+        let d = PortDispatcher::spawn();
+        let port = free_port();
+        d.send(DispatchCmd::Add {
+            host_port: port,
+            container_port: 80,
+        });
+        // Give the dispatcher time to process the command.
+        std::thread::sleep(Duration::from_millis(50));
+        // Port should now be in use — binding it again must fail.
+        assert!(
+            TcpListener::bind(("0.0.0.0", port)).is_err(),
+            "port {} should be bound by dispatcher",
+            port
+        );
+        d.send(DispatchCmd::Shutdown);
+    }
+
+    #[test]
+    fn dispatcher_unbinds_on_remove() {
+        let d = PortDispatcher::spawn();
+        let port = free_port();
+        d.send(DispatchCmd::Add {
+            host_port: port,
+            container_port: 80,
+        });
+        std::thread::sleep(Duration::from_millis(50));
+        d.send(DispatchCmd::Remove { host_port: port });
+        std::thread::sleep(Duration::from_millis(50));
+        // Port should now be free again.
+        let l = TcpListener::bind(("0.0.0.0", port));
+        assert!(l.is_ok(), "port {} should be free after remove", port);
+        d.send(DispatchCmd::Shutdown);
+    }
+
+    #[test]
+    fn dispatcher_shutdown_closes_all() {
+        let d = PortDispatcher::spawn();
+        let port = free_port();
+        d.send(DispatchCmd::Add {
+            host_port: port,
+            container_port: 80,
+        });
+        std::thread::sleep(Duration::from_millis(50));
+        d.send(DispatchCmd::Shutdown);
+        std::thread::sleep(Duration::from_millis(50));
+        // After shutdown all listeners should be closed.
+        let l = TcpListener::bind(("0.0.0.0", port));
+        assert!(l.is_ok(), "port {} should be free after shutdown", port);
+    }
+}

--- a/pelagos-mac/src/state.rs
+++ b/pelagos-mac/src/state.rs
@@ -201,27 +201,6 @@ impl StateDir {
         }
     }
 
-    /// Write the current daemon's port forward configuration as JSON.
-    pub fn write_ports(&self, ports: &[crate::daemon::PortForward]) -> io::Result<()> {
-        let json = serde_json::to_string(ports)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        let tmp = self.ports_file.with_extension("ports.tmp");
-        std::fs::write(&tmp, json)?;
-        std::fs::rename(&tmp, &self.ports_file)
-    }
-
-    /// Read the running daemon's port forward configuration.  Returns an empty
-    /// Vec if the file does not exist.
-    pub fn read_ports(&self) -> io::Result<Vec<crate::daemon::PortForward>> {
-        match std::fs::read_to_string(&self.ports_file) {
-            Ok(s) => {
-                serde_json::from_str(&s).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-            }
-            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Vec::new()),
-            Err(e) => Err(e),
-        }
-    }
-
     /// Remove PID, socket, console socket, mounts, ports, and extra_disks files. Best-effort.
     pub fn clear(&self) {
         let _ = std::fs::remove_file(&self.pid_file);
@@ -358,31 +337,6 @@ mod tests {
         let s = temp_state();
         std::fs::write(&s.pid_file, b"not-a-pid").expect("write garbage");
         assert_eq!(s.running_pid(), None);
-    }
-
-    #[test]
-    fn write_and_read_ports() {
-        let s = temp_state();
-        let ports = vec![
-            crate::daemon::PortForward {
-                host_port: 8080,
-                container_port: 80,
-            },
-            crate::daemon::PortForward {
-                host_port: 3000,
-                container_port: 3000,
-            },
-        ];
-        s.write_ports(&ports).expect("write_ports");
-        let read_back = s.read_ports().expect("read_ports");
-        assert_eq!(ports, read_back);
-    }
-
-    #[test]
-    fn read_ports_absent_file() {
-        let s = temp_state();
-        let ports = s.read_ports().expect("read_ports on missing file");
-        assert!(ports.is_empty());
     }
 
     /// Verify that the field paths are computed relative to the supplied base.

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -17,8 +17,11 @@ mod app;
 mod runner;
 mod ui;
 
+use std::collections::HashMap;
 use std::io;
-use std::sync::mpsc;
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
 use std::time::Duration;
 
 use crossterm::{
@@ -240,12 +243,16 @@ fn run_loop(
     sub_rx: mpsc::Receiver<SubscriptionMsg>,
 ) -> anyhow::Result<()> {
     let tick = Duration::from_millis(250);
+    let mut proxy_mgr = PortProxyManager::new();
 
     loop {
         // Drain all pending subscription events (non-blocking).
         loop {
             match sub_rx.try_recv() {
-                Ok(msg) => app.apply_subscription(msg),
+                Ok(msg) => {
+                    proxy_mgr.handle(&msg);
+                    app.apply_subscription(msg);
+                }
                 Err(mpsc::TryRecvError::Empty) => break,
                 Err(mpsc::TryRecvError::Disconnected) => break,
             }
@@ -312,6 +319,7 @@ fn run_loop(
         }
 
         if app.should_quit {
+            proxy_mgr.stop_all();
             break;
         }
     }
@@ -536,6 +544,216 @@ fn send_status(tx: &Option<mpsc::SyncSender<String>>, msg: String) {
     if let Some(tx) = tx {
         let _ = tx.try_send(msg);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Port proxy manager (TUI lifecycle)
+// ---------------------------------------------------------------------------
+
+/// Manages host-side TCP proxies for container port mappings.
+///
+/// Proxies are started when a container with ports appears in the subscription
+/// stream and stopped when that container exits or is removed.  Each proxy
+/// uses a non-blocking accept loop so it can be signalled to stop without
+/// blocking the caller.
+struct PortProxyManager {
+    /// host_port → stop token
+    proxies: HashMap<u16, Arc<AtomicBool>>,
+}
+
+/// Relay proxy port (must match `pelagos_vz::nat_relay::RELAY_PROXY_PORT`).
+const RELAY_PROXY_PORT: u16 = 17900;
+
+impl PortProxyManager {
+    fn new() -> Self {
+        Self {
+            proxies: HashMap::new(),
+        }
+    }
+
+    /// Apply a subscription event: start/stop proxies to match container state.
+    fn handle(&mut self, msg: &SubscriptionMsg) {
+        match msg {
+            SubscriptionMsg::Snapshot {
+                containers,
+                vm_running,
+                ..
+            } => {
+                if !vm_running {
+                    self.stop_all();
+                    return;
+                }
+                // Collect ports of currently-running containers.
+                let mut wanted: HashMap<u16, u16> = HashMap::new();
+                for c in containers {
+                    if c.status == "running" {
+                        for spec in &c.ports {
+                            if let Some(pf) = parse_port_spec(spec) {
+                                wanted.insert(pf.0, pf.1);
+
+                            }
+                        }
+                    }
+                }
+                // Stop proxies no longer wanted.
+                let stale: Vec<u16> = self
+                    .proxies
+                    .keys()
+                    .filter(|p| !wanted.contains_key(p))
+                    .copied()
+                    .collect();
+                for port in stale {
+                    self.stop_proxy(port);
+                }
+                // Start new proxies.
+                for (host_port, container_port) in wanted {
+                    self.start(host_port, container_port);
+                }
+            }
+            SubscriptionMsg::ContainerStarted { container } => {
+                for spec in &container.ports {
+                    if let Some(pf) = parse_port_spec(spec) {
+                        self.start(pf.0, pf.1);
+                    }
+                }
+            }
+            SubscriptionMsg::ContainerExited { .. } => {
+                // The next Snapshot will clean up stale proxies.
+            }
+            SubscriptionMsg::Disconnected => {
+                self.stop_all();
+            }
+            _ => {}
+        }
+    }
+
+    fn start(&mut self, host_port: u16, container_port: u16) {
+        if self.proxies.contains_key(&host_port) {
+            return;
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+        self.proxies.insert(host_port, stop.clone());
+        std::thread::Builder::new()
+            .name(format!("port-proxy-{}", host_port))
+            .spawn(move || {
+                port_forward_loop_stoppable(host_port, container_port, stop);
+            })
+            .expect("spawn port proxy");
+        log::info!("port proxy started: {}→{}", host_port, container_port);
+    }
+
+    fn stop_proxy(&mut self, host_port: u16) {
+        if let Some(stop) = self.proxies.remove(&host_port) {
+            stop.store(true, Ordering::Relaxed);
+            log::info!("port proxy stopped: {}", host_port);
+        }
+    }
+
+    fn stop_all(&mut self) {
+        for (_, stop) in self.proxies.drain() {
+            stop.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Parse `"host:container"` or `"port"` into `(host_port, container_port)`.
+fn parse_port_spec(spec: &str) -> Option<(u16, u16)> {
+    let parts: Vec<&str> = spec.splitn(2, ':').collect();
+    if parts.len() == 2 {
+        let h = parts[0].parse::<u16>().ok()?;
+        let c = parts[1].parse::<u16>().ok()?;
+        Some((h, c))
+    } else {
+        let p = spec.parse::<u16>().ok()?;
+        Some((p, p))
+    }
+}
+
+/// Accept TCP connections on `host_port`, relay each to `container_port` via
+/// the smoltcp NAT relay at `127.0.0.1:RELAY_PROXY_PORT`.  Returns when
+/// `stop` is set to true.
+fn port_forward_loop_stoppable(host_port: u16, container_port: u16, stop: Arc<AtomicBool>) {
+    use std::io::Write;
+
+    let listener = match TcpListener::bind(("0.0.0.0", host_port)) {
+        Ok(l) => l,
+        Err(e) => {
+            log::error!("port forward bind 0.0.0.0:{}: {}", host_port, e);
+            return;
+        }
+    };
+    listener
+        .set_nonblocking(true)
+        .expect("set_nonblocking on port forward listener");
+
+    log::info!(
+        "port forward active: 0.0.0.0:{} → VM:{} (relay :{})",
+        host_port,
+        container_port,
+        RELAY_PROXY_PORT
+    );
+
+    while !stop.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((client, _)) => {
+                // Client connections must be blocking for io::copy.
+                client.set_nonblocking(false).ok();
+                let stop2 = stop.clone();
+                std::thread::Builder::new()
+                    .name(format!("port-fwd-conn-{}", host_port))
+                    .spawn(move || {
+                        let relay_addr =
+                            std::net::SocketAddr::from(([127, 0, 0, 1], RELAY_PROXY_PORT));
+                        let mut server = match TcpStream::connect_timeout(
+                            &relay_addr,
+                            Duration::from_secs(5),
+                        ) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                log::warn!(
+                                    "port forward connect relay:{}: {}",
+                                    RELAY_PROXY_PORT,
+                                    e
+                                );
+                                return;
+                            }
+                        };
+                        if server.write_all(&container_port.to_be_bytes()).is_err() {
+                            return;
+                        }
+                        drop(stop2);
+                        tcp_proxy_tui(client, server);
+                    })
+                    .ok();
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                log::warn!("port forward accept: {}", e);
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+    log::info!("port forward loop exited: 0.0.0.0:{}", host_port);
+}
+
+fn tcp_proxy_tui(client: TcpStream, server: TcpStream) {
+    let mut client_read = client;
+    let mut server_read = server;
+    let mut client_write = client_read.try_clone().expect("tcp clone");
+    let mut server_write = server_read.try_clone().expect("tcp clone");
+
+    let t1 = std::thread::spawn(move || {
+        let _ = std::io::copy(&mut client_read, &mut server_write);
+        let _ = server_write.shutdown(std::net::Shutdown::Write);
+    });
+    let t2 = std::thread::spawn(move || {
+        let _ = std::io::copy(&mut server_read, &mut client_write);
+        let _ = client_write.shutdown(std::net::Shutdown::Write);
+    });
+    let _ = t1.join();
+    let _ = t2.join();
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -17,11 +17,8 @@ mod app;
 mod runner;
 mod ui;
 
-use std::collections::HashMap;
 use std::io;
-use std::net::{TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::mpsc;
 use std::time::Duration;
 
 use crossterm::{
@@ -243,16 +240,12 @@ fn run_loop(
     sub_rx: mpsc::Receiver<SubscriptionMsg>,
 ) -> anyhow::Result<()> {
     let tick = Duration::from_millis(250);
-    let mut proxy_mgr = PortProxyManager::new();
 
     loop {
         // Drain all pending subscription events (non-blocking).
         loop {
             match sub_rx.try_recv() {
-                Ok(msg) => {
-                    proxy_mgr.handle(&msg);
-                    app.apply_subscription(msg);
-                }
+                Ok(msg) => app.apply_subscription(msg),
                 Err(mpsc::TryRecvError::Empty) => break,
                 Err(mpsc::TryRecvError::Disconnected) => break,
             }
@@ -319,7 +312,6 @@ fn run_loop(
         }
 
         if app.should_quit {
-            proxy_mgr.stop_all();
             break;
         }
     }
@@ -544,216 +536,6 @@ fn send_status(tx: &Option<mpsc::SyncSender<String>>, msg: String) {
     if let Some(tx) = tx {
         let _ = tx.try_send(msg);
     }
-}
-
-// ---------------------------------------------------------------------------
-// Port proxy manager (TUI lifecycle)
-// ---------------------------------------------------------------------------
-
-/// Manages host-side TCP proxies for container port mappings.
-///
-/// Proxies are started when a container with ports appears in the subscription
-/// stream and stopped when that container exits or is removed.  Each proxy
-/// uses a non-blocking accept loop so it can be signalled to stop without
-/// blocking the caller.
-struct PortProxyManager {
-    /// host_port → stop token
-    proxies: HashMap<u16, Arc<AtomicBool>>,
-}
-
-/// Relay proxy port (must match `pelagos_vz::nat_relay::RELAY_PROXY_PORT`).
-const RELAY_PROXY_PORT: u16 = 17900;
-
-impl PortProxyManager {
-    fn new() -> Self {
-        Self {
-            proxies: HashMap::new(),
-        }
-    }
-
-    /// Apply a subscription event: start/stop proxies to match container state.
-    fn handle(&mut self, msg: &SubscriptionMsg) {
-        match msg {
-            SubscriptionMsg::Snapshot {
-                containers,
-                vm_running,
-                ..
-            } => {
-                if !vm_running {
-                    self.stop_all();
-                    return;
-                }
-                // Collect ports of currently-running containers.
-                let mut wanted: HashMap<u16, u16> = HashMap::new();
-                for c in containers {
-                    if c.status == "running" {
-                        for spec in &c.ports {
-                            if let Some(pf) = parse_port_spec(spec) {
-                                wanted.insert(pf.0, pf.1);
-
-                            }
-                        }
-                    }
-                }
-                // Stop proxies no longer wanted.
-                let stale: Vec<u16> = self
-                    .proxies
-                    .keys()
-                    .filter(|p| !wanted.contains_key(p))
-                    .copied()
-                    .collect();
-                for port in stale {
-                    self.stop_proxy(port);
-                }
-                // Start new proxies.
-                for (host_port, container_port) in wanted {
-                    self.start(host_port, container_port);
-                }
-            }
-            SubscriptionMsg::ContainerStarted { container } => {
-                for spec in &container.ports {
-                    if let Some(pf) = parse_port_spec(spec) {
-                        self.start(pf.0, pf.1);
-                    }
-                }
-            }
-            SubscriptionMsg::ContainerExited { .. } => {
-                // The next Snapshot will clean up stale proxies.
-            }
-            SubscriptionMsg::Disconnected => {
-                self.stop_all();
-            }
-            _ => {}
-        }
-    }
-
-    fn start(&mut self, host_port: u16, container_port: u16) {
-        if self.proxies.contains_key(&host_port) {
-            return;
-        }
-        let stop = Arc::new(AtomicBool::new(false));
-        self.proxies.insert(host_port, stop.clone());
-        std::thread::Builder::new()
-            .name(format!("port-proxy-{}", host_port))
-            .spawn(move || {
-                port_forward_loop_stoppable(host_port, container_port, stop);
-            })
-            .expect("spawn port proxy");
-        log::info!("port proxy started: {}→{}", host_port, container_port);
-    }
-
-    fn stop_proxy(&mut self, host_port: u16) {
-        if let Some(stop) = self.proxies.remove(&host_port) {
-            stop.store(true, Ordering::Relaxed);
-            log::info!("port proxy stopped: {}", host_port);
-        }
-    }
-
-    fn stop_all(&mut self) {
-        for (_, stop) in self.proxies.drain() {
-            stop.store(true, Ordering::Relaxed);
-        }
-    }
-}
-
-/// Parse `"host:container"` or `"port"` into `(host_port, container_port)`.
-fn parse_port_spec(spec: &str) -> Option<(u16, u16)> {
-    let parts: Vec<&str> = spec.splitn(2, ':').collect();
-    if parts.len() == 2 {
-        let h = parts[0].parse::<u16>().ok()?;
-        let c = parts[1].parse::<u16>().ok()?;
-        Some((h, c))
-    } else {
-        let p = spec.parse::<u16>().ok()?;
-        Some((p, p))
-    }
-}
-
-/// Accept TCP connections on `host_port`, relay each to `container_port` via
-/// the smoltcp NAT relay at `127.0.0.1:RELAY_PROXY_PORT`.  Returns when
-/// `stop` is set to true.
-fn port_forward_loop_stoppable(host_port: u16, container_port: u16, stop: Arc<AtomicBool>) {
-    use std::io::Write;
-
-    let listener = match TcpListener::bind(("0.0.0.0", host_port)) {
-        Ok(l) => l,
-        Err(e) => {
-            log::error!("port forward bind 0.0.0.0:{}: {}", host_port, e);
-            return;
-        }
-    };
-    listener
-        .set_nonblocking(true)
-        .expect("set_nonblocking on port forward listener");
-
-    log::info!(
-        "port forward active: 0.0.0.0:{} → VM:{} (relay :{})",
-        host_port,
-        container_port,
-        RELAY_PROXY_PORT
-    );
-
-    while !stop.load(Ordering::Relaxed) {
-        match listener.accept() {
-            Ok((client, _)) => {
-                // Client connections must be blocking for io::copy.
-                client.set_nonblocking(false).ok();
-                let stop2 = stop.clone();
-                std::thread::Builder::new()
-                    .name(format!("port-fwd-conn-{}", host_port))
-                    .spawn(move || {
-                        let relay_addr =
-                            std::net::SocketAddr::from(([127, 0, 0, 1], RELAY_PROXY_PORT));
-                        let mut server = match TcpStream::connect_timeout(
-                            &relay_addr,
-                            Duration::from_secs(5),
-                        ) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                log::warn!(
-                                    "port forward connect relay:{}: {}",
-                                    RELAY_PROXY_PORT,
-                                    e
-                                );
-                                return;
-                            }
-                        };
-                        if server.write_all(&container_port.to_be_bytes()).is_err() {
-                            return;
-                        }
-                        drop(stop2);
-                        tcp_proxy_tui(client, server);
-                    })
-                    .ok();
-            }
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                std::thread::sleep(Duration::from_millis(50));
-            }
-            Err(e) => {
-                log::warn!("port forward accept: {}", e);
-                std::thread::sleep(Duration::from_millis(100));
-            }
-        }
-    }
-    log::info!("port forward loop exited: 0.0.0.0:{}", host_port);
-}
-
-fn tcp_proxy_tui(client: TcpStream, server: TcpStream) {
-    let mut client_read = client;
-    let mut server_read = server;
-    let mut client_write = client_read.try_clone().expect("tcp clone");
-    let mut server_write = server_read.try_clone().expect("tcp clone");
-
-    let t1 = std::thread::spawn(move || {
-        let _ = std::io::copy(&mut client_read, &mut server_write);
-        let _ = server_write.shutdown(std::net::Shutdown::Write);
-    });
-    let t2 = std::thread::spawn(move || {
-        let _ = std::io::copy(&mut server_read, &mut client_write);
-        let _ = client_write.shutdown(std::net::Shutdown::Write);
-    });
-    let _ = t1.join();
-    let _ = t2.join();
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-tui/src/runner.rs
+++ b/pelagos-tui/src/runner.rs
@@ -29,6 +29,9 @@ pub struct Container {
     #[serde(default)]
     #[allow(dead_code)]
     pub command: Vec<String>,
+    /// Port mappings from `pelagos run -p HOST:CONTAINER` (e.g. `["8080:80"]`).
+    #[serde(default)]
+    pub ports: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -48,6 +48,7 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
         Cell::from("NAME").style(Style::default().add_modifier(Modifier::BOLD)),
         Cell::from("STATUS").style(Style::default().add_modifier(Modifier::BOLD)),
         Cell::from("IMAGE").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("PORTS").style(Style::default().add_modifier(Modifier::BOLD)),
         Cell::from("UPTIME").style(Style::default().add_modifier(Modifier::BOLD)),
     ])
     .height(1);
@@ -74,10 +75,19 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
                 Cell::from(c.name.as_str())
             };
 
+            // Format ports as "8080→80, 443→443".
+            let ports_str = c
+                .ports
+                .iter()
+                .map(|s| s.replacen(':', "→", 1))
+                .collect::<Vec<_>>()
+                .join(", ");
+
             Row::new(vec![
                 name_cell,
                 Cell::from(c.status.as_str()).style(status_style),
                 Cell::from(c.rootfs.as_str()),
+                Cell::from(ports_str).style(Style::default().fg(Color::Cyan)),
                 Cell::from(uptime),
             ])
             .height(1)
@@ -99,10 +109,11 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
     let table = Table::new(
         rows,
         [
-            Constraint::Percentage(25), // NAME
-            Constraint::Percentage(12), // STATUS
-            Constraint::Percentage(43), // IMAGE
-            Constraint::Percentage(20), // UPTIME
+            Constraint::Percentage(23), // NAME
+            Constraint::Percentage(10), // STATUS
+            Constraint::Percentage(37), // IMAGE
+            Constraint::Percentage(15), // PORTS
+            Constraint::Percentage(15), // UPTIME
         ],
     )
     .header(header)

--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -36,7 +36,7 @@
 #   bash scripts/vm-restart.sh --profile <name>
 #   pelagos --profile <name> vm ssh
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -185,15 +185,18 @@ echo "ok"
 echo ""
 
 # ---------------------------------------------------------------------------
-# Write the provisioning script to the volumes dir (virtiofs, small file only).
-# The script itself is tiny; only the build.img I/O avoids virtiofs.
+# Write the provisioning script to a local temp file.
+# It is executed inside the Alpine VM via SSH stdin, avoiding any virtiofs
+# dependency (virtiofs.ko is not loaded until after the first successful
+# provisioning run extracts it from the Ubuntu modules package).
 # ---------------------------------------------------------------------------
 
 PUB_KEY_CONTENT="$(cat "${SSH_KEY_FILE}.pub")"
 
-mkdir -p "$ALPINE_VOLUMES_DIR"
+PROVISION_SCRIPT="$(mktemp /tmp/provision-build.XXXXXX.sh)"
+trap 'rm -f "$PROVISION_SCRIPT"' EXIT
 
-cat > "$ALPINE_VOLUMES_DIR/provision-build.sh" << OUTER_EOF
+cat > "$PROVISION_SCRIPT" << OUTER_EOF
 #!/bin/sh
 # Provisioning script — runs inside the Alpine VM as root.
 # build.img is presented as /dev/vdb (virtio-blk); no loop device required.
@@ -262,7 +265,18 @@ chroot "\$MNT" env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-instal
     build-essential git curl wget ca-certificates \
     iproute2 nftables openssh-server sudo \
     systemd systemd-sysv systemd-timesyncd \
-    pkg-config libssl-dev
+    pkg-config libssl-dev \
+    initramfs-tools \
+    linux-image-6.8.0-106-generic linux-modules-6.8.0-106-generic
+
+# Explicitly generate the initrd — apt's post-install hook is blocked by the
+# flash-kernel removal above, so initramfs-tools never runs automatically.
+# The bind-mounts (proc/sys/dev) are already in place, so this works cleanly.
+KVER_PKG=\$(chroot "\$MNT" dpkg-query -W -f '\${Version}\n' linux-image-6.8.0-106-generic 2>/dev/null | head -1)
+if [ -n "\$KVER_PKG" ] && [ ! -f "\$MNT/boot/initrd.img-6.8.0-106-generic" ]; then
+    echo "[provision] generating initrd for 6.8.0-106-generic"
+    chroot "\$MNT" update-initramfs -c -k 6.8.0-106-generic
+fi
 
 # ---- networking: systemd-networkd with static IP ----
 
@@ -372,48 +386,59 @@ ln -sf /lib/systemd/system/systemd-timesyncd.service \
 echo "[provision] extracting Ubuntu kernel, initrd, and modules for host AVF boot"
 KVER=\$(ls "\$MNT/boot/vmlinuz-"* 2>/dev/null | sort -V | tail -1 | sed 's|.*/vmlinuz-||')
 if [ -n "\$KVER" ]; then
-    zcat "\$MNT/boot/vmlinuz-\$KVER" > /var/lib/pelagos/volumes/ubuntu-vmlinuz
-    cp "\$MNT/boot/initrd.img-\$KVER" /var/lib/pelagos/volumes/ubuntu-initrd.img
-    echo "  kernel: vmlinuz-\$KVER (\$(du -sh /var/lib/pelagos/volumes/ubuntu-vmlinuz | cut -f1) decompressed)"
-    echo "  initrd: initrd.img-\$KVER (\$(du -sh /var/lib/pelagos/volumes/ubuntu-initrd.img | cut -f1))"
+    # Write outputs to a local Alpine path — NOT the virtiofs volumes dir.
+    # virtiofs.ko is not yet loaded on a fresh provisioning run; the outer
+    # script pulls these files back via SSH after this script completes.
+    OUTDIR=/root/build-outputs
+    mkdir -p "\$OUTDIR"
+
+    zcat "\$MNT/boot/vmlinuz-\$KVER" > "\$OUTDIR/ubuntu-vmlinuz"
+    cp "\$MNT/boot/initrd.img-\$KVER" "\$OUTDIR/ubuntu-initrd.img"
+    echo "  kernel: vmlinuz-\$KVER (\$(du -sh \$OUTDIR/ubuntu-vmlinuz | cut -f1) decompressed)"
+    echo "  initrd: initrd.img-\$KVER (\$(du -sh \$OUTDIR/ubuntu-initrd.img | cut -f1))"
 
     # Extract kernel modules that are =m in Ubuntu 6.8 HWE and are required
-    # by the container VM initramfs.  All virtio drivers are =y (built-in).
+    # by the container VM initramfs.  All core virtio drivers are =y (built-in).
     #
     # Modules extracted:
     #   vsock          — pelagos-guest ↔ host comms
     #   overlayfs      — container layer stacking
+    #   virtiofs       — AVF host directory sharing (needed for vm volumes)
     #   bridge + deps  — pelagos bridge networking (NetworkMode::Bridge, -p flag)
     #   nftables       — port-forward DNAT rules (pelagos network.rs)
     MODDIR="\$MNT/lib/modules/\$KVER/kernel"
-    VOLS=/var/lib/pelagos/volumes
     mkdir -p \
-        "\$VOLS/ubuntu-modules/net/vmw_vsock" \
-        "\$VOLS/ubuntu-modules/fs/overlayfs" \
-        "\$VOLS/ubuntu-modules/net/bridge" \
-        "\$VOLS/ubuntu-modules/net/802" \
-        "\$VOLS/ubuntu-modules/net/llc" \
-        "\$VOLS/ubuntu-modules/net/netfilter"
+        "\$OUTDIR/ubuntu-modules/net/vmw_vsock" \
+        "\$OUTDIR/ubuntu-modules/fs/overlayfs" \
+        "\$OUTDIR/ubuntu-modules/fs/fuse" \
+        "\$OUTDIR/ubuntu-modules/net/bridge" \
+        "\$OUTDIR/ubuntu-modules/net/802" \
+        "\$OUTDIR/ubuntu-modules/net/llc" \
+        "\$OUTDIR/ubuntu-modules/net/netfilter"
     # vsock
     for ko in \
         "\$MODDIR/net/vmw_vsock/vsock.ko" \
         "\$MODDIR/net/vmw_vsock/vmw_vsock_virtio_transport_common.ko" \
         "\$MODDIR/net/vmw_vsock/vmw_vsock_virtio_transport.ko"
     do
-        [ -f "\$ko" ] && cp "\$ko" "\$VOLS/ubuntu-modules/net/vmw_vsock/" \
+        [ -f "\$ko" ] && cp "\$ko" "\$OUTDIR/ubuntu-modules/net/vmw_vsock/" \
             && echo "  module: \$(basename \$ko)"
     done
     # overlayfs
     [ -f "\$MODDIR/fs/overlayfs/overlay.ko" ] \
-        && cp "\$MODDIR/fs/overlayfs/overlay.ko" "\$VOLS/ubuntu-modules/fs/overlayfs/" \
+        && cp "\$MODDIR/fs/overlayfs/overlay.ko" "\$OUTDIR/ubuntu-modules/fs/overlayfs/" \
         && echo "  module: overlay.ko"
+    # virtiofs (AVF host directory sharing — fs/fuse/virtiofs.ko in Ubuntu 6.8)
+    [ -f "\$MODDIR/fs/fuse/virtiofs.ko" ] \
+        && cp "\$MODDIR/fs/fuse/virtiofs.ko" "\$OUTDIR/ubuntu-modules/fs/fuse/" \
+        && echo "  module: virtiofs.ko"
     # bridge + dependency chain (llc → stp → bridge)
     for ko in \
         "\$MODDIR/net/llc/llc.ko" \
         "\$MODDIR/net/802/stp.ko" \
         "\$MODDIR/net/bridge/bridge.ko"
     do
-        dir="\$VOLS/ubuntu-modules/\$(dirname \${ko#\$MODDIR/})"
+        dir="\$OUTDIR/ubuntu-modules/\$(dirname \${ko#\$MODDIR/})"
         mkdir -p "\$dir"
         [ -f "\$ko" ] && cp "\$ko" "\$dir/" && echo "  module: \$(basename \$ko)"
     done
@@ -422,19 +447,46 @@ if [ -n "\$KVER" ]; then
         "\$MODDIR/net/netfilter/nfnetlink.ko" \
         "\$MODDIR/net/netfilter/nf_tables.ko" \
         "\$MODDIR/net/netfilter/nf_conntrack.ko" \
-        "\$MODDIR/net/netfilter/nf_nat.ko"
+        "\$MODDIR/net/netfilter/nf_nat.ko" \
+        "\$MODDIR/net/netfilter/nft_nat.ko" \
+        "\$MODDIR/net/netfilter/nft_chain_nat.ko"
     do
-        dir="\$VOLS/ubuntu-modules/\$(dirname \${ko#\$MODDIR/})"
+        dir="\$OUTDIR/ubuntu-modules/\$(dirname \${ko#\$MODDIR/})"
+        mkdir -p "\$dir"
+        [ -f "\$ko" ] && cp "\$ko" "\$dir/" && echo "  module: \$(basename \$ko)"
+    done
+    # veth — virtual ethernet pairs for container bridge networking
+    for ko in \
+        "\$MODDIR/drivers/net/veth.ko"
+    do
+        dir="\$OUTDIR/ubuntu-modules/\$(dirname \${ko#\$MODDIR/})"
+        mkdir -p "\$dir"
+        [ -f "\$ko" ] && cp "\$ko" "\$dir/" && echo "  module: \$(basename \$ko)"
+    done
+    # libcrc32c — required by nf_conntrack (dependency for nf_nat DNAT rules)
+    for ko in \
+        "\$MODDIR/lib/libcrc32c.ko"
+    do
+        dir="\$OUTDIR/ubuntu-modules/\$(dirname \${ko#\$MODDIR/})"
+        mkdir -p "\$dir"
+        [ -f "\$ko" ] && cp "\$ko" "\$dir/" && echo "  module: \$(basename \$ko)"
+    done
+    # nf_defrag_ipv4/ipv6 — required by nf_conntrack (missing these causes symbol errors)
+    for ko in \
+        "\$MODDIR/net/ipv4/netfilter/nf_defrag_ipv4.ko" \
+        "\$MODDIR/net/ipv6/netfilter/nf_defrag_ipv6.ko"
+    do
+        dir="\$OUTDIR/ubuntu-modules/\$(dirname \${ko#\$MODDIR/})"
         mkdir -p "\$dir"
         [ -f "\$ko" ] && cp "\$ko" "\$dir/" && echo "  module: \$(basename \$ko)"
     done
     # modules.dep so modprobe can resolve the full dependency chain.
-    cp "\$MNT/lib/modules/\$KVER/modules.dep" "\$VOLS/ubuntu-modules/" 2>/dev/null || true
-    cp "\$MNT/lib/modules/\$KVER/modules.dep.bin" "\$VOLS/ubuntu-modules/" 2>/dev/null || true
+    cp "\$MNT/lib/modules/\$KVER/modules.dep" "\$OUTDIR/ubuntu-modules/" 2>/dev/null || true
+    cp "\$MNT/lib/modules/\$KVER/modules.dep.bin" "\$OUTDIR/ubuntu-modules/" 2>/dev/null || true
     # Write kver.txt so build-vm-image.sh can detect the kernel version without
     # parsing modules.dep (which uses relative paths, not absolute paths).
-    echo "\$KVER" > "\$VOLS/ubuntu-modules/kver.txt"
-    echo "  stored Ubuntu modules in volumes/ubuntu-modules/ (kver: \$KVER)"
+    echo "\$KVER" > "\$OUTDIR/ubuntu-modules/kver.txt"
+    echo "  stored Ubuntu modules in /root/build-outputs/ubuntu-modules/ (kver: \$KVER)"
 else
     echo "WARNING: no vmlinuz found in \$MNT/boot — cannot extract kernel" >&2
 fi
@@ -453,12 +505,13 @@ rmdir  "\$MNT" 2>/dev/null || true
 echo "[provision] done"
 OUTER_EOF
 
-chmod +x "$ALPINE_VOLUMES_DIR/provision-build.sh"
-echo "--- wrote provisioning script ---"
+chmod +x "$PROVISION_SCRIPT"
+echo "--- wrote provisioning script (local, stdin delivery) ---"
 echo ""
 
 # ---------------------------------------------------------------------------
-# Execute the provisioning script inside the Alpine VM.
+# Execute the provisioning script inside the Alpine VM via SSH stdin.
+# This avoids any virtiofs dependency: the script is piped directly to sh.
 # ---------------------------------------------------------------------------
 
 echo "--- running provisioning script in Alpine VM ---"
@@ -466,13 +519,38 @@ echo "    waiting for VM SSH to become available (~30s cold start)..."
 echo "    once connected, [provision] log lines will stream in real-time"
 echo ""
 
-pelagos_provision vm ssh -- sh /var/lib/pelagos/volumes/provision-build.sh
+pelagos_provision vm ssh -- "sh -s" < "$PROVISION_SCRIPT"
 
 echo ""
 echo "--- provisioning complete ---"
 
-# Clean up the provisioning script from the volumes dir.
-rm -f "$ALPINE_VOLUMES_DIR/provision-build.sh"
+# ---------------------------------------------------------------------------
+# Pull build outputs back to the host via SSH (no virtiofs needed).
+# The provisioning script wrote them to /root/build-outputs/ on the Alpine disk.
+# ---------------------------------------------------------------------------
+
+echo "--- pulling build outputs from Alpine VM via SSH ---"
+
+UBUNTU_VMLINUZ="$REPO_ROOT/out/ubuntu-vmlinuz"
+UBUNTU_INITRD="$REPO_ROOT/out/ubuntu-initrd.img"
+UBUNTU_MODULES_DST="$REPO_ROOT/out/ubuntu-modules"
+
+if pelagos_provision vm ssh -- "test -f /root/build-outputs/ubuntu-vmlinuz" 2>/dev/null; then
+    echo "  pulling ubuntu-vmlinuz..."
+    pelagos_provision vm ssh -- "cat /root/build-outputs/ubuntu-vmlinuz" > "$UBUNTU_VMLINUZ"
+    echo "  pulling ubuntu-initrd.img..."
+    pelagos_provision vm ssh -- "cat /root/build-outputs/ubuntu-initrd.img" > "$UBUNTU_INITRD"
+    echo "  pulling ubuntu-modules/ (tar)..."
+    rm -rf "$UBUNTU_MODULES_DST"
+    mkdir -p "$UBUNTU_MODULES_DST"
+    pelagos_provision vm ssh -- "tar -C /root/build-outputs/ubuntu-modules -czf - ." \
+        | tar -C "$UBUNTU_MODULES_DST" -xzf -
+    echo "  pulled ubuntu-vmlinuz  ($(du -sh "$UBUNTU_VMLINUZ" | cut -f1))"
+    echo "  pulled ubuntu-initrd   ($(du -sh "$UBUNTU_INITRD"  | cut -f1))"
+    echo "  pulled ubuntu-modules/ ($(find "$UBUNTU_MODULES_DST" -name "*.ko" | wc -l) modules)"
+else
+    echo "WARNING: /root/build-outputs/ubuntu-vmlinuz not found — kernel extraction may have failed" >&2
+fi
 
 # ---------------------------------------------------------------------------
 # Stop the provisioning VM and restart the normal Alpine VM.
@@ -499,28 +577,15 @@ echo ""
 # Write vm.conf for the build profile.
 # ---------------------------------------------------------------------------
 
-# Move the Ubuntu kernel and initrd from the Alpine volumes dir to out/.
-# These were extracted from the provisioned build.img by the provisioning
-# script and staged on the virtiofs share.
-UBUNTU_VMLINUZ="$REPO_ROOT/out/ubuntu-vmlinuz"
-UBUNTU_INITRD="$REPO_ROOT/out/ubuntu-initrd.img"
-if [[ -f "$ALPINE_VOLUMES_DIR/ubuntu-vmlinuz" ]]; then
-    mv "$ALPINE_VOLUMES_DIR/ubuntu-vmlinuz"   "$UBUNTU_VMLINUZ"
-    mv "$ALPINE_VOLUMES_DIR/ubuntu-initrd.img" "$UBUNTU_INITRD"
-    echo "--- extracted Ubuntu kernel to out/ubuntu-vmlinuz ($(du -sh "$UBUNTU_VMLINUZ" | cut -f1)) ---"
-    echo "--- extracted Ubuntu initrd  to out/ubuntu-initrd.img ($(du -sh "$UBUNTU_INITRD" | cut -f1)) ---"
-    # Move kernel modules needed by the container VM initramfs.
-    UBUNTU_MODULES_SRC="$ALPINE_VOLUMES_DIR/ubuntu-modules"
-    UBUNTU_MODULES_DST="$REPO_ROOT/out/ubuntu-modules"
-    if [[ -d "$UBUNTU_MODULES_SRC" ]]; then
-        rm -rf "$UBUNTU_MODULES_DST"
-        mv "$UBUNTU_MODULES_SRC" "$UBUNTU_MODULES_DST"
-        echo "--- extracted Ubuntu kernel modules to out/ubuntu-modules/ ---"
-    fi
-else
-    echo "ERROR: ubuntu-vmlinuz not found in Alpine volumes dir — kernel extraction failed" >&2
+# ubuntu-vmlinuz, ubuntu-initrd.img, and ubuntu-modules were already pulled
+# back from the provisioning VM via SSH above.  Verify they are present.
+if [[ ! -f "$UBUNTU_VMLINUZ" ]]; then
+    echo "ERROR: out/ubuntu-vmlinuz not found — kernel extraction failed" >&2
     exit 1
 fi
+echo "--- Ubuntu kernel:  out/ubuntu-vmlinuz  ($(du -sh "$UBUNTU_VMLINUZ" | cut -f1)) ---"
+echo "--- Ubuntu initrd:  out/ubuntu-initrd.img ($(du -sh "$UBUNTU_INITRD" | cut -f1)) ---"
+echo "--- Ubuntu modules: out/ubuntu-modules/ ($(find "$UBUNTU_MODULES_DST" -name "*.ko" | wc -l) modules) ---"
 echo ""
 
 echo "--- writing vm.conf for profile '$PROFILE' ---"

--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -377,13 +377,24 @@ if [ -n "\$KVER" ]; then
     echo "  kernel: vmlinuz-\$KVER (\$(du -sh /var/lib/pelagos/volumes/ubuntu-vmlinuz | cut -f1) decompressed)"
     echo "  initrd: initrd.img-\$KVER (\$(du -sh /var/lib/pelagos/volumes/ubuntu-initrd.img | cut -f1))"
 
-    # Extract the two kernel modules that are =m in Ubuntu 6.8 HWE and are
-    # required by the container VM initramfs: vsock (pelagos-guest comms) and
-    # overlayfs (container layer stacking).  All other virtio drivers are =y
-    # (built-in) so no modules are needed for them.
+    # Extract kernel modules that are =m in Ubuntu 6.8 HWE and are required
+    # by the container VM initramfs.  All virtio drivers are =y (built-in).
+    #
+    # Modules extracted:
+    #   vsock          — pelagos-guest ↔ host comms
+    #   overlayfs      — container layer stacking
+    #   bridge + deps  — pelagos bridge networking (NetworkMode::Bridge, -p flag)
+    #   nftables       — port-forward DNAT rules (pelagos network.rs)
     MODDIR="\$MNT/lib/modules/\$KVER/kernel"
     VOLS=/var/lib/pelagos/volumes
-    mkdir -p "\$VOLS/ubuntu-modules/net/vmw_vsock" "\$VOLS/ubuntu-modules/fs/overlayfs"
+    mkdir -p \
+        "\$VOLS/ubuntu-modules/net/vmw_vsock" \
+        "\$VOLS/ubuntu-modules/fs/overlayfs" \
+        "\$VOLS/ubuntu-modules/net/bridge" \
+        "\$VOLS/ubuntu-modules/net/802" \
+        "\$VOLS/ubuntu-modules/net/llc" \
+        "\$VOLS/ubuntu-modules/net/netfilter"
+    # vsock
     for ko in \
         "\$MODDIR/net/vmw_vsock/vsock.ko" \
         "\$MODDIR/net/vmw_vsock/vmw_vsock_virtio_transport_common.ko" \
@@ -392,10 +403,32 @@ if [ -n "\$KVER" ]; then
         [ -f "\$ko" ] && cp "\$ko" "\$VOLS/ubuntu-modules/net/vmw_vsock/" \
             && echo "  module: \$(basename \$ko)"
     done
+    # overlayfs
     [ -f "\$MODDIR/fs/overlayfs/overlay.ko" ] \
         && cp "\$MODDIR/fs/overlayfs/overlay.ko" "\$VOLS/ubuntu-modules/fs/overlayfs/" \
         && echo "  module: overlay.ko"
-    # Also copy modules.dep so modprobe can resolve the vsock dependency chain.
+    # bridge + dependency chain (llc → stp → bridge)
+    for ko in \
+        "\$MODDIR/net/llc/llc.ko" \
+        "\$MODDIR/net/802/stp.ko" \
+        "\$MODDIR/net/bridge/bridge.ko"
+    do
+        dir="\$VOLS/ubuntu-modules/\$(dirname \${ko#\$MODDIR/})"
+        mkdir -p "\$dir"
+        [ -f "\$ko" ] && cp "\$ko" "\$dir/" && echo "  module: \$(basename \$ko)"
+    done
+    # nftables / netfilter (required for port-forward DNAT rules)
+    for ko in \
+        "\$MODDIR/net/netfilter/nfnetlink.ko" \
+        "\$MODDIR/net/netfilter/nf_tables.ko" \
+        "\$MODDIR/net/netfilter/nf_conntrack.ko" \
+        "\$MODDIR/net/netfilter/nf_nat.ko"
+    do
+        dir="\$VOLS/ubuntu-modules/\$(dirname \${ko#\$MODDIR/})"
+        mkdir -p "\$dir"
+        [ -f "\$ko" ] && cp "\$ko" "\$dir/" && echo "  module: \$(basename \$ko)"
+    done
+    # modules.dep so modprobe can resolve the full dependency chain.
     cp "\$MNT/lib/modules/\$KVER/modules.dep" "\$VOLS/ubuntu-modules/" 2>/dev/null || true
     cp "\$MNT/lib/modules/\$KVER/modules.dep.bin" "\$VOLS/ubuntu-modules/" 2>/dev/null || true
     # Write kver.txt so build-vm-image.sh can detect the kernel version without

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -397,8 +397,8 @@ fi
 
 # Detect which kernel version string to embed in the initramfs module tree.
 # If the Ubuntu 6.8 modules are available (produced by build-build-image.sh),
-# use their version and source vsock/overlay from there; all other virtio
-# drivers are built-in (=y) in Ubuntu 6.8 HWE and need no modules.
+# use their version and source vsock/overlay/bridge/nftables from there; all
+# virtio drivers are =y (built-in) in Ubuntu 6.8 HWE and need no modules.
 # On first-time setup (before build-build-image.sh), fall back to Alpine lts.
 USE_UBUNTU_MODULES=0
 if [[ -f "$UBUNTU_VMLINUZ" && -d "$UBUNTU_MODULES" ]]; then
@@ -460,12 +460,23 @@ if [ ! -f "$INITRAMFS_OUT" ] \
 
     if [[ "$USE_UBUNTU_MODULES" -eq 1 ]]; then
         # Ubuntu 6.8 HWE: virtio_net, virtio_blk, virtio_pci, ext4, tun, virtio_console
-        # are all CONFIG_xxx=y (built-in).  Only vsock and overlayfs are =m.
-        # Stage exactly those two from the Ubuntu module tree extracted by
+        # are all CONFIG_xxx=y (built-in).  Modules that are =m and required:
+        #   vsock        — pelagos-guest comms
+        #   overlayfs    — container layer stacking
+        #   bridge+deps  — pelagos bridge networking (NetworkMode::Bridge / -p)
+        #   nftables     — port-forward DNAT rules
+        # Stage all of the above from the Ubuntu module tree extracted by
         # build-build-image.sh; no Alpine modules needed.
-        mkdir -p \
-            "$INITRD_TMP/lib/modules/$KVER/kernel/net/vmw_vsock" \
-            "$INITRD_TMP/lib/modules/$KVER/kernel/fs/overlayfs"
+        for rel_dir in \
+            net/vmw_vsock \
+            fs/overlayfs \
+            net/llc \
+            net/802 \
+            net/bridge \
+            net/netfilter
+        do
+            mkdir -p "$INITRD_TMP/lib/modules/$KVER/kernel/$rel_dir"
+        done
         for ko in vsock.ko vmw_vsock_virtio_transport_common.ko vmw_vsock_virtio_transport.ko; do
             src="$UBUNTU_MODULES/net/vmw_vsock/$ko"
             if [ -f "$src" ]; then
@@ -482,7 +493,27 @@ if [ ! -f "$INITRAMFS_OUT" ] \
         else
             echo "  WARNING: overlay.ko not found in $UBUNTU_MODULES" >&2
         fi
-        # Use the Ubuntu modules.dep so modprobe resolves vsock dependencies correctly.
+        # bridge + nftables modules (optional — warn but don't abort if missing,
+        # since they are only absent on old ubuntu-modules trees built before #172)
+        for rel_ko in \
+            net/llc/llc.ko \
+            net/802/stp.ko \
+            net/bridge/bridge.ko \
+            net/netfilter/nfnetlink.ko \
+            net/netfilter/nf_tables.ko \
+            net/netfilter/nf_conntrack.ko \
+            net/netfilter/nf_nat.ko
+        do
+            src="$UBUNTU_MODULES/$rel_ko"
+            dst="$INITRD_TMP/lib/modules/$KVER/kernel/$rel_ko"
+            if [ -f "$src" ]; then
+                cp "$src" "$dst"
+                echo "  staged (Ubuntu) $(basename $rel_ko)"
+            else
+                echo "  INFO: $(basename $rel_ko) not in ubuntu-modules (rebuild with build-build-image.sh to enable bridge/nftables)" >&2
+            fi
+        done
+        # Use the Ubuntu modules.dep so modprobe resolves all dependency chains.
         cp "$UBUNTU_MODULES/modules.dep"     "$INITRD_TMP/lib/modules/$KVER/modules.dep"     2>/dev/null || true
         cp "$UBUNTU_MODULES/modules.dep.bin" "$INITRD_TMP/lib/modules/$KVER/modules.dep.bin" 2>/dev/null || true
         echo "  updated modules.dep from Ubuntu modules"
@@ -707,6 +738,16 @@ if busybox grep -q '^rootfs / rootfs' /proc/mounts 2>/dev/null; then
     modprobe tun                 2>/dev/null || true
     modprobe jbd2                2>/dev/null || true
     modprobe ext4                2>/dev/null || true
+    # Bridge networking + nftables for pelagos container networking (-p / bridge mode).
+    # These are =m in Ubuntu 6.8 HWE; loaded here so pelagos run works immediately
+    # after boot.  Silently skipped on old images that predate #172.
+    modprobe llc                 2>/dev/null || true
+    modprobe stp                 2>/dev/null || true
+    modprobe bridge              2>/dev/null || true
+    modprobe nfnetlink           2>/dev/null || true
+    modprobe nf_conntrack        2>/dev/null || true
+    modprobe nf_nat              2>/dev/null || true
+    modprobe nf_tables           2>/dev/null || true
     # Create /dev/net/tun device node.  The tun kernel module registers
     # the device (char major 10, minor 200) but does not create the node
     # automatically without udevd/mdev.  pasta requires /dev/net/tun to

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -96,6 +96,52 @@ LIBCOM_ERR_PKG="libcom_err-1.47.1-r1"
 LIBCOM_ERR_APK="$WORK/${LIBCOM_ERR_PKG}.apk"
 LIBCOM_ERR_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${LIBCOM_ERR_PKG}.apk"
 
+# iproute2-minimal: provides /sbin/ip — required by pelagos bridge networking (-p flag).
+IPROUTE2_MIN_PKG="iproute2-minimal-6.11.0-r0"
+IPROUTE2_MIN_APK="$WORK/${IPROUTE2_MIN_PKG}.apk"
+IPROUTE2_MIN_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${IPROUTE2_MIN_PKG}.apk"
+IP_BIN="$WORK/ip-bin"
+
+# nftables: provides /usr/sbin/nft — required for DNAT port-forward rules.
+NFTABLES_PKG="nftables-1.1.1-r0"
+NFTABLES_APK="$WORK/${NFTABLES_PKG}.apk"
+NFTABLES_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${NFTABLES_PKG}.apk"
+NFT_BIN="$WORK/nft-bin"
+
+# Shared library dependencies for ip and nft.
+# All paths are usr/lib/ inside the APK (Alpine 3.21+ moved libs there).
+LIBCAP2_PKG="libcap2-2.71-r0"
+LIBCAP2_APK="$WORK/${LIBCAP2_PKG}.apk"
+LIBCAP2_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${LIBCAP2_PKG}.apk"
+
+LIBELF_PKG="libelf-0.191-r0"
+LIBELF_APK="$WORK/${LIBELF_PKG}.apk"
+LIBELF_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${LIBELF_PKG}.apk"
+
+LIBMNL_PKG="libmnl-1.0.5-r2"
+LIBMNL_APK="$WORK/${LIBMNL_PKG}.apk"
+LIBMNL_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${LIBMNL_PKG}.apk"
+
+LIBNFTNL_PKG="libnftnl-1.2.8-r0"
+LIBNFTNL_APK="$WORK/${LIBNFTNL_PKG}.apk"
+LIBNFTNL_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${LIBNFTNL_PKG}.apk"
+
+LIBGMP_PKG="gmp-6.3.0-r2"
+LIBGMP_APK="$WORK/${LIBGMP_PKG}.apk"
+LIBGMP_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${LIBGMP_PKG}.apk"
+
+LIBJANSSON_PKG="jansson-2.14-r4"
+LIBJANSSON_APK="$WORK/${LIBJANSSON_PKG}.apk"
+LIBJANSSON_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${LIBJANSSON_PKG}.apk"
+
+LIBREADLINE_PKG="readline-8.2.13-r0"
+LIBREADLINE_APK="$WORK/${LIBREADLINE_PKG}.apk"
+LIBREADLINE_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${LIBREADLINE_PKG}.apk"
+
+LIBNCURSESW_PKG="libncursesw-6.5_p20241006-r3"
+LIBNCURSESW_APK="$WORK/${LIBNCURSESW_PKG}.apk"
+LIBNCURSESW_URL="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/${ALPINE_ARCH}/${LIBNCURSESW_PKG}.apk"
+
 # SSH key for 'pelagos vm ssh': generated once per user, baked into the initramfs.
 PELAGOS_STATE_DIR="$HOME/.local/share/pelagos"
 SSH_KEY_FILE="$PELAGOS_STATE_DIR/vm_key"
@@ -373,6 +419,69 @@ else
     echo "  (cached: e2fsprogs libs)"
 fi
 
+# ---------------------------------------------------------------------------
+echo "[5f/8] Downloading iproute2-minimal + nftables (for pelagos bridge networking)"
+# ---------------------------------------------------------------------------
+extract_bin() {
+    # Usage: extract_bin <apk> <src-path-in-apk> <dest>
+    local apk="$1" src="$2" dest="$3"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    bsdtar -xf "$apk" -C "$tmpdir" 2>/dev/null || true
+    if [ -f "$tmpdir/$src" ]; then
+        cp "$tmpdir/$src" "$dest"
+        chmod 755 "$dest"
+        rm -rf "$tmpdir"
+        return 0
+    fi
+    rm -rf "$tmpdir"
+    return 1
+}
+
+if [ ! -f "$IP_BIN" ]; then
+    [ ! -f "$IPROUTE2_MIN_APK" ] && curl -L --progress-bar -o "$IPROUTE2_MIN_APK" "$IPROUTE2_MIN_URL"
+    extract_bin "$IPROUTE2_MIN_APK" "sbin/ip" "$IP_BIN" || \
+        { echo "ERROR: ip not found in $IPROUTE2_MIN_APK" >&2; exit 1; }
+    echo "  Extracted ip binary"
+else
+    echo "  (cached: ip-bin)"
+fi
+
+if [ ! -f "$NFT_BIN" ]; then
+    [ ! -f "$NFTABLES_APK" ] && curl -L --progress-bar -o "$NFTABLES_APK" "$NFTABLES_URL"
+    extract_bin "$NFTABLES_APK" "usr/sbin/nft" "$NFT_BIN" || \
+        { echo "ERROR: nft not found in $NFTABLES_APK" >&2; exit 1; }
+    echo "  Extracted nft binary"
+else
+    echo "  (cached: nft-bin)"
+fi
+
+# Shared libs needed by ip and nft.
+# ip  needs: libcap.so.2, libelf.so.1, libmnl.so.0
+# nft needs: libmnl.so.0, libnftnl.so.11, libnftables.so.1, libgmp.so.10,
+#             libjansson.so.4, libreadline.so.8, libncursesw.so.6
+_fetch_so() {
+    local apk_file="$1" apk_url="$2" soname="$3"
+    local dest="$WORK/$soname"
+    if [ ! -f "$dest" ]; then
+        [ ! -f "$apk_file" ] && curl -L --progress-bar -o "$apk_file" "$apk_url"
+        extract_so "$apk_file" "$soname" "$dest" || \
+            { echo "ERROR: $soname not found in $apk_file" >&2; exit 1; }
+        echo "  Extracted $soname"
+    else
+        echo "  (cached: $soname)"
+    fi
+}
+_fetch_so "$LIBCAP2_APK"    "$LIBCAP2_URL"    "libcap.so.2"
+_fetch_so "$LIBELF_APK"     "$LIBELF_URL"     "libelf.so.1"
+_fetch_so "$LIBMNL_APK"     "$LIBMNL_URL"     "libmnl.so.0"
+_fetch_so "$LIBNFTNL_APK"   "$LIBNFTNL_URL"   "libnftnl.so.11"
+_fetch_so "$LIBGMP_APK"     "$LIBGMP_URL"     "libgmp.so.10"
+_fetch_so "$LIBJANSSON_APK" "$LIBJANSSON_URL" "libjansson.so.4"
+_fetch_so "$LIBREADLINE_APK" "$LIBREADLINE_URL" "libreadline.so.8"
+_fetch_so "$LIBNCURSESW_APK" "$LIBNCURSESW_URL" "libncursesw.so.6"
+_fetch_so "$NFTABLES_APK"   "$NFTABLES_URL"   "libnftables.so.1"
+
 
 # ---------------------------------------------------------------------------
 echo "[6/8] Staging Mozilla CA bundle (for TLS inside VM)"
@@ -463,6 +572,7 @@ if [ ! -f "$INITRAMFS_OUT" ] \
         # are all CONFIG_xxx=y (built-in).  Modules that are =m and required:
         #   vsock        — pelagos-guest comms
         #   overlayfs    — container layer stacking
+        #   virtiofs     — AVF host directory sharing (volumes, $HOME bind-mounts)
         #   bridge+deps  — pelagos bridge networking (NetworkMode::Bridge / -p)
         #   nftables     — port-forward DNAT rules
         # Stage all of the above from the Ubuntu module tree extracted by
@@ -470,6 +580,7 @@ if [ ! -f "$INITRAMFS_OUT" ] \
         for rel_dir in \
             net/vmw_vsock \
             fs/overlayfs \
+            fs/fuse \
             net/llc \
             net/802 \
             net/bridge \
@@ -493,24 +604,32 @@ if [ ! -f "$INITRAMFS_OUT" ] \
         else
             echo "  WARNING: overlay.ko not found in $UBUNTU_MODULES" >&2
         fi
-        # bridge + nftables modules (optional — warn but don't abort if missing,
-        # since they are only absent on old ubuntu-modules trees built before #172)
+        # virtiofs, bridge, nftables modules (optional — warn but don't abort if missing,
+        # since they are absent on old ubuntu-modules trees built before this fix)
         for rel_ko in \
+            fs/fuse/virtiofs.ko \
             net/llc/llc.ko \
             net/802/stp.ko \
             net/bridge/bridge.ko \
+            drivers/net/veth.ko \
+            lib/libcrc32c.ko \
+            net/ipv4/netfilter/nf_defrag_ipv4.ko \
+            net/ipv6/netfilter/nf_defrag_ipv6.ko \
             net/netfilter/nfnetlink.ko \
             net/netfilter/nf_tables.ko \
             net/netfilter/nf_conntrack.ko \
-            net/netfilter/nf_nat.ko
+            net/netfilter/nf_nat.ko \
+            net/netfilter/nft_nat.ko \
+            net/netfilter/nft_chain_nat.ko
         do
             src="$UBUNTU_MODULES/$rel_ko"
             dst="$INITRD_TMP/lib/modules/$KVER/kernel/$rel_ko"
             if [ -f "$src" ]; then
+                mkdir -p "$(dirname "$dst")"
                 cp "$src" "$dst"
                 echo "  staged (Ubuntu) $(basename $rel_ko)"
             else
-                echo "  INFO: $(basename $rel_ko) not in ubuntu-modules (rebuild with build-build-image.sh to enable bridge/nftables)" >&2
+                echo "  INFO: $(basename $rel_ko) not in ubuntu-modules (rebuild with build-build-image.sh to enable virtiofs/bridge/nftables)" >&2
             fi
         done
         # Use the Ubuntu modules.dep so modprobe resolves all dependency chains.
@@ -660,6 +779,25 @@ if [ ! -f "$INITRAMFS_OUT" ] \
     fi
 
 
+    # Add ip (iproute2-minimal) + nft (nftables) + their shared libs.
+    # Required for pelagos bridge networking and port-forward DNAT rules.
+    mkdir -p "$INITRD_TMP/sbin" "$INITRD_TMP/usr/sbin" "$INITRD_TMP/usr/lib"
+    cp "$IP_BIN"  "$INITRD_TMP/sbin/ip"
+    cp "$NFT_BIN" "$INITRD_TMP/usr/sbin/nft"
+    chmod 755 "$INITRD_TMP/sbin/ip" "$INITRD_TMP/usr/sbin/nft"
+    for soname in \
+        libcap.so.2 libelf.so.1 libmnl.so.0 libnftnl.so.11 \
+        libgmp.so.10 libjansson.so.4 libreadline.so.8 libncursesw.so.6 \
+        libnftables.so.1; do
+        src="$WORK/$soname"
+        if [ -f "$src" ]; then
+            cp "$src" "$INITRD_TMP/usr/lib/$soname"
+            echo "  staged $soname"
+        else
+            echo "  WARNING: $soname not found in $WORK — ip/nft may not work" >&2
+        fi
+    done
+
     # Stage the host's public key as the VM's authorized_keys.
     mkdir -p "$INITRD_TMP/root/.ssh"
     cp "${SSH_KEY_FILE}.pub" "$INITRD_TMP/root/.ssh/authorized_keys"
@@ -738,16 +876,25 @@ if busybox grep -q '^rootfs / rootfs' /proc/mounts 2>/dev/null; then
     modprobe tun                 2>/dev/null || true
     modprobe jbd2                2>/dev/null || true
     modprobe ext4                2>/dev/null || true
+    # virtiofs for AVF host directory sharing (pelagos volumes, $HOME bind-mounts).
+    # =m in Ubuntu 6.8 HWE; absent on old images, silently skipped in that case.
+    modprobe virtiofs            2>/dev/null || true
     # Bridge networking + nftables for pelagos container networking (-p / bridge mode).
     # These are =m in Ubuntu 6.8 HWE; loaded here so pelagos run works immediately
     # after boot.  Silently skipped on old images that predate #172.
     modprobe llc                 2>/dev/null || true
     modprobe stp                 2>/dev/null || true
     modprobe bridge              2>/dev/null || true
+    modprobe libcrc32c           2>/dev/null || true
+    modprobe nf_defrag_ipv4      2>/dev/null || true
+    modprobe nf_defrag_ipv6      2>/dev/null || true
     modprobe nfnetlink           2>/dev/null || true
     modprobe nf_conntrack        2>/dev/null || true
     modprobe nf_nat              2>/dev/null || true
+    modprobe nft_nat             2>/dev/null || true
+    modprobe nft_chain_nat       2>/dev/null || true
     modprobe nf_tables           2>/dev/null || true
+    modprobe veth                2>/dev/null || true
     # Create /dev/net/tun device node.  The tun kernel module registers
     # the device (char major 10, minor 200) but does not create the node
     # automatically without udevd/mdev.  pasta requires /dev/net/tun to
@@ -829,6 +976,7 @@ if busybox grep -q '^rootfs / rootfs' /proc/mounts 2>/dev/null; then
             [ -d "/\$d" ] && busybox cp -a "/\$d" /newroot/ 2>/dev/null || true
         done
         busybox cp /init /newroot/init
+        busybox chmod 755 /newroot/init
         busybox mkdir -p /newroot/proc /newroot/sys \
                          /newroot/dev /newroot/dev/pts /newroot/dev/net \
                          /newroot/tmp /newroot/run /newroot/run/pelagos \
@@ -871,6 +1019,11 @@ busybox ip link set eth0 up
 busybox ip addr add 192.168.105.2/24 dev eth0
 busybox ip route add default via 192.168.105.1
 echo "[pelagos-init] network: static 192.168.105.2/24"
+# Enable IP forwarding unconditionally — this is a container runtime VM.
+# pelagos port-forwarding uses nftables DNAT in PREROUTING to redirect
+# host-port connections to the container IP, which requires ip_forward=1
+# to move packets from eth0 to the bridge (pelagos0) interface.
+echo 1 > /proc/sys/net/ipv4/ip_forward
 echo "[pelagos-init] network ready"
 busybox mkdir -p /etc
 echo 'nameserver 8.8.8.8' > /etc/resolv.conf
@@ -879,6 +1032,10 @@ echo 'nameserver 8.8.4.4' >> /etc/resolv.conf
 # /tmp: bounded tmpfs — prevents VM-level OOM from unbounded temp storage.
 # Container workloads write to their own overlayfs (on /dev/vda), not here.
 busybox mkdir -p /tmp /run /run/pelagos
+# pelagos looks for /run/netns/{name}; Alpine iproute2 creates /var/run/netns.
+# Symlink so both paths resolve to the same directory.
+busybox mkdir -p /var/run/netns
+busybox ln -sf /var/run/netns /run/netns
 busybox mount -t tmpfs -o size=512m tmpfs /tmp
 
 # Gate on network readiness before pelagos-guest starts pulling images.
@@ -945,6 +1102,7 @@ mkdir -p /etc/dropbear
 
 (while true; do /bin/sh </dev/hvc0 >/dev/hvc0 2>/dev/hvc0; sleep 1; done) &
 
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export RUST_LOG=warn
 # Raise the open-file limit.  The default (1024) is easily exceeded when VS
 # Code opens 10+ simultaneous vsock connections each using namespace fds,


### PR DESCRIPTION
## Summary

- Set `ip_forward=1` unconditionally in the VM init script (pass 2, after eth0 is configured)
- Reset `RUST_LOG` from `debug` back to `warn`
- Fix protocol bug in `port_dispatcher.rs`: relay receives `host_port` (VM TCP proxy port), not `container_port`
- Add bridge/nftables kernel modules to VM image (`veth`, `libcrc32c`, `nf_defrag_ipv4/ipv6`, `nft_nat`, `nft_chain_nat`)

## Root cause analysis

`pelagos run -p 8080:80 nginx:alpine` installs nftables DNAT rules in `PREROUTING` (e.g. `tcp dport 8080 dnat to 172.19.0.X:80`). Without `ip_forward=1`, the kernel drops DNAT'd packets instead of forwarding them from `eth0` → `pelagos0` bridge. The smoltcp relay's TCP SYN was correctly sent to `192.168.105.2:8080` but the VM returned no SYN-ACK, leaving the connection in `pending` state.

SSH (port 22 → dropbear in main netns) worked because no DNAT is involved — direct local delivery. Port 8080 required DNAT+forwarding, which needs `ip_forward=1`.

## Remaining pelagos-side issues (documented in ONGOING_TASKS.md)

1. **`ip_forward` not set by pelagos** — `enable_port_forwards()` installs DNAT without calling `enable_nat()`, so `ip_forward` stays 0. Workaround here: init script sets it unconditionally (safe for a container runtime VM).
2. **Stale DNAT rules accumulate** — `enable_port_forwards()` evicts stale entries only if `/run/netns/{name}` is missing, but pelagos doesn't delete the netns file when a container dies uncleanly. First matching (stale) DNAT rule wins, silently forwarding to a dead IP.

## Test plan

- [x] `pelagos vm ssh -- cat /proc/sys/net/ipv4/ip_forward` → `1` after VM boot
- [x] `curl http://localhost:8080/` returns nginx HTML with a fresh container (after manually flushing stale DNAT rules until pelagos bug #2 is fixed)
- [x] `nat_relay: inbound pending -> established (age ~3ms)` visible in daemon.log
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)