### PR TITLE
feat: debian-dev container image with Rust stable toolchain

### DIFF
--- a/images/debian-dev/Dockerfile
+++ b/images/debian-dev/Dockerfile
@@ -1,0 +1,53 @@
+# debian-dev — Debian bookworm-slim base image with Rust stable toolchain
+# and pelagos build dependencies (glibc, libseccomp, libcap, pkg-config).
+#
+# Use inside the default pelagos Alpine VM for building Rust projects that
+# have C library dependencies that require glibc.
+#
+# Build:
+#   pelagos build -t debian-dev:latest images/debian-dev/
+#
+# Run (mounting host source tree via virtiofs):
+#   pelagos run --rm -it \
+#     -v $HOME/Projects/pelagos:/workspace \
+#     -w /workspace \
+#     debian-dev:latest \
+#     bash
+
+FROM debian:bookworm-slim
+
+# Suppress debconf interactive prompts (no controlling tty in a build container).
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system build dependencies.
+# libseccomp-dev + libcap-dev are required by the pelagos container runtime.
+# pkg-config is required by many *-sys crates.
+# curl + ca-certificates are required by rustup.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        libssl-dev \
+        libseccomp-dev \
+        libcap-dev \
+        curl \
+        ca-certificates \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust stable via rustup.
+# CARGO_HOME / RUSTUP_HOME are set explicitly so the toolchain is in a
+# predictable location regardless of the user the container runs as.
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo \
+      sh -s -- -y --default-toolchain stable --no-modify-path \
+    && RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo \
+       /usr/local/cargo/bin/rustc --version \
+    && RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo \
+       /usr/local/cargo/bin/cargo --version
+
+WORKDIR /workspace


### PR DESCRIPTION
## Summary

Adds `images/debian-dev/Dockerfile` — a `debian:bookworm-slim`-based container image with the Rust stable toolchain and pelagos build dependencies pre-installed.

- `debian:bookworm-slim` base (glibc, full `apt`)
- `build-essential`, `pkg-config`, `libssl-dev`, `libseccomp-dev`, `libcap-dev`, `curl`, `git`
- Rust 1.94.0 stable via rustup, installed to `/usr/local/{rustup,cargo}`
- `PATH` includes `/usr/local/cargo/bin` at container runtime

This is the "middle ground" between Alpine (musl, no C deps) and the Ubuntu build VM (large, SSH-only). Runs inside the `default` Alpine VM profile; source trees mount via virtiofs so incremental build cache persists on the host.

## Build

```bash
pelagos build -t debian-dev:latest images/debian-dev/
```

## Test plan

- [x] `pelagos build -t debian-dev:latest images/debian-dev/` succeeds
- [x] `pelagos run debian-dev:latest rustc --version` → `rustc 1.94.0`
- [x] `pelagos run debian-dev:latest cargo --version` → `cargo 1.94.0`
- [x] `pelagos run debian-dev:latest bash -c 'cargo init && cargo build'` compiles hello-world
- [x] `pkg-config --modversion libseccomp` → `2.5.4`
- [x] `pkg-config --modversion libcap` → `2.66`
- [x] `scripts/test-vm-profiles.sh` → 18/18 PASS
- [x] Removed stale `~/.local/share/pelagos/profiles/default/` artifact (pre-existing, not caused by this change)

## Notes

pelagos's build system merges multi-variable `ENV key1=v1 key2=v2` into a single environment entry. Fixed by using one `ENV` instruction per variable.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)