### PR TITLE
fix(tui): prompt to stop-and-remove when deleting a running container

### DIFF
--- a/pelagos-tui/src/app.rs
+++ b/pelagos-tui/src/app.rs
@@ -48,6 +48,8 @@ pub enum ConfirmAction {
     Stop,
     Restart,
     Remove,
+    /// Stop then remove: used when at least one target is currently running.
+    StopAndRemove,
 }
 
 impl ConfirmAction {
@@ -57,15 +59,18 @@ impl ConfirmAction {
             ConfirmAction::Stop => "stop",
             ConfirmAction::Restart => "restart",
             ConfirmAction::Remove => "remove",
+            ConfirmAction::StopAndRemove => "stop and remove",
         }
     }
 
-    /// The `pelagos` subcommand name.
+    /// The `pelagos` subcommand name.  `StopAndRemove` is handled specially in
+    /// `execute_action_bg` and should not be used directly as a subcommand.
     pub fn pelagos_cmd(&self) -> &'static str {
         match self {
             ConfirmAction::Stop => "stop",
             ConfirmAction::Restart => "restart",
             ConfirmAction::Remove => "rm",
+            ConfirmAction::StopAndRemove => "rm",
         }
     }
 }
@@ -432,11 +437,28 @@ impl App {
 
     fn begin_action(&mut self, action: ConfirmAction) {
         let targets = self.action_targets();
-        if !targets.is_empty() {
-            self.confirm_action = Some(action);
-            self.confirm_targets = targets;
-            self.mode = Mode::Confirm;
+        if targets.is_empty() {
+            return;
         }
+        // If the user asks to remove a container that is still running, upgrade
+        // to StopAndRemove so they get a clear prompt and the stop happens first.
+        let action = if action == ConfirmAction::Remove {
+            let any_running = self
+                .containers
+                .iter()
+                .filter(|c| targets.contains(&c.name))
+                .any(|c| c.status == "running");
+            if any_running {
+                ConfirmAction::StopAndRemove
+            } else {
+                action
+            }
+        } else {
+            action
+        };
+        self.confirm_action = Some(action);
+        self.confirm_targets = targets;
+        self.mode = Mode::Confirm;
     }
 
     #[allow(dead_code)]

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -291,11 +291,12 @@ fn run_loop(
             // race the rm commands: the snapshot would arrive mid-delete and some
             // containers would reappear.  stop/restart rely on ContainerExited /
             // ContainerStarted subscription events and don't need a forced reconnect.
-            let sub_config_for_rm = if action == ConfirmAction::Remove {
-                app.sub_config.clone()
-            } else {
-                None
-            };
+            let sub_config_for_rm =
+                if action == ConfirmAction::Remove || action == ConfirmAction::StopAndRemove {
+                    app.sub_config.clone()
+                } else {
+                    None
+                };
             std::thread::spawn(move || {
                 execute_action_bg(&profile, &action, &targets, status_tx, sub_config_for_rm);
             });
@@ -379,10 +380,22 @@ fn execute_action_bg(
     status_tx: Option<mpsc::SyncSender<String>>,
     sub_config: Option<std::sync::Arc<std::sync::Mutex<SubConfig>>>,
 ) {
-    let subcmd = action.pelagos_cmd();
     let mut errors: Vec<String> = Vec::new();
 
     for name in targets {
+        // StopAndRemove: stop the container first, then remove it.
+        if *action == ConfirmAction::StopAndRemove {
+            log::info!("action: profile={} stop {}", profile, name);
+            let _ = std::process::Command::new("pelagos")
+                .arg("--profile")
+                .arg(profile)
+                .arg("stop")
+                .arg(name)
+                .stdin(std::process::Stdio::null())
+                .output();
+        }
+
+        let subcmd = action.pelagos_cmd();
         log::info!("action: profile={} {} {}", profile, subcmd, name);
         let result = std::process::Command::new("pelagos")
             .arg("--profile")

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -210,6 +210,7 @@ fn render_modeline(f: &mut Frame, app: &App, area: Rect) {
             };
             let action_color = match action {
                 ConfirmAction::Remove => Color::Red,
+                ConfirmAction::StopAndRemove => Color::Red,
                 ConfirmAction::Stop => Color::Yellow,
                 ConfirmAction::Restart => Color::Cyan,
             };


### PR DESCRIPTION
## Summary

- Pressing `d` on a running container previously queued `pelagos rm` which fails silently (requires `--force` on running containers)
- `begin_action` now checks whether any target container has `status == "running"`
- If so, upgrades `ConfirmAction::Remove` → `ConfirmAction::StopAndRemove`
- Confirmation prompt reads **"stop and remove N container(s)? [y/N]"** instead of the misleading "remove"
- `execute_action_bg` issues `pelagos stop` before `pelagos rm` for each target when action is `StopAndRemove`
- Subscription reconnect after stop-and-remove works the same as after a plain remove

## Test plan

- [ ] Run a container, press `d` — confirm prompt now reads "stop and remove 1 container?"
- [ ] Press `y` — container stops and disappears from the list
- [ ] Multi-select mix of running + exited containers, press `d` — prompt reads "stop and remove N containers?", all are removed
- [ ] Press `d` on an exited container — prompt still reads "remove 1 container?" (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)