### PR TITLE
fix(tui): stop old VM before starting new one on profile switch

### DIFF
--- a/pelagos-tui/src/app.rs
+++ b/pelagos-tui/src/app.rs
@@ -152,6 +152,9 @@ pub struct App {
     pub tui_config: TuiConfig,
     /// Set by confirm on 'y'; main.rs drains this to execute the action.
     pub pending_action: Option<(ConfirmAction, Vec<String>)>,
+    /// Old profile name set on profile switch; main.rs stops that VM then
+    /// bumps the subscription generation to connect to the new profile.
+    pub pending_profile_switch: Option<String>,
     pub status_message: Option<String>,
     pub status_tx: Option<mpsc::SyncSender<String>>,
     pub status_rx: Option<mpsc::Receiver<String>>,
@@ -195,6 +198,7 @@ impl App {
             pending_run: None,
             tui_config,
             pending_action: None,
+            pending_profile_switch: None,
             status_message: None,
             status_tx: Some(status_tx),
             status_rx: Some(status_rx),
@@ -415,16 +419,19 @@ impl App {
             KeyCode::Enter => {
                 if let Some(chosen) = self.profiles.get(self.profile_picker_selected).cloned() {
                     if chosen != self.profile {
-                        log::debug!("profile switch: {} -> {}", self.profile, chosen);
-                        self.profile = chosen.clone();
+                        let old = std::mem::replace(&mut self.profile, chosen.clone());
+                        log::debug!("profile switch: {} -> {}", old, chosen);
                         self.containers.clear();
                         self.selected = 0;
                         self.selected_names.clear();
+                        self.tui_config = TuiConfig::load(&chosen);
+                        // Update the target profile but do NOT bump generation yet.
+                        // main.rs will stop the old VM first, then bump, so the
+                        // new VM starts without a NAT relay port conflict.
                         if let Some(cfg) = &self.sub_config {
-                            let mut c = cfg.lock().unwrap();
-                            c.profile = chosen;
-                            c.generation = c.generation.wrapping_add(1);
+                            cfg.lock().unwrap().profile = chosen;
                         }
+                        self.pending_profile_switch = Some(old);
                     }
                 }
                 self.mode = Mode::Normal;

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -315,6 +315,23 @@ fn run_loop(
             });
         }
 
+        // Profile switch: stop the old VM, then trigger subscription reconnect.
+        // Stopping first avoids a NAT relay port conflict that would cause
+        // ensure_running to fail and the TUI to show "vm not running".
+        if let Some(old_profile) = app.pending_profile_switch.take() {
+            let sub_config = app.sub_config.clone();
+            std::thread::spawn(move || {
+                log::info!("profile switch: stopping VM for profile '{}'", old_profile);
+                let _ = std::process::Command::new("pelagos")
+                    .args(["--profile", &old_profile, "vm", "stop"])
+                    .status();
+                if let Some(cfg) = sub_config {
+                    let mut c = cfg.lock().unwrap();
+                    c.generation = c.generation.wrapping_add(1);
+                }
+            });
+        }
+
         // Liveness check: if the subscription has been silent for > 15s,
         // force a reconnect (handles silently-dead vsock connections).
         if app.subscription_stale() {


### PR DESCRIPTION
## Bug

Switching profiles in the TUI immediately bumped the subscription generation, causing `ensure_running` for the new profile to hit a NAT relay port conflict with the still-running old VM. Result: TUI showed "vm not running".

## Fix

- On Enter in the profile picker: store the old profile name in `pending_profile_switch`, update `sub_config.profile` to the new profile, but do **not** bump the generation yet
- In the main loop: drain `pending_profile_switch`, spawn a background thread that runs `pelagos --profile <old> vm stop`, then bumps the subscription generation — triggering the reconnect only after the port is free
- Also reload `tui_config` on profile switch so the command palette pre-seeds the correct `default_image` / `default_it_cmd` for the new profile (was using the old profile's config)

## On per-profile default images

`tui.conf` per profile already supports this — the reload fix above makes it actually work on switch. To configure for a named profile:

```
# ~/.local/share/pelagos/profiles/<name>/tui.conf
default_image  = debian-dev:latest
default_it_cmd = bash
```

## Test plan

- [ ] Switch from `default` → `build` profile: old VM stops, new VM starts, TUI connects
- [ ] Switch back `build` → `default`: same
- [ ] Command palette after switch pre-seeds the new profile's `default_image`
- [ ] No regression: normal container ops on default profile

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)