### PR TITLE
refactor(run): unify interactive and detached run paths

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -126,6 +126,13 @@ pub enum GuestCommand {
         /// Optional container name passed to `pelagos run --name`.
         #[serde(default)]
         name: Option<String>,
+        #[serde(default)]
+        mounts: Vec<GuestMount>,
+        #[serde(default)]
+        labels: Vec<String>,
+        /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
+        #[serde(default)]
+        publish: Vec<String>,
     },
     /// Exec a command inside an already-running container by name.
     /// Enters the container's namespaces via setns(2) and execs the command.
@@ -495,8 +502,11 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 env,
                 tty,
                 name,
+                mounts,
+                labels,
+                publish,
             } => {
-                handle_exec(fd, &image, &args, &env, tty, name.as_deref())?;
+                handle_exec(fd, &image, &args, &env, tty, name.as_deref(), &mounts, &labels, &publish)?;
                 return Ok(());
             }
             GuestCommand::ExecInto {
@@ -1561,6 +1571,7 @@ fn handle_cp_to(
 // Exec handler
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn handle_exec(
     fd: libc::c_int,
     image: &str,
@@ -1568,6 +1579,9 @@ fn handle_exec(
     env: &std::collections::HashMap<String, String>,
     tty: bool,
     name: Option<&str>,
+    mounts: &[GuestMount],
+    labels: &[String],
+    publish: &[String],
 ) -> std::io::Result<()> {
     let pelagos = pelagos_bin();
 
@@ -1597,6 +1611,20 @@ fn handle_exec(
     }
     if let Some(n) = name {
         cmd.arg("--name").arg(n);
+    }
+    for label in labels {
+        cmd.arg("--label").arg(label);
+    }
+    for port in publish {
+        cmd.arg("--publish").arg(port);
+    }
+    for m in mounts {
+        let host_dir = if m.subpath.is_empty() {
+            format!("/mnt/{}", m.tag)
+        } else {
+            format!("/mnt/{}/{}", m.tag, m.subpath)
+        };
+        cmd.arg("--volume").arg(format!("{}:{}", host_dir, m.container_path));
     }
     cmd.arg(image);
     if !args.is_empty() {

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -356,6 +356,13 @@ enum GuestCommand {
         tty: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        mounts: Vec<GuestMount>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        labels: Vec<String>,
+        /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        publish: Vec<String>,
     },
     ExecInto {
         container: String,
@@ -681,34 +688,8 @@ fn main() {
             let args = args.clone();
             let name = name.clone();
             let labels = labels.clone();
-            // -it: route through the PTY/interactive path (GuestCommand::Exec)
-            if interactive || tty {
-                let tty = tty || unsafe { libc::isatty(libc::STDOUT_FILENO) } != 0;
-                let env_map: std::collections::HashMap<String, String> = env
-                    .iter()
-                    .filter_map(|kv| {
-                        let (k, v) = kv.split_once('=')?;
-                        Some((k.to_string(), v.to_string()))
-                    })
-                    .collect();
-                let daemon_args = daemon_args_from_cli(&cli);
-                if let Err(e) = daemon::ensure_running(&daemon_args) {
-                    log::error!("failed to start VM daemon: {}", e);
-                    process::exit(1);
-                }
-                let stream = connect_or_exit(&profile);
-                process::exit(exec_command(
-                    stream,
-                    GuestCommand::Exec {
-                        image,
-                        args,
-                        env: env_map,
-                        tty,
-                        name,
-                    },
-                    tty,
-                ));
-            }
+
+            // --- Shared setup for both interactive and detached paths ---
             let env_map: std::collections::HashMap<String, String> = env
                 .iter()
                 .filter_map(|kv| {
@@ -778,6 +759,26 @@ fn main() {
                         process::exit(1);
                     }
                 }
+            }
+
+            // --- Branch: interactive (PTY/Exec) vs foreground/detached (Run) ---
+            if interactive || tty {
+                let tty = tty || unsafe { libc::isatty(libc::STDOUT_FILENO) } != 0;
+                let stream = connect_or_exit(&profile);
+                process::exit(exec_command(
+                    stream,
+                    GuestCommand::Exec {
+                        image,
+                        args,
+                        env: env_map,
+                        tty,
+                        name,
+                        mounts,
+                        labels,
+                        publish: cli.ports.clone(),
+                    },
+                    tty,
+                ));
             }
             let stream = connect_or_exit(&profile);
             let exit_code = passthrough_command(
@@ -2909,6 +2910,9 @@ mod tests {
             env: std::collections::HashMap::new(),
             tty: true,
             name: None,
+            mounts: vec![],
+            labels: vec![],
+            publish: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary

- Moves shared setup (env_map, mounts build, daemon startup, port-forward registration) before the `if interactive || tty` branch — eliminates the duplicated initialization that previously existed only in the detached path
- Adds `mounts`, `labels`, and `publish` fields to `GuestCommand::Exec` on both host and guest sides, so interactive containers now receive the same volume mounts, labels, and published ports that detached containers already supported
- Updates `handle_exec` in `pelagos-guest` to pass `--volume`, `--label`, and `--publish` args to `pelagos run`

## Test plan

- [ ] `cargo test -p pelagos-mac` passes (89 tests)
- [ ] `cargo clippy -p pelagos-mac -- -D warnings` clean
- [ ] `cargo clippy -p pelagos-guest --target aarch64-unknown-linux-musl -- -D warnings` clean
- [ ] Interactive run with `-v` mount works end-to-end
- [ ] Interactive run with `-p` port publish registers correctly

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)