### PR TITLE
feat(tui): container inspect overlay (Enter/i)

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -123,6 +123,9 @@ pub enum GuestCommand {
         env: std::collections::HashMap<String, String>,
         #[serde(default)]
         tty: bool,
+        /// Optional container name passed to `pelagos run --name`.
+        #[serde(default)]
+        name: Option<String>,
     },
     /// Exec a command inside an already-running container by name.
     /// Enters the container's namespaces via setns(2) and execs the command.
@@ -491,8 +494,9 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 args,
                 env,
                 tty,
+                name,
             } => {
-                handle_exec(fd, &image, &args, &env, tty)?;
+                handle_exec(fd, &image, &args, &env, tty, name.as_deref())?;
                 return Ok(());
             }
             GuestCommand::ExecInto {
@@ -1563,6 +1567,7 @@ fn handle_exec(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     tty: bool,
+    name: Option<&str>,
 ) -> std::io::Result<()> {
     let pelagos = pelagos_bin();
 
@@ -1589,6 +1594,9 @@ fn handle_exec(
     // adding another PTY layer on top would double-process terminal escapes.
     if tty {
         cmd.arg("--interactive");
+    }
+    if let Some(n) = name {
+        cmd.arg("--name").arg(n);
     }
     cmd.arg(image);
     if !args.is_empty() {

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -354,6 +354,8 @@ enum GuestCommand {
         #[serde(default)]
         env: std::collections::HashMap<String, String>,
         tty: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
     },
     ExecInto {
         container: String,
@@ -702,6 +704,7 @@ fn main() {
                         args,
                         env: env_map,
                         tty,
+                        name,
                     },
                     tty,
                 ));
@@ -2905,6 +2908,7 @@ mod tests {
             args: vec!["sh".into()],
             env: std::collections::HashMap::new(),
             tty: true,
+            name: None,
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/pelagos-tui/src/app.rs
+++ b/pelagos-tui/src/app.rs
@@ -353,7 +353,7 @@ impl App {
 
             KeyCode::Char('r') => {
                 self.palette_input = format!(
-                    "--name {} -it {} {}",
+                    "--name {} -i {} {}",
                     random_name(),
                     self.tui_config.default_image,
                     self.tui_config.default_it_cmd,

--- a/pelagos-tui/src/app.rs
+++ b/pelagos-tui/src/app.rs
@@ -5,6 +5,41 @@ use std::collections::HashSet;
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Instant;
 
+// ---------------------------------------------------------------------------
+// Random container name generator (adjective-noun)
+// ---------------------------------------------------------------------------
+
+const ADJECTIVES: &[&str] = &[
+    "admiring", "adoring", "agitated", "amazing", "bold", "brave", "busy", "charming",
+    "clever", "confident", "cool", "curious", "daring", "determined", "eager", "earnest",
+    "elegant", "epic", "fervent", "fierce", "focused", "friendly", "gentle", "graceful",
+    "happy", "hopeful", "jolly", "keen", "lively", "lucid", "merry", "nifty", "nimble",
+    "peaceful", "quiet", "relaxed", "sharp", "sleepy", "stoic", "tender", "trusting",
+    "upbeat", "vigilant", "vivid", "witty", "wonderful", "zealous",
+];
+
+const NOUNS: &[&str] = &[
+    "albatross", "baboon", "bear", "beaver", "capybara", "cheetah", "condor", "crane",
+    "dingo", "dolphin", "dragon", "eagle", "falcon", "ferret", "firefly", "flamingo",
+    "gazelle", "gecko", "gibbon", "giraffe", "gorilla", "hawk", "hedgehog", "heron",
+    "ibis", "iguana", "jaguar", "jellyfish", "kestrel", "kingfisher", "lemur", "leopard",
+    "lynx", "meerkat", "narwhal", "ocelot", "osprey", "otter", "panda", "panther",
+    "parrot", "peacock", "pelican", "penguin", "phoenix", "puffin", "raven", "seahorse",
+    "sparrow", "squirrel", "swift", "tiger", "tortoise", "toucan", "vulture", "wombat",
+    "zebra",
+];
+
+fn random_name() -> String {
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(42);
+    let adj = ADJECTIVES[(seed as usize) % ADJECTIVES.len()];
+    let noun = NOUNS[((seed >> 16) as usize) % NOUNS.len()];
+    format!("{}-{}", adj, noun)
+}
+
+use crate::config::TuiConfig;
 use crate::runner::Container;
 
 // ---------------------------------------------------------------------------
@@ -21,7 +56,7 @@ pub enum SubscriptionMsg {
         vm_running: bool,
     },
     ContainerStarted {
-        container: Container,
+        container: Box<Container>,
     },
     ContainerExited {
         name: String,
@@ -89,6 +124,8 @@ pub enum Mode {
     Confirm,
     /// Waiting for y/N/q confirmation before quitting.
     ConfirmQuit,
+    /// Scrollable inspect overlay showing full container detail.
+    Inspect,
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +149,7 @@ pub struct App {
     pub palette_input: String,
     /// Set by the palette on Enter; main.rs drains this to spawn the run.
     pub pending_run: Option<String>,
+    pub tui_config: TuiConfig,
     /// Set by confirm on 'y'; main.rs drains this to execute the action.
     pub pending_action: Option<(ConfirmAction, Vec<String>)>,
     pub status_message: Option<String>,
@@ -123,12 +161,24 @@ pub struct App {
     // Confirm mode state — valid only when mode == Mode::Confirm.
     pub confirm_action: Option<ConfirmAction>,
     pub confirm_targets: Vec<String>,
+    // Inspect overlay state.
+    /// Container name to fetch detail for; drained by main.rs to spawn the query.
+    pub pending_inspect: Option<String>,
+    /// Channel on which the background ps thread delivers the enriched Container.
+    pub inspect_result_tx: Option<mpsc::SyncSender<Container>>,
+    pub inspect_result_rx: Option<mpsc::Receiver<Container>>,
+    /// The container whose detail is currently displayed.
+    pub inspect_container: Option<Container>,
+    /// Scroll offset within the inspect overlay (lines).
+    pub inspect_scroll: usize,
 }
 
 impl App {
     pub fn new(profile: String, profiles: Vec<String>) -> Self {
         let picker_idx = profiles.iter().position(|p| p == &profile).unwrap_or(0);
         let (status_tx, status_rx) = mpsc::sync_channel(8);
+        let (inspect_tx, inspect_rx) = mpsc::sync_channel(1);
+        let tui_config = TuiConfig::load(&profile);
         Self {
             mode: Mode::Normal,
             containers: Vec::new(),
@@ -143,6 +193,7 @@ impl App {
             should_quit: false,
             palette_input: String::new(),
             pending_run: None,
+            tui_config,
             pending_action: None,
             status_message: None,
             status_tx: Some(status_tx),
@@ -152,6 +203,11 @@ impl App {
             last_any_msg: Instant::now(),
             confirm_action: None,
             confirm_targets: Vec::new(),
+            pending_inspect: None,
+            inspect_result_tx: Some(inspect_tx),
+            inspect_result_rx: Some(inspect_rx),
+            inspect_container: None,
+            inspect_scroll: 0,
         }
     }
 
@@ -198,9 +254,9 @@ impl App {
                         .iter()
                         .position(|c| c.name == container.name)
                     {
-                        self.containers[pos] = container;
+                        self.containers[pos] = *container;
                     } else {
-                        self.containers.push(container);
+                        self.containers.push(*container);
                     }
                 }
                 self.last_refresh = Instant::now();
@@ -243,6 +299,7 @@ impl App {
             Mode::CommandPalette => self.on_key_palette(key),
             Mode::Confirm => self.on_key_confirm(key),
             Mode::ConfirmQuit => self.on_key_confirm_quit(key),
+            Mode::Inspect => self.on_key_inspect(key),
         }
     }
 
@@ -295,7 +352,17 @@ impl App {
             }
 
             KeyCode::Char('r') => {
-                self.palette_input.clear();
+                self.palette_input = format!(
+                    "--name {} -it {} {}",
+                    random_name(),
+                    self.tui_config.default_image,
+                    self.tui_config.default_it_cmd,
+                );
+                self.mode = Mode::CommandPalette;
+            }
+
+            KeyCode::Char('R') => {
+                self.palette_input = format!("--name {} -d ", random_name());
                 self.mode = Mode::CommandPalette;
             }
 
@@ -303,6 +370,15 @@ impl App {
             KeyCode::Char('s') => self.begin_action(ConfirmAction::Stop),
             KeyCode::Char('S') => self.begin_action(ConfirmAction::Restart),
             KeyCode::Char('d') => self.begin_action(ConfirmAction::Remove),
+
+            // Inspect overlay: show full detail for highlighted container.
+            KeyCode::Enter | KeyCode::Char('i') => {
+                if let Some(c) = self.containers.get(self.selected) {
+                    self.pending_inspect = Some(c.name.clone());
+                    self.inspect_scroll = 0;
+                    self.mode = Mode::Inspect;
+                }
+            }
 
             // Prune: target all exited containers regardless of selection.
             KeyCode::Char('P') => {
@@ -414,6 +490,22 @@ impl App {
         }
     }
 
+    fn on_key_inspect(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.mode = Mode::Normal;
+                self.inspect_container = None;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.inspect_scroll = self.inspect_scroll.saturating_add(1);
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.inspect_scroll = self.inspect_scroll.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
@@ -464,6 +556,17 @@ impl App {
     #[allow(dead_code)]
     pub fn selected_container(&self) -> Option<&Container> {
         self.containers.get(self.selected)
+    }
+
+    /// Drain any pending inspect result delivered by the background thread.
+    pub fn poll_inspect_result(&mut self) {
+        if let Some(rx) = &self.inspect_result_rx {
+            while let Ok(c) = rx.try_recv() {
+                self.inspect_container = Some(c);
+                // Clamp scroll in case the new result is shorter.
+                self.inspect_scroll = 0;
+            }
+        }
     }
 
     pub fn refresh_age_secs(&self) -> u64 {

--- a/pelagos-tui/src/config.rs
+++ b/pelagos-tui/src/config.rs
@@ -1,0 +1,104 @@
+//! Per-profile TUI configuration loaded from `tui.conf`.
+//!
+//! File location:
+//!   default profile → `~/.local/share/pelagos/tui.conf`
+//!   named profile   → `~/.local/share/pelagos/profiles/<name>/tui.conf`
+//!
+//! Respects `$XDG_DATA_HOME` (falls back to `$HOME/.local/share`).
+//!
+//! ```text
+//! # tui.conf
+//! default_image  = alpine
+//! default_it_cmd = /bin/sh
+//! ```
+
+use std::io;
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// TuiConfig
+// ---------------------------------------------------------------------------
+
+/// Per-profile TUI defaults.  Missing keys fall back to the built-in defaults.
+#[derive(Debug, Clone)]
+pub struct TuiConfig {
+    /// Image used when preseeding an interactive (`r`) run. Default: `alpine`.
+    pub default_image: String,
+    /// Command used when preseeding an interactive (`r`) run. Default: `/bin/sh`.
+    pub default_it_cmd: String,
+}
+
+impl Default for TuiConfig {
+    fn default() -> Self {
+        Self {
+            default_image: "alpine".to_string(),
+            default_it_cmd: "/bin/sh".to_string(),
+        }
+    }
+}
+
+impl TuiConfig {
+    /// Load `tui.conf` for the given profile.  Returns built-in defaults if
+    /// the file does not exist.
+    pub fn load(profile: &str) -> Self {
+        let path = match profile_dir(profile) {
+            Ok(d) => d.join("tui.conf"),
+            Err(e) => {
+                log::warn!("tui config: cannot resolve profile dir: {}", e);
+                return Self::default();
+            }
+        };
+
+        let text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Self::default(),
+            Err(e) => {
+                log::warn!("tui config: failed to read {:?}: {}", path, e);
+                return Self::default();
+            }
+        };
+
+        let mut cfg = Self::default();
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let Some((key, val)) = line.split_once('=') else {
+                continue;
+            };
+            let key = key.trim();
+            let val = val.trim();
+            match key {
+                "default_image" => cfg.default_image = val.to_string(),
+                "default_it_cmd" => cfg.default_it_cmd = val.to_string(),
+                _ => {}
+            }
+        }
+        log::debug!("tui config loaded from {:?}: {:?}", path, cfg);
+        cfg
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers — mirrors the logic in pelagos-mac/src/state.rs
+// ---------------------------------------------------------------------------
+
+fn pelagos_base() -> io::Result<PathBuf> {
+    let base = std::env::var("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+            PathBuf::from(home).join(".local/share")
+        });
+    Ok(base.join("pelagos"))
+}
+
+fn profile_dir(name: &str) -> io::Result<PathBuf> {
+    let base = pelagos_base()?;
+    if name == "default" {
+        Ok(base)
+    } else {
+        Ok(base.join("profiles").join(name))
+    }
+}

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -406,12 +406,14 @@ fn execute_run_bg(profile: &str, input: &str, status_tx: Option<mpsc::SyncSender
         .iter()
         .any(|a| *a == "-i" || *a == "--interactive" || *a == "-it" || *a == "-ti");
     if interactive {
+        log::debug!("run interactive: raw input={:?}", input);
         if let Err(e) = open_in_terminal(profile, input) {
             send_status(&status_tx, format!("terminal launch: {}", e));
         }
         return;
     }
 
+    log::debug!("run detached: args={:?}", args);
     let result = std::process::Command::new("pelagos")
         .arg("--profile")
         .arg(profile)
@@ -624,8 +626,38 @@ fn send_status(tx: &Option<mpsc::SyncSender<String>>, msg: String) {
 // Terminal launcher (for interactive -i runs)
 // ---------------------------------------------------------------------------
 
+/// Resolve the full path of the `pelagos` binary so that interactive runs
+/// in new terminal windows don't depend on the terminal's shell PATH.
+fn resolve_pelagos_path() -> String {
+    // Prefer a sibling binary next to the running pelagos-tui executable.
+    if let Ok(mut exe) = std::env::current_exe() {
+        exe.set_file_name("pelagos");
+        if exe.exists() {
+            return exe.to_string_lossy().into_owned();
+        }
+    }
+    // Fall back to `which pelagos` using the current process's PATH.
+    if let Ok(out) = std::process::Command::new("which").arg("pelagos").output() {
+        if out.status.success() {
+            let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !p.is_empty() {
+                return p;
+            }
+        }
+    }
+    // Last resort: well-known homebrew locations.
+    for candidate in &["/opt/homebrew/bin/pelagos", "/usr/local/bin/pelagos"] {
+        if std::path::Path::new(candidate).exists() {
+            return candidate.to_string();
+        }
+    }
+    "pelagos".to_string()
+}
+
 fn open_in_terminal(profile: &str, input: &str) -> anyhow::Result<()> {
-    let cmd = format!("pelagos --profile {} run {}", shell_escape(profile), input);
+    let pelagos = resolve_pelagos_path();
+    let cmd = format!("{} --profile {} run {}", pelagos, shell_escape(profile), input);
+    log::debug!("open_in_terminal: cmd={:?}", cmd);
 
     if let Ok(term_bin) = std::env::var("PELAGOS_TERMINAL") {
         return spawn_generic(&term_bin, &cmd);

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -14,6 +14,7 @@
 //! spawned in a background thread so the event loop never blocks on them either.
 
 mod app;
+mod config;
 mod runner;
 mod ui;
 
@@ -271,6 +272,18 @@ fn run_loop(
             }
         }
 
+        // Inspect: drain any result delivered by the background ps thread.
+        app.poll_inspect_result();
+
+        // Inspect: spawn a background ps query when the user opens the overlay.
+        if let Some(name) = app.pending_inspect.take() {
+            let profile = app.profile.clone();
+            let tx = app.inspect_result_tx.clone();
+            std::thread::spawn(move || {
+                execute_inspect_bg(&profile, &name, tx);
+            });
+        }
+
         // Command palette: execute pending run in a background thread so the
         // event loop never blocks.  The subscription thread will deliver the
         // ContainerStarted event when the container appears.
@@ -318,6 +331,62 @@ fn run_loop(
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Inspect query (background thread — never blocks event loop)
+// ---------------------------------------------------------------------------
+
+/// Run `pelagos ps --json --all`, find the container named `name`, and send it
+/// back via `tx`.  If the container is not found or the query fails the channel
+/// simply stays empty and the overlay shows a loading indicator.
+fn execute_inspect_bg(
+    profile: &str,
+    name: &str,
+    tx: Option<mpsc::SyncSender<runner::Container>>,
+) {
+    let tx = match tx {
+        Some(t) => t,
+        None => return,
+    };
+
+    let out = std::process::Command::new("pelagos")
+        .arg("--profile")
+        .arg(profile)
+        .arg("ps")
+        .arg("--json")
+        .arg("--all")
+        .stdin(std::process::Stdio::null())
+        .output();
+
+    let out = match out {
+        Ok(o) if o.status.success() => o,
+        Ok(o) => {
+            log::debug!(
+                "inspect ps failed: {}",
+                String::from_utf8_lossy(&o.stderr).trim()
+            );
+            return;
+        }
+        Err(e) => {
+            log::debug!("inspect ps error: {}", e);
+            return;
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    match serde_json::from_str::<Vec<runner::Container>>(stdout.trim()) {
+        Ok(list) => {
+            if let Some(c) = list.into_iter().find(|c| c.name == name) {
+                let _ = tx.try_send(c);
+            } else {
+                log::debug!("inspect: container '{}' not found in ps output", name);
+            }
+        }
+        Err(e) => {
+            log::debug!("inspect ps parse error: {}", e);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-tui/src/runner.rs
+++ b/pelagos-tui/src/runner.rs
@@ -3,6 +3,7 @@
 //! The Runner trait abstracts over the underlying pelagos binary invocation so
 //! that M5 can add a `LinuxRunner` without touching app or ui code.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -10,28 +11,67 @@ use std::process::Command;
 // Data model
 // ---------------------------------------------------------------------------
 
-/// Mirrors the JSON shape emitted by `pelagos ps --format json`.
+/// Subset of `SpawnConfig` from pelagos/src/cli/mod.rs that we surface in the
+/// inspect overlay.  Fields are all `#[serde(default)]` so old state files
+/// (without a `spawn_config` key) deserialise cleanly.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct SpawnConfigView {
+    #[serde(default)]
+    pub env: Vec<String>,
+    #[serde(default)]
+    pub bind: Vec<String>,
+    #[serde(default)]
+    pub bind_ro: Vec<String>,
+    #[serde(default)]
+    pub volume: Vec<String>,
+    #[serde(default)]
+    pub working_dir: Option<String>,
+    #[serde(default)]
+    pub hostname: Option<String>,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub read_only: bool,
+}
+
+/// Mirrors the JSON shape emitted by `pelagos ps --json`.
 ///
 /// Field names match `ContainerState` in pelagos/src/cli/mod.rs exactly.
-/// Optional fields use `#[serde(default)]` for forward/backward compatibility.
+/// Optional/collection fields use `#[serde(default)]` for forward/backward
+/// compatibility — absent keys deserialise to empty/None.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct Container {
     pub name: String,
     pub rootfs: String,
     pub status: String, // "running" | "exited"
-    // pid, exit_code, and command are part of the wire format and may be used in M2+.
-    #[allow(dead_code)]
     pub pid: i32,
     pub started_at: String,
     #[serde(default)]
-    #[allow(dead_code)]
     pub exit_code: Option<i32>,
     #[serde(default)]
-    #[allow(dead_code)]
     pub command: Vec<String>,
     /// Port mappings from `pelagos run -p HOST:CONTAINER` (e.g. `["8080:80"]`).
     #[serde(default)]
     pub ports: Vec<String>,
+    // ---- fields present in ContainerState but absent from ContainerSnapshot ----
+    /// Bridge IP address (bridge networking).
+    #[serde(default)]
+    pub bridge_ip: Option<String>,
+    /// Per-network IP map: network_name → IP.
+    #[serde(default)]
+    pub network_ips: HashMap<String, String>,
+    /// Key-value labels.
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    /// Captured stdout log path (detached containers).
+    #[serde(default)]
+    pub stdout_log: Option<String>,
+    /// Captured stderr log path (detached containers).
+    #[serde(default)]
+    pub stderr_log: Option<String>,
+    /// Original spawn configuration (present after first `pelagos run`).
+    #[serde(default)]
+    pub spawn_config: Option<SpawnConfigView>,
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -162,7 +162,7 @@ fn render_hint_bar(f: &mut Frame, app: &App, area: Rect) {
         Mode::Confirm => "  confirm action: [y]yes  [any]cancel",
         Mode::ConfirmQuit => "  quit pelagos-tui: [y/q]yes  [any]cancel",
         Mode::Inspect => "  [j/k] scroll  [Esc/q] close",
-        _ => "  [q]quit  [a]all  [j/k]nav  [Space]sel  [s]stop  [S]restart  [d]rm  [P]prune  [r]run-it  [R]run-d  [i/Enter]inspect  [p]profile",
+        _ => "  [q]quit  [a]all  [j/k]nav  [Space]sel  [s]stop  [S]restart  [d]rm  [P]prune  [r]run-i  [R]run-d  [i/Enter]inspect  [p]profile",
     };
     let hints = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));
     f.render_widget(hints, area);

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -9,6 +9,7 @@ use ratatui::{
 };
 
 use crate::app::{App, ConfirmAction, Mode};
+use crate::runner::Container;
 
 // Cursor indicator appended to the palette input line.
 const CURSOR: &str = "▏";
@@ -36,6 +37,10 @@ pub fn render(f: &mut Frame, app: &App) {
 
     if app.mode == Mode::ProfilePicker {
         render_profile_picker(f, app, area);
+    }
+
+    if app.mode == Mode::Inspect {
+        render_inspect_overlay(f, app, area);
     }
 }
 
@@ -156,7 +161,8 @@ fn render_hint_bar(f: &mut Frame, app: &App, area: Rect) {
         Mode::CommandPalette => "  [Enter]run  [Esc]cancel",
         Mode::Confirm => "  confirm action: [y]yes  [any]cancel",
         Mode::ConfirmQuit => "  quit pelagos-tui: [y/q]yes  [any]cancel",
-        _ => "  [q]quit  [a]all  [j/k]nav  [Space]sel  [s]stop  [S]restart  [d]rm  [P]prune  [r]run  [p]profile",
+        Mode::Inspect => "  [j/k] scroll  [Esc/q] close",
+        _ => "  [q]quit  [a]all  [j/k]nav  [Space]sel  [s]stop  [S]restart  [d]rm  [P]prune  [r]run-it  [R]run-d  [i/Enter]inspect  [p]profile",
     };
     let hints = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));
     f.render_widget(hints, area);
@@ -361,6 +367,251 @@ fn render_profile_picker(f: &mut Frame, app: &App, area: Rect) {
         .highlight_symbol("▶ ");
 
     f.render_stateful_widget(picker_table, inner, &mut picker_state);
+}
+
+// ---------------------------------------------------------------------------
+// Inspect overlay
+// ---------------------------------------------------------------------------
+
+fn render_inspect_overlay(f: &mut Frame, app: &App, area: Rect) {
+    // Popup dimensions: 70% wide, up to 80% tall.
+    let popup_width = (area.width * 70 / 100).max(60).min(area.width.saturating_sub(4));
+    let popup_height = (area.height * 80 / 100).max(10).min(area.height.saturating_sub(4));
+    let popup_x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let popup_y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
+
+    f.render_widget(Clear, popup_area);
+
+    // Build content lines before we know the title (we need the container name).
+    match &app.inspect_container {
+        None => {
+            // Still fetching — show a spinner/loading message.
+            let name = app
+                .containers
+                .get(app.selected)
+                .map(|c| c.name.as_str())
+                .unwrap_or("?");
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" {} ", name))
+                .title_style(Style::default().add_modifier(Modifier::BOLD));
+            let inner = block.inner(popup_area);
+            f.render_widget(block, popup_area);
+            let loading = Paragraph::new("  loading…").style(Style::default().fg(Color::DarkGray));
+            f.render_widget(loading, inner);
+        }
+        Some(c) => {
+            let lines = build_inspect_lines(c);
+            let title = format!(" {} ", c.name);
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .title_style(
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                );
+            let inner = block.inner(popup_area);
+            f.render_widget(block, popup_area);
+
+            // Apply scroll offset, clamped to content length.
+            let max_scroll = lines.len().saturating_sub(inner.height as usize);
+            let scroll = app.inspect_scroll.min(max_scroll);
+            let visible: Vec<Line> = lines.into_iter().skip(scroll).collect();
+
+            let para = Paragraph::new(visible);
+            f.render_widget(para, inner);
+        }
+    }
+}
+
+/// Section header line for the inspect overlay (takes owned title so callers
+/// can pass either `"STATIC"` or `format!(...)` without lifetime trouble).
+fn inspect_section(title: impl Into<String>) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("\n  {}:", title.into()),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+/// Build the full list of content lines for the inspect overlay.
+fn build_inspect_lines(c: &Container) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Helper closures.
+    let label = |key: &'static str| {
+        Span::styled(
+            format!("  {:<12}", key),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+    };
+    let value = |v: String| Span::styled(v, Style::default().fg(Color::White));
+
+    // --- Identity ---
+    let status_color = if c.status == "running" {
+        Color::Green
+    } else {
+        Color::Red
+    };
+    lines.push(Line::from(vec![
+        label("STATUS"),
+        Span::styled(c.status.clone(), Style::default().fg(status_color)),
+    ]));
+    lines.push(Line::from(vec![
+        label("IMAGE"),
+        value(c.rootfs.clone()),
+    ]));
+    lines.push(Line::from(vec![
+        label("PID"),
+        value(c.pid.to_string()),
+    ]));
+    lines.push(Line::from(vec![
+        label("UPTIME"),
+        value(format_uptime(&c.started_at)),
+    ]));
+    if let Some(code) = c.exit_code {
+        lines.push(Line::from(vec![
+            label("EXIT CODE"),
+            Span::styled(
+                code.to_string(),
+                Style::default().fg(if code == 0 {
+                    Color::Green
+                } else {
+                    Color::Red
+                }),
+            ),
+        ]));
+    }
+
+    // --- Command ---
+    if !c.command.is_empty() {
+        lines.push(inspect_section("COMMAND"));
+        lines.push(Line::from(vec![
+            Span::raw("    "),
+            value(c.command.join(" ")),
+        ]));
+    }
+
+    // --- Network ---
+    let has_network = c.bridge_ip.is_some() || !c.network_ips.is_empty();
+    if has_network {
+        lines.push(inspect_section("NETWORK"));
+        if let Some(ip) = &c.bridge_ip {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "    bridge       ",
+                    Style::default().fg(Color::DarkGray),
+                ),
+                value(ip.clone()),
+            ]));
+        }
+        let mut nets: Vec<(&String, &String)> = c.network_ips.iter().collect();
+        nets.sort_by_key(|(k, _)| k.as_str());
+        for (net, ip) in nets {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("    {:<13}", net),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                value(ip.clone()),
+            ]));
+        }
+    }
+
+    // --- Ports ---
+    if !c.ports.is_empty() {
+        lines.push(inspect_section("PORTS"));
+        for p in &c.ports {
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                value(p.replacen(':', " → ", 1)),
+            ]));
+        }
+    }
+
+    // --- Spawn config extras ---
+    if let Some(sc) = &c.spawn_config {
+        // Volumes: bind, bind_ro, volume
+        let has_vols = !sc.bind.is_empty() || !sc.bind_ro.is_empty() || !sc.volume.is_empty();
+        if has_vols {
+            lines.push(inspect_section("VOLUMES"));
+            for m in &sc.bind {
+                lines.push(Line::from(vec![Span::raw("    "), value(m.clone())]));
+            }
+            for m in &sc.bind_ro {
+                lines.push(Line::from(vec![
+                    Span::raw("    "),
+                    value(format!("{} (ro)", m)),
+                ]));
+            }
+            for m in &sc.volume {
+                lines.push(Line::from(vec![Span::raw("    "), value(m.clone())]));
+            }
+        }
+
+        // Working dir / hostname / user
+        if let Some(wd) = &sc.working_dir {
+            lines.push(inspect_section("WORKDIR"));
+            lines.push(Line::from(vec![Span::raw("    "), value(wd.clone())]));
+        }
+        if let Some(h) = &sc.hostname {
+            lines.push(Line::from(vec![label("HOSTNAME"), value(h.clone())]));
+        }
+        if let Some(u) = &sc.user {
+            lines.push(Line::from(vec![label("USER"), value(u.clone())]));
+        }
+        if sc.read_only {
+            lines.push(Line::from(vec![
+                label("ROOTFS"),
+                Span::styled("read-only", Style::default().fg(Color::Yellow)),
+            ]));
+        }
+
+        // Env vars
+        if !sc.env.is_empty() {
+            lines.push(inspect_section(format!("ENV ({})", sc.env.len())));
+            for e in &sc.env {
+                lines.push(Line::from(vec![Span::raw("    "), value(e.clone())]));
+            }
+        }
+    }
+
+    // --- Labels ---
+    if !c.labels.is_empty() {
+        lines.push(inspect_section("LABELS"));
+        let mut lbls: Vec<(&String, &String)> = c.labels.iter().collect();
+        lbls.sort_by_key(|(k, _)| k.as_str());
+        for (k, v) in lbls {
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                value(format!("{}={}", k, v)),
+            ]));
+        }
+    }
+
+    // --- Log paths ---
+    if c.stdout_log.is_some() || c.stderr_log.is_some() {
+        lines.push(inspect_section("LOGS"));
+        if let Some(p) = &c.stdout_log {
+            lines.push(Line::from(vec![
+                Span::styled("    stdout  ", Style::default().fg(Color::DarkGray)),
+                value(p.clone()),
+            ]));
+        }
+        if let Some(p) = &c.stderr_log {
+            lines.push(Line::from(vec![
+                Span::styled("    stderr  ", Style::default().fg(Color::DarkGray)),
+                value(p.clone()),
+            ]));
+        }
+    }
+
+    lines
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a scrollable inspect overlay triggered by `Enter` or `i` on any highlighted container
- Background thread runs `pelagos ps --json --all`, finds the container by name, sends enriched data back via channel — event loop never blocks
- Overlay shows "loading…" until data arrives, then renders full detail
- `j`/`k` scroll; `Esc`/`q` close

**Overlay sections (all conditional on data presence):**

| Section | Source |
|---|---|
| STATUS / IMAGE / PID / UPTIME / EXIT CODE | `Container` (already in subscription) |
| COMMAND | `Container.command` |
| NETWORK | `bridge_ip` + `network_ips` (new fields from `ContainerState`) |
| PORTS | `Container.ports` (expanded) |
| VOLUMES | `spawn_config.bind / bind_ro / volume` |
| WORKDIR / HOSTNAME / USER / read-only flag | `spawn_config.*` |
| ENV (N) | `spawn_config.env` |
| LABELS | `Container.labels` |
| LOGS | `stdout_log / stderr_log` (detached containers) |

Also carries forward the TuiConfig WIP (`r` keybinding defaults, new `R` keybinding for detached-run shortcut) that was uncommitted on main.

Closes #178

## Test plan

- [ ] `cargo test -p pelagos-tui` passes (12/12)
- [ ] `cargo clippy -p pelagos-tui -- -D warnings` clean
- [ ] With VM running: press `Enter`/`i` on a container → overlay appears with correct data
- [ ] Press `j`/`k` to scroll ENV vars (try a container with many env vars)
- [ ] Press `Esc` → returns to normal table
- [ ] Press `i` with no containers → nothing happens (no crash)
- [ ] Show-all mode (`a`): inspect works on exited containers, EXIT CODE section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)