### PR TITLE
feat: OCI image management — protocol, CLI, and TUI (Phases 1-3)

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -249,6 +249,30 @@ pub enum GuestCommand {
     /// (NDJSON, one per line) until the client disconnects.  This connection
     /// is held open indefinitely — it does not produce a `GuestResponse`.
     Subscribe,
+    /// List locally stored OCI images; maps to `pelagos image ls --format json`.
+    ImageLs,
+    /// Pull an OCI image from a registry; maps to `pelagos image pull <reference>`.
+    ImagePull {
+        #[serde(default)]
+        reference: String,
+    },
+    /// Remove a locally stored OCI image; maps to `pelagos image rm <reference>`.
+    ImageRm {
+        #[serde(default)]
+        reference: String,
+    },
+    /// Tag a local OCI image with a new reference; maps to `pelagos image tag <source> <target>`.
+    ImageTag {
+        #[serde(default)]
+        source: String,
+        #[serde(default)]
+        target: String,
+    },
+    /// Inspect a local OCI image; maps to `pelagos image ls --format json` filtered by reference.
+    ImageInspect {
+        #[serde(default)]
+        reference: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -714,6 +738,21 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 // Holds connection open; does not participate in the read loop.
                 handle_subscribe(&mut writer)?;
                 return Ok(());
+            }
+            GuestCommand::ImageLs => {
+                handle_image_ls(&mut writer)?;
+            }
+            GuestCommand::ImagePull { reference } => {
+                handle_image_pull(&mut writer, &reference)?;
+            }
+            GuestCommand::ImageRm { reference } => {
+                handle_image_rm(&mut writer, &reference)?;
+            }
+            GuestCommand::ImageTag { source, target } => {
+                handle_image_tag(&mut writer, &source, &target)?;
+            }
+            GuestCommand::ImageInspect { reference } => {
+                handle_image_inspect(&mut writer, &reference)?;
             }
         }
     }
@@ -1300,6 +1339,43 @@ fn handle_volume(writer: &mut impl Write, sub: &str, name: Option<&str>) -> std:
 fn handle_network(writer: &mut impl Write, sub: &str, args: &[String]) -> std::io::Result<()> {
     let mut cmd = Command::new(pelagos_bin());
     cmd.arg("network").arg(sub).args(args);
+    spawn_and_stream(writer, cmd)
+}
+
+// ---------------------------------------------------------------------------
+// Image management handlers
+// ---------------------------------------------------------------------------
+
+fn handle_image_ls(writer: &mut impl Write) -> std::io::Result<()> {
+    let mut cmd = Command::new(pelagos_bin());
+    cmd.arg("image").arg("ls").arg("--format").arg("json");
+    spawn_and_stream(writer, cmd)
+}
+
+fn handle_image_pull(writer: &mut impl Write, reference: &str) -> std::io::Result<()> {
+    let mut cmd = Command::new(pelagos_bin());
+    cmd.arg("image").arg("pull").arg(reference);
+    spawn_and_stream(writer, cmd)
+}
+
+fn handle_image_rm(writer: &mut impl Write, reference: &str) -> std::io::Result<()> {
+    let mut cmd = Command::new(pelagos_bin());
+    cmd.arg("image").arg("rm").arg(reference);
+    spawn_and_stream(writer, cmd)
+}
+
+fn handle_image_tag(writer: &mut impl Write, source: &str, target: &str) -> std::io::Result<()> {
+    let mut cmd = Command::new(pelagos_bin());
+    cmd.arg("image").arg("tag").arg(source).arg(target);
+    spawn_and_stream(writer, cmd)
+}
+
+fn handle_image_inspect(writer: &mut impl Write, reference: &str) -> std::io::Result<()> {
+    // pelagos has no `image inspect` subcommand; stream the full image list as
+    // JSON and let the caller filter by reference client-side.
+    let _ = reference;
+    let mut cmd = Command::new(pelagos_bin());
+    cmd.arg("image").arg("ls").arg("--format").arg("json");
     spawn_and_stream(writer, cmd)
 }
 
@@ -2776,5 +2852,61 @@ mod tests {
         let (ft, data) = recv_frame(&mut cursor).unwrap();
         assert_eq!(ft, FRAME_STDOUT);
         assert_eq!(data, payload);
+    }
+
+    #[test]
+    fn image_ls_deserializes() {
+        let json = r#"{"cmd":"image_ls"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        assert!(matches!(cmd, GuestCommand::ImageLs));
+    }
+
+    #[test]
+    fn image_pull_deserializes() {
+        let json = r#"{"cmd":"image_pull","reference":"alpine:latest"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::ImagePull { reference } => {
+                assert_eq!(reference, "alpine:latest");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn image_rm_deserializes() {
+        let json = r#"{"cmd":"image_rm","reference":"alpine:latest"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::ImageRm { reference } => {
+                assert_eq!(reference, "alpine:latest");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn image_tag_deserializes() {
+        let json = r#"{"cmd":"image_tag","source":"alpine:latest","target":"alpine:sparky"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::ImageTag { source, target } => {
+                assert_eq!(source, "alpine:latest");
+                assert_eq!(target, "alpine:sparky");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn image_inspect_deserializes() {
+        let json = r#"{"cmd":"image_inspect","reference":"alpine:latest"}"#;
+        let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
+        match cmd {
+            GuestCommand::ImageInspect { reference } => {
+                assert_eq!(reference, "alpine:latest");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
     }
 }

--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -249,8 +249,11 @@ pub enum GuestCommand {
     /// (NDJSON, one per line) until the client disconnects.  This connection
     /// is held open indefinitely — it does not produce a `GuestResponse`.
     Subscribe,
-    /// List locally stored OCI images; maps to `pelagos image ls --format json`.
-    ImageLs,
+    /// List locally stored OCI images; maps to `pelagos image ls [--format json]`.
+    ImageLs {
+        #[serde(default)]
+        json: bool,
+    },
     /// Pull an OCI image from a registry; maps to `pelagos image pull <reference>`.
     ImagePull {
         #[serde(default)]
@@ -739,8 +742,8 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 handle_subscribe(&mut writer)?;
                 return Ok(());
             }
-            GuestCommand::ImageLs => {
-                handle_image_ls(&mut writer)?;
+            GuestCommand::ImageLs { json } => {
+                handle_image_ls(&mut writer, json)?;
             }
             GuestCommand::ImagePull { reference } => {
                 handle_image_pull(&mut writer, &reference)?;
@@ -1346,9 +1349,12 @@ fn handle_network(writer: &mut impl Write, sub: &str, args: &[String]) -> std::i
 // Image management handlers
 // ---------------------------------------------------------------------------
 
-fn handle_image_ls(writer: &mut impl Write) -> std::io::Result<()> {
+fn handle_image_ls(writer: &mut impl Write, json: bool) -> std::io::Result<()> {
     let mut cmd = Command::new(pelagos_bin());
-    cmd.arg("image").arg("ls").arg("--format").arg("json");
+    cmd.arg("image").arg("ls");
+    if json {
+        cmd.arg("--format").arg("json");
+    }
     spawn_and_stream(writer, cmd)
 }
 
@@ -2858,7 +2864,7 @@ mod tests {
     fn image_ls_deserializes() {
         let json = r#"{"cmd":"image_ls"}"#;
         let cmd: GuestCommand = serde_json::from_str(json).expect("parse failed");
-        assert!(matches!(cmd, GuestCommand::ImageLs));
+        assert!(matches!(cmd, GuestCommand::ImageLs { .. }));
     }
 
     #[test]

--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -533,7 +533,17 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 labels,
                 publish,
             } => {
-                handle_exec(fd, &image, &args, &env, tty, name.as_deref(), &mounts, &labels, &publish)?;
+                handle_exec(
+                    fd,
+                    &image,
+                    &args,
+                    &env,
+                    tty,
+                    name.as_deref(),
+                    &mounts,
+                    &labels,
+                    &publish,
+                )?;
                 return Ok(());
             }
             GuestCommand::ExecInto {
@@ -1706,7 +1716,8 @@ fn handle_exec(
         } else {
             format!("/mnt/{}/{}", m.tag, m.subpath)
         };
-        cmd.arg("--volume").arg(format!("{}:{}", host_dir, m.container_path));
+        cmd.arg("--volume")
+            .arg(format!("{}:{}", host_dir, m.container_path));
     }
     cmd.arg(image);
     if !args.is_empty() {

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -227,6 +227,11 @@ enum Commands {
         #[arg(default_value = ".")]
         context: String,
     },
+    /// Manage OCI images stored inside the VM
+    Image {
+        #[command(subcommand)]
+        cmd: ImageCmd,
+    },
     /// Manage named volumes inside the VM
     Volume {
         /// Subcommand: create, ls, rm
@@ -278,6 +283,34 @@ enum Commands {
     SshRelayProxy {
         /// VM port to connect to (e.g. 22 for SSH).
         port: u16,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ImageCmd {
+    /// List locally stored OCI images
+    Ls,
+    /// Pull an OCI image from a registry
+    Pull {
+        /// Image reference (e.g. alpine:latest, registry.io/org/repo:tag)
+        reference: String,
+    },
+    /// Remove a locally stored OCI image
+    Rm {
+        /// Image reference to remove
+        reference: String,
+    },
+    /// Tag a local OCI image with a new reference
+    Tag {
+        /// Source image reference
+        source: String,
+        /// New tag to apply
+        target: String,
+    },
+    /// Show details of a locally stored OCI image (JSON)
+    Inspect {
+        /// Image reference
+        reference: String,
     },
 }
 
@@ -448,6 +481,25 @@ enum GuestCommand {
         container: String,
         dst: String,
         data_size: u64,
+    },
+    /// List locally stored OCI images; maps to `pelagos image ls --format json`.
+    ImageLs,
+    /// Pull an OCI image from a registry; maps to `pelagos image pull <reference>`.
+    ImagePull {
+        reference: String,
+    },
+    /// Remove a locally stored OCI image; maps to `pelagos image rm <reference>`.
+    ImageRm {
+        reference: String,
+    },
+    /// Tag a local OCI image with a new reference; maps to `pelagos image tag <source> <target>`.
+    ImageTag {
+        source: String,
+        target: String,
+    },
+    /// Inspect a local OCI image; maps to `pelagos image ls --format json` filtered by reference.
+    ImageInspect {
+        reference: String,
     },
 }
 
@@ -1039,6 +1091,32 @@ fn main() {
                 no_cache,
                 &context,
             ));
+        }
+
+        Commands::Image { ref cmd } => {
+            let daemon_args = daemon_args_from_cli(&cli);
+            if let Err(e) = daemon::ensure_running(&daemon_args) {
+                log::error!("failed to start VM daemon: {}", e);
+                process::exit(1);
+            }
+            let stream = connect_or_exit(&profile);
+            let guest_cmd = match cmd {
+                ImageCmd::Ls => GuestCommand::ImageLs,
+                ImageCmd::Pull { reference } => GuestCommand::ImagePull {
+                    reference: reference.clone(),
+                },
+                ImageCmd::Rm { reference } => GuestCommand::ImageRm {
+                    reference: reference.clone(),
+                },
+                ImageCmd::Tag { source, target } => GuestCommand::ImageTag {
+                    source: source.clone(),
+                    target: target.clone(),
+                },
+                ImageCmd::Inspect { reference } => GuestCommand::ImageInspect {
+                    reference: reference.clone(),
+                },
+            };
+            process::exit(passthrough_command(stream, guest_cmd));
         }
 
         Commands::Volume { ref sub, ref name } => {
@@ -3197,6 +3275,60 @@ mod tests {
         assert_eq!(v["container"], "mybox");
         assert_eq!(v["dst"], "/tmp/");
         assert_eq!(v["data_size"], 4096);
+    }
+
+    #[test]
+    fn image_ls_serializes() {
+        let cmd = GuestCommand::ImageLs;
+        let json = serde_json::to_string(&cmd).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "image_ls");
+    }
+
+    #[test]
+    fn image_pull_serializes() {
+        let cmd = GuestCommand::ImagePull {
+            reference: "alpine:latest".into(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "image_pull");
+        assert_eq!(v["reference"], "alpine:latest");
+    }
+
+    #[test]
+    fn image_rm_serializes() {
+        let cmd = GuestCommand::ImageRm {
+            reference: "alpine:latest".into(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "image_rm");
+        assert_eq!(v["reference"], "alpine:latest");
+    }
+
+    #[test]
+    fn image_tag_serializes() {
+        let cmd = GuestCommand::ImageTag {
+            source: "alpine:latest".into(),
+            target: "alpine:sparky".into(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "image_tag");
+        assert_eq!(v["source"], "alpine:latest");
+        assert_eq!(v["target"], "alpine:sparky");
+    }
+
+    #[test]
+    fn image_inspect_serializes() {
+        let cmd = GuestCommand::ImageInspect {
+            reference: "alpine:latest".into(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cmd"], "image_inspect");
+        assert_eq!(v["reference"], "alpine:latest");
     }
 
     #[test]

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -289,7 +289,11 @@ enum Commands {
 #[derive(Subcommand, Debug)]
 enum ImageCmd {
     /// List locally stored OCI images
-    Ls,
+    Ls {
+        /// Output as JSON instead of a human-readable table
+        #[arg(long)]
+        json: bool,
+    },
     /// Pull an OCI image from a registry
     Pull {
         /// Image reference (e.g. alpine:latest, registry.io/org/repo:tag)
@@ -482,8 +486,11 @@ enum GuestCommand {
         dst: String,
         data_size: u64,
     },
-    /// List locally stored OCI images; maps to `pelagos image ls --format json`.
-    ImageLs,
+    /// List locally stored OCI images; maps to `pelagos image ls [--format json]`.
+    ImageLs {
+        #[serde(skip_serializing_if = "is_false")]
+        json: bool,
+    },
     /// Pull an OCI image from a registry; maps to `pelagos image pull <reference>`.
     ImagePull {
         reference: String,
@@ -1101,7 +1108,7 @@ fn main() {
             }
             let stream = connect_or_exit(&profile);
             let guest_cmd = match cmd {
-                ImageCmd::Ls => GuestCommand::ImageLs,
+                ImageCmd::Ls { json } => GuestCommand::ImageLs { json: *json },
                 ImageCmd::Pull { reference } => GuestCommand::ImagePull {
                     reference: reference.clone(),
                 },
@@ -3279,10 +3286,12 @@ mod tests {
 
     #[test]
     fn image_ls_serializes() {
-        let cmd = GuestCommand::ImageLs;
+        let cmd = GuestCommand::ImageLs { json: false };
         let json = serde_json::to_string(&cmd).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["cmd"], "image_ls");
+        // json=false is skip_serializing, so the field must be absent
+        assert!(v.get("json").is_none());
     }
 
     #[test]

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -1119,9 +1119,9 @@ fn main() {
                     source: source.clone(),
                     target: target.clone(),
                 },
-                ImageCmd::Inspect { reference } => GuestCommand::ImageInspect {
-                    reference: reference.clone(),
-                },
+                ImageCmd::Inspect { reference } => {
+                    process::exit(inspect_image_command(stream, reference));
+                }
             };
             process::exit(passthrough_command(stream, guest_cmd));
         }
@@ -1783,6 +1783,92 @@ fn passthrough_command(stream: UnixStream, cmd: GuestCommand) -> i32 {
         }
     }
     exit_code
+}
+
+/// Send ImageInspect to the guest, accumulate the JSON image list, and print
+/// the single entry whose "reference" field matches `reference`. Exits 0 on
+/// success, 1 if the image is not found or the response cannot be parsed.
+fn inspect_image_command(stream: UnixStream, reference: &str) -> i32 {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut writer = stream;
+
+    let cmd = GuestCommand::ImageInspect {
+        reference: reference.to_string(),
+    };
+    let mut msg = serde_json::to_string(&cmd).unwrap();
+    msg.push('\n');
+    if let Err(e) = writer.write_all(msg.as_bytes()) {
+        log::error!("write error: {}", e);
+        return 1;
+    }
+
+    // Accumulate stdout chunks; the guest streams `pelagos image ls --format json`.
+    let mut stdout_buf = String::new();
+    let mut exit_code = 1;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<GuestResponse>(trimmed) {
+            Ok(GuestResponse::Stream { stream, data }) => {
+                if stream == "stderr" {
+                    eprint!("{}", data);
+                } else {
+                    stdout_buf.push_str(&data);
+                }
+            }
+            Ok(GuestResponse::Exit { exit }) => {
+                exit_code = exit;
+                break;
+            }
+            Ok(GuestResponse::Error { error }) => {
+                log::error!("guest error: {}", error);
+                return 1;
+            }
+            Ok(resp) => {
+                log::warn!("unexpected response: {:?}", resp);
+            }
+            Err(e) => {
+                log::error!("parse error: {} (line: {:?})", e, trimmed);
+                return 1;
+            }
+        }
+    }
+
+    if exit_code != 0 {
+        return exit_code;
+    }
+
+    // Parse the JSON image list and find the matching entry.
+    let images: Vec<serde_json::Value> = match serde_json::from_str(&stdout_buf) {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!("failed to parse image list JSON: {}", e);
+            return 1;
+        }
+    };
+
+    let matched = images
+        .into_iter()
+        .find(|img| img.get("reference").and_then(|r| r.as_str()) == Some(reference));
+
+    match matched {
+        Some(img) => {
+            println!("{}", serde_json::to_string_pretty(&img).unwrap_or_default());
+            0
+        }
+        None => {
+            eprintln!("Error: image not found: {}", reference);
+            1
+        }
+    }
 }
 
 /// Tar up the build context, send it to the guest, and relay build output.

--- a/pelagos-tui/src/app.rs
+++ b/pelagos-tui/src/app.rs
@@ -10,22 +10,112 @@ use std::time::Instant;
 // ---------------------------------------------------------------------------
 
 const ADJECTIVES: &[&str] = &[
-    "admiring", "adoring", "agitated", "amazing", "bold", "brave", "busy", "charming",
-    "clever", "confident", "cool", "curious", "daring", "determined", "eager", "earnest",
-    "elegant", "epic", "fervent", "fierce", "focused", "friendly", "gentle", "graceful",
-    "happy", "hopeful", "jolly", "keen", "lively", "lucid", "merry", "nifty", "nimble",
-    "peaceful", "quiet", "relaxed", "sharp", "sleepy", "stoic", "tender", "trusting",
-    "upbeat", "vigilant", "vivid", "witty", "wonderful", "zealous",
+    "admiring",
+    "adoring",
+    "agitated",
+    "amazing",
+    "bold",
+    "brave",
+    "busy",
+    "charming",
+    "clever",
+    "confident",
+    "cool",
+    "curious",
+    "daring",
+    "determined",
+    "eager",
+    "earnest",
+    "elegant",
+    "epic",
+    "fervent",
+    "fierce",
+    "focused",
+    "friendly",
+    "gentle",
+    "graceful",
+    "happy",
+    "hopeful",
+    "jolly",
+    "keen",
+    "lively",
+    "lucid",
+    "merry",
+    "nifty",
+    "nimble",
+    "peaceful",
+    "quiet",
+    "relaxed",
+    "sharp",
+    "sleepy",
+    "stoic",
+    "tender",
+    "trusting",
+    "upbeat",
+    "vigilant",
+    "vivid",
+    "witty",
+    "wonderful",
+    "zealous",
 ];
 
 const NOUNS: &[&str] = &[
-    "albatross", "baboon", "bear", "beaver", "capybara", "cheetah", "condor", "crane",
-    "dingo", "dolphin", "dragon", "eagle", "falcon", "ferret", "firefly", "flamingo",
-    "gazelle", "gecko", "gibbon", "giraffe", "gorilla", "hawk", "hedgehog", "heron",
-    "ibis", "iguana", "jaguar", "jellyfish", "kestrel", "kingfisher", "lemur", "leopard",
-    "lynx", "meerkat", "narwhal", "ocelot", "osprey", "otter", "panda", "panther",
-    "parrot", "peacock", "pelican", "penguin", "phoenix", "puffin", "raven", "seahorse",
-    "sparrow", "squirrel", "swift", "tiger", "tortoise", "toucan", "vulture", "wombat",
+    "albatross",
+    "baboon",
+    "bear",
+    "beaver",
+    "capybara",
+    "cheetah",
+    "condor",
+    "crane",
+    "dingo",
+    "dolphin",
+    "dragon",
+    "eagle",
+    "falcon",
+    "ferret",
+    "firefly",
+    "flamingo",
+    "gazelle",
+    "gecko",
+    "gibbon",
+    "giraffe",
+    "gorilla",
+    "hawk",
+    "hedgehog",
+    "heron",
+    "ibis",
+    "iguana",
+    "jaguar",
+    "jellyfish",
+    "kestrel",
+    "kingfisher",
+    "lemur",
+    "leopard",
+    "lynx",
+    "meerkat",
+    "narwhal",
+    "ocelot",
+    "osprey",
+    "otter",
+    "panda",
+    "panther",
+    "parrot",
+    "peacock",
+    "pelican",
+    "penguin",
+    "phoenix",
+    "puffin",
+    "raven",
+    "seahorse",
+    "sparrow",
+    "squirrel",
+    "swift",
+    "tiger",
+    "tortoise",
+    "toucan",
+    "vulture",
+    "wombat",
     "zebra",
 ];
 
@@ -608,8 +698,7 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => {
                 if !self.images.is_empty() {
-                    self.images_selected =
-                        (self.images_selected + 1).min(self.images.len() - 1);
+                    self.images_selected = (self.images_selected + 1).min(self.images.len() - 1);
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
@@ -623,11 +712,7 @@ impl App {
             // Open the run command palette with the selected image pre-filled.
             KeyCode::Char('R') => {
                 if let Some(img) = self.images.get(self.images_selected) {
-                    self.palette_input = format!(
-                        "--name {} -d {}",
-                        random_name(),
-                        img.reference,
-                    );
+                    self.palette_input = format!("--name {} -d {}", random_name(), img.reference,);
                     self.mode = Mode::CommandPalette;
                 }
             }
@@ -787,8 +872,7 @@ impl App {
                 self.image_inspect_loading = false;
                 match result {
                     Ok(json) => {
-                        self.image_inspect_lines =
-                            json.lines().map(|l| l.to_string()).collect();
+                        self.image_inspect_lines = json.lines().map(|l| l.to_string()).collect();
                         self.image_inspect_scroll = 0;
                     }
                     Err(e) => {

--- a/pelagos-tui/src/app.rs
+++ b/pelagos-tui/src/app.rs
@@ -620,6 +620,17 @@ impl App {
                 self.images_error = None;
                 self.pending_image_ls = true;
             }
+            // Open the run command palette with the selected image pre-filled.
+            KeyCode::Char('R') => {
+                if let Some(img) = self.images.get(self.images_selected) {
+                    self.palette_input = format!(
+                        "--name {} -d {}",
+                        random_name(),
+                        img.reference,
+                    );
+                    self.mode = Mode::CommandPalette;
+                }
+            }
             KeyCode::Char('p') => {
                 self.image_pull_input.clear();
                 self.mode = Mode::ImagePull;

--- a/pelagos-tui/src/app.rs
+++ b/pelagos-tui/src/app.rs
@@ -43,6 +43,26 @@ use crate::config::TuiConfig;
 use crate::runner::Container;
 
 // ---------------------------------------------------------------------------
+// ImageInfo — parsed from `pelagos image ls --json`
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct ImageInfo {
+    pub reference: String,
+    pub digest: String,
+    #[serde(default)]
+    pub layers: Vec<String>,
+}
+
+impl ImageInfo {
+    /// First 12 hex chars of the digest, without the "sha256:" prefix.
+    pub fn short_digest(&self) -> &str {
+        let hex = self.digest.strip_prefix("sha256:").unwrap_or(&self.digest);
+        &hex[..hex.len().min(12)]
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Subscription message (deserialized from `pelagos subscribe` NDJSON output)
 // ---------------------------------------------------------------------------
 
@@ -85,6 +105,8 @@ pub enum ConfirmAction {
     Remove,
     /// Stop then remove: used when at least one target is currently running.
     StopAndRemove,
+    /// Remove an OCI image; `confirm_targets[0]` is the image reference.
+    ImageRm,
 }
 
 impl ConfirmAction {
@@ -95,17 +117,19 @@ impl ConfirmAction {
             ConfirmAction::Restart => "restart",
             ConfirmAction::Remove => "remove",
             ConfirmAction::StopAndRemove => "stop and remove",
+            ConfirmAction::ImageRm => "remove image",
         }
     }
 
-    /// The `pelagos` subcommand name.  `StopAndRemove` is handled specially in
-    /// `execute_action_bg` and should not be used directly as a subcommand.
+    /// The `pelagos` subcommand name.  `StopAndRemove` and `ImageRm` are
+    /// handled specially in `execute_action_bg`.
     pub fn pelagos_cmd(&self) -> &'static str {
         match self {
             ConfirmAction::Stop => "stop",
             ConfirmAction::Restart => "restart",
             ConfirmAction::Remove => "rm",
             ConfirmAction::StopAndRemove => "rm",
+            ConfirmAction::ImageRm => "image rm",
         }
     }
 }
@@ -117,6 +141,12 @@ impl ConfirmAction {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Mode {
     Normal,
+    /// Image management screen (toggled with `I` from Normal).
+    Images,
+    /// Pull dialog: modeline becomes a `pull> <input>` text field.
+    ImagePull,
+    /// Scrollable overlay showing full image JSON detail.
+    ImageInspect,
     ProfilePicker,
     /// Command palette: modeline becomes a `run> <input>` text field.
     CommandPalette,
@@ -171,6 +201,31 @@ pub struct App {
     pub inspect_container: Option<Container>,
     /// Scroll offset within the inspect overlay (lines).
     pub inspect_scroll: usize,
+
+    // Images screen state.
+    pub images: Vec<ImageInfo>,
+    pub images_selected: usize,
+    pub images_loading: bool,
+    pub images_error: Option<String>,
+    /// Set to true to trigger a background image list fetch.
+    pub pending_image_ls: bool,
+    pub image_ls_tx: Option<mpsc::SyncSender<Result<Vec<ImageInfo>, String>>>,
+    pub image_ls_rx: Option<mpsc::Receiver<Result<Vec<ImageInfo>, String>>>,
+    /// Pull dialog text input.
+    pub image_pull_input: String,
+    /// Set to trigger a background pull; drained by main.rs.
+    pub pending_image_pull: Option<String>,
+    /// Set after image-rm confirmation; drained by main.rs.
+    pub pending_image_rm: Option<String>,
+    // Image inspect overlay state.
+    /// Image reference to inspect; drained by main.rs to spawn the query.
+    pub pending_image_inspect: Option<String>,
+    pub image_inspect_tx: Option<mpsc::SyncSender<Result<String, String>>>,
+    pub image_inspect_rx: Option<mpsc::Receiver<Result<String, String>>>,
+    /// Pretty-printed JSON lines for the image inspect overlay.
+    pub image_inspect_lines: Vec<String>,
+    pub image_inspect_loading: bool,
+    pub image_inspect_scroll: usize,
 }
 
 impl App {
@@ -178,6 +233,8 @@ impl App {
         let picker_idx = profiles.iter().position(|p| p == &profile).unwrap_or(0);
         let (status_tx, status_rx) = mpsc::sync_channel(8);
         let (inspect_tx, inspect_rx) = mpsc::sync_channel(1);
+        let (image_ls_tx, image_ls_rx) = mpsc::sync_channel(1);
+        let (image_inspect_tx, image_inspect_rx) = mpsc::sync_channel(1);
         let tui_config = TuiConfig::load(&profile);
         Self {
             mode: Mode::Normal,
@@ -208,6 +265,22 @@ impl App {
             inspect_result_rx: Some(inspect_rx),
             inspect_container: None,
             inspect_scroll: 0,
+            images: Vec::new(),
+            images_selected: 0,
+            images_loading: false,
+            images_error: None,
+            pending_image_ls: false,
+            image_ls_tx: Some(image_ls_tx),
+            image_ls_rx: Some(image_ls_rx),
+            image_pull_input: String::new(),
+            pending_image_pull: None,
+            pending_image_rm: None,
+            pending_image_inspect: None,
+            image_inspect_tx: Some(image_inspect_tx),
+            image_inspect_rx: Some(image_inspect_rx),
+            image_inspect_lines: Vec::new(),
+            image_inspect_loading: false,
+            image_inspect_scroll: 0,
         }
     }
 
@@ -295,6 +368,9 @@ impl App {
     pub fn on_key(&mut self, key: KeyEvent) {
         match self.mode {
             Mode::Normal => self.on_key_normal(key),
+            Mode::Images => self.on_key_images(key),
+            Mode::ImagePull => self.on_key_image_pull(key),
+            Mode::ImageInspect => self.on_key_image_inspect(key),
             Mode::ProfilePicker => self.on_key_profile_picker(key),
             Mode::CommandPalette => self.on_key_palette(key),
             Mode::Confirm => self.on_key_confirm(key),
@@ -378,6 +454,15 @@ impl App {
                     self.inspect_scroll = 0;
                     self.mode = Mode::Inspect;
                 }
+            }
+
+            // Images screen.
+            KeyCode::Char('I') => {
+                self.images_selected = 0;
+                self.images_error = None;
+                self.pending_image_ls = true;
+                self.images_loading = true;
+                self.mode = Mode::Images;
             }
 
             // Prune: target all exited containers regardless of selection.
@@ -465,16 +550,26 @@ impl App {
             KeyCode::Char('y') | KeyCode::Char('Y') => {
                 if let Some(action) = self.confirm_action.take() {
                     let targets = std::mem::take(&mut self.confirm_targets);
-                    self.pending_action = Some((action, targets));
+                    if action == ConfirmAction::ImageRm {
+                        self.pending_image_rm = targets.into_iter().next();
+                        self.mode = Mode::Images;
+                    } else {
+                        self.pending_action = Some((action, targets));
+                        self.selected_names.clear();
+                        self.mode = Mode::Normal;
+                    }
                 }
-                self.selected_names.clear();
-                self.mode = Mode::Normal;
             }
             _ => {
-                // Any key other than 'y' cancels.
+                // Any key other than 'y' cancels — return to whichever screen initiated.
+                let from_images = self.confirm_action == Some(ConfirmAction::ImageRm);
                 self.confirm_action = None;
                 self.confirm_targets.clear();
-                self.mode = Mode::Normal;
+                self.mode = if from_images {
+                    Mode::Images
+                } else {
+                    Mode::Normal
+                };
             }
         }
     }
@@ -501,6 +596,89 @@ impl App {
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.inspect_scroll = self.inspect_scroll.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
+    fn on_key_images(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('I') => {
+                self.mode = Mode::Normal;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !self.images.is_empty() {
+                    self.images_selected =
+                        (self.images_selected + 1).min(self.images.len() - 1);
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.images_selected = self.images_selected.saturating_sub(1);
+            }
+            KeyCode::Char('r') => {
+                self.images_loading = true;
+                self.images_error = None;
+                self.pending_image_ls = true;
+            }
+            KeyCode::Char('p') => {
+                self.image_pull_input.clear();
+                self.mode = Mode::ImagePull;
+            }
+            KeyCode::Char('d') => {
+                if let Some(img) = self.images.get(self.images_selected) {
+                    self.confirm_action = Some(ConfirmAction::ImageRm);
+                    self.confirm_targets = vec![img.reference.clone()];
+                    self.mode = Mode::Confirm;
+                }
+            }
+            KeyCode::Enter => {
+                if let Some(img) = self.images.get(self.images_selected) {
+                    self.pending_image_inspect = Some(img.reference.clone());
+                    self.image_inspect_lines.clear();
+                    self.image_inspect_loading = true;
+                    self.image_inspect_scroll = 0;
+                    self.mode = Mode::ImageInspect;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn on_key_image_pull(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => {
+                self.image_pull_input.clear();
+                self.mode = Mode::Images;
+            }
+            KeyCode::Enter => {
+                let input = self.image_pull_input.trim().to_string();
+                if !input.is_empty() {
+                    self.pending_image_pull = Some(input);
+                }
+                self.image_pull_input.clear();
+                self.mode = Mode::Images;
+            }
+            KeyCode::Backspace => {
+                self.image_pull_input.pop();
+            }
+            KeyCode::Char(c) => {
+                self.image_pull_input.push(c);
+            }
+            _ => {}
+        }
+    }
+
+    fn on_key_image_inspect(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.image_inspect_lines.clear();
+                self.mode = Mode::Images;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.image_inspect_scroll = self.image_inspect_scroll.saturating_add(1);
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.image_inspect_scroll = self.image_inspect_scroll.saturating_sub(1);
             }
             _ => {}
         }
@@ -565,6 +743,47 @@ impl App {
                 self.inspect_container = Some(c);
                 // Clamp scroll in case the new result is shorter.
                 self.inspect_scroll = 0;
+            }
+        }
+    }
+
+    /// Drain any image list result delivered by the background fetch thread.
+    pub fn poll_image_ls_result(&mut self) {
+        if let Some(rx) = &self.image_ls_rx {
+            while let Ok(result) = rx.try_recv() {
+                self.images_loading = false;
+                match result {
+                    Ok(list) => {
+                        self.images = list;
+                        self.images_error = None;
+                        // Clamp selection to new list length.
+                        if self.images_selected >= self.images.len() {
+                            self.images_selected = self.images.len().saturating_sub(1);
+                        }
+                    }
+                    Err(e) => {
+                        self.images_error = Some(e);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Drain any image inspect result delivered by the background fetch thread.
+    pub fn poll_image_inspect_result(&mut self) {
+        if let Some(rx) = &self.image_inspect_rx {
+            while let Ok(result) = rx.try_recv() {
+                self.image_inspect_loading = false;
+                match result {
+                    Ok(json) => {
+                        self.image_inspect_lines =
+                            json.lines().map(|l| l.to_string()).collect();
+                        self.image_inspect_scroll = 0;
+                    }
+                    Err(e) => {
+                        self.image_inspect_lines = vec![format!("Error: {}", e)];
+                    }
+                }
             }
         }
     }

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -534,11 +534,7 @@ fn execute_image_inspect_bg(
 /// Run `pelagos ps --json --all`, find the container named `name`, and send it
 /// back via `tx`.  If the container is not found or the query fails the channel
 /// simply stays empty and the overlay shows a loading indicator.
-fn execute_inspect_bg(
-    profile: &str,
-    name: &str,
-    tx: Option<mpsc::SyncSender<runner::Container>>,
-) {
+fn execute_inspect_bg(profile: &str, name: &str, tx: Option<mpsc::SyncSender<runner::Container>>) {
     let tx = match tx {
         Some(t) => t,
         None => return,
@@ -850,7 +846,12 @@ fn resolve_pelagos_path() -> String {
 
 fn open_in_terminal(profile: &str, input: &str) -> anyhow::Result<()> {
     let pelagos = resolve_pelagos_path();
-    let cmd = format!("{} --profile {} run {}", pelagos, shell_escape(profile), input);
+    let cmd = format!(
+        "{} --profile {} run {}",
+        pelagos,
+        shell_escape(profile),
+        input
+    );
     log::debug!("open_in_terminal: cmd={:?}", cmd);
 
     if let Ok(term_bin) = std::env::var("PELAGOS_TERMINAL") {

--- a/pelagos-tui/src/main.rs
+++ b/pelagos-tui/src/main.rs
@@ -29,7 +29,7 @@ use crossterm::{
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
 
-use app::{App, ConfirmAction, SubscriptionMsg};
+use app::{App, ConfirmAction, ImageInfo, SubscriptionMsg};
 use runner::{MacOsRunner, Runner};
 
 /// Shared state that the subscription thread reads before each (re)connect.
@@ -284,6 +284,49 @@ fn run_loop(
             });
         }
 
+        // Images: drain background fetch results.
+        app.poll_image_ls_result();
+        app.poll_image_inspect_result();
+
+        // Images: spawn background image list fetch.
+        if app.pending_image_ls {
+            app.pending_image_ls = false;
+            let profile = app.profile.clone();
+            let tx = app.image_ls_tx.clone();
+            std::thread::spawn(move || {
+                execute_image_ls_bg(&profile, tx);
+            });
+        }
+
+        // Images: spawn background pull.
+        if let Some(reference) = app.pending_image_pull.take() {
+            let profile = app.profile.clone();
+            let status_tx = app.status_tx.clone();
+            let ls_tx = app.image_ls_tx.clone();
+            std::thread::spawn(move || {
+                execute_image_pull_bg(&profile, &reference, status_tx, ls_tx);
+            });
+        }
+
+        // Images: spawn background rm (after confirm).
+        if let Some(reference) = app.pending_image_rm.take() {
+            let profile = app.profile.clone();
+            let status_tx = app.status_tx.clone();
+            let ls_tx = app.image_ls_tx.clone();
+            std::thread::spawn(move || {
+                execute_image_rm_bg(&profile, &reference, status_tx, ls_tx);
+            });
+        }
+
+        // Image inspect: spawn background fetch.
+        if let Some(reference) = app.pending_image_inspect.take() {
+            let profile = app.profile.clone();
+            let tx = app.image_inspect_tx.clone();
+            std::thread::spawn(move || {
+                execute_image_inspect_bg(&profile, &reference, tx);
+            });
+        }
+
         // Command palette: execute pending run in a background thread so the
         // event loop never blocks.  The subscription thread will deliver the
         // ContainerStarted event when the container appears.
@@ -331,6 +374,157 @@ fn run_loop(
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Image background functions (never block event loop)
+// ---------------------------------------------------------------------------
+
+/// Run `pelagos --profile <p> image ls --json`, parse into `Vec<ImageInfo>`, send result.
+fn execute_image_ls_bg(
+    profile: &str,
+    tx: Option<mpsc::SyncSender<Result<Vec<ImageInfo>, String>>>,
+) {
+    let tx = match tx {
+        Some(t) => t,
+        None => return,
+    };
+
+    let out = std::process::Command::new("pelagos")
+        .arg("--profile")
+        .arg(profile)
+        .arg("image")
+        .arg("ls")
+        .arg("--json")
+        .stdin(std::process::Stdio::null())
+        .output();
+
+    let result = match out {
+        Ok(o) if o.status.success() => {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            match serde_json::from_str::<Vec<ImageInfo>>(stdout.trim()) {
+                Ok(list) => Ok(list),
+                Err(e) => Err(format!("parse error: {}", e)),
+            }
+        }
+        Ok(o) => Err(String::from_utf8_lossy(&o.stderr).trim().to_string()),
+        Err(e) => Err(e.to_string()),
+    };
+
+    let _ = tx.try_send(result);
+}
+
+/// Run `pelagos --profile <p> image pull <reference>`, then refresh the image list.
+fn execute_image_pull_bg(
+    profile: &str,
+    reference: &str,
+    status_tx: Option<mpsc::SyncSender<String>>,
+    ls_tx: Option<mpsc::SyncSender<Result<Vec<ImageInfo>, String>>>,
+) {
+    log::info!("image pull: profile={} reference={}", profile, reference);
+
+    let result = std::process::Command::new("pelagos")
+        .arg("--profile")
+        .arg(profile)
+        .arg("image")
+        .arg("pull")
+        .arg(reference)
+        .stdin(std::process::Stdio::null())
+        .output();
+
+    match result {
+        Ok(out) if out.status.success() => {
+            // Refresh image list after successful pull.
+            execute_image_ls_bg(profile, ls_tx);
+        }
+        Ok(out) => {
+            let msg = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            let msg = if msg.is_empty() {
+                format!("pull failed (exit {})", out.status)
+            } else {
+                format!("pull: {}", msg)
+            };
+            log::warn!("{}", msg);
+            send_status(&status_tx, msg);
+        }
+        Err(e) => {
+            send_status(&status_tx, format!("pull: {}", e));
+        }
+    }
+}
+
+/// Run `pelagos --profile <p> image rm <reference>`, then refresh the image list.
+fn execute_image_rm_bg(
+    profile: &str,
+    reference: &str,
+    status_tx: Option<mpsc::SyncSender<String>>,
+    ls_tx: Option<mpsc::SyncSender<Result<Vec<ImageInfo>, String>>>,
+) {
+    log::info!("image rm: profile={} reference={}", profile, reference);
+
+    let result = std::process::Command::new("pelagos")
+        .arg("--profile")
+        .arg(profile)
+        .arg("image")
+        .arg("rm")
+        .arg(reference)
+        .stdin(std::process::Stdio::null())
+        .output();
+
+    match result {
+        Ok(out) if out.status.success() => {
+            execute_image_ls_bg(profile, ls_tx);
+        }
+        Ok(out) => {
+            let msg = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            let msg = if msg.is_empty() {
+                format!("rm failed (exit {})", out.status)
+            } else {
+                format!("image rm: {}", msg)
+            };
+            log::warn!("{}", msg);
+            send_status(&status_tx, msg);
+        }
+        Err(e) => {
+            send_status(&status_tx, format!("image rm: {}", e));
+        }
+    }
+}
+
+/// Run `pelagos --profile <p> image inspect <reference>`, send pretty JSON string.
+fn execute_image_inspect_bg(
+    profile: &str,
+    reference: &str,
+    tx: Option<mpsc::SyncSender<Result<String, String>>>,
+) {
+    let tx = match tx {
+        Some(t) => t,
+        None => return,
+    };
+
+    let out = std::process::Command::new("pelagos")
+        .arg("--profile")
+        .arg(profile)
+        .arg("image")
+        .arg("inspect")
+        .arg(reference)
+        .stdin(std::process::Stdio::null())
+        .output();
+
+    let result = match out {
+        Ok(o) if o.status.success() => Ok(String::from_utf8_lossy(&o.stdout).trim().to_string()),
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
+            Err(if stderr.is_empty() {
+                format!("inspect failed (exit {})", o.status)
+            } else {
+                stderr
+            })
+        }
+        Err(e) => Err(e.to_string()),
+    };
+
+    let _ = tx.try_send(result);
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -178,7 +178,7 @@ fn render_hint_bar(f: &mut Frame, app: &App, area: Rect) {
         Mode::ConfirmQuit => "  quit pelagos-tui: [y/q]yes  [any]cancel",
         Mode::Inspect => "  [j/k]scroll  [Esc/q]close",
         Mode::ImageInspect => "  [j/k]scroll  [Esc/q]close",
-        Mode::Images => "  [I/Esc]containers  [j/k]nav  [p]pull  [d]delete  [Enter]inspect  [r]refresh",
+        Mode::Images => "  [I/Esc]containers  [j/k]nav  [R]run  [p]pull  [d]delete  [Enter]inspect  [r]refresh",
         _ => "  [q]quit  [a]all  [j/k]nav  [Space]sel  [s]stop  [S]restart  [d]rm  [P]prune  [r]run-i  [R]run-d  [i/Enter]inspect  [p]profile  [I]images",
     };
     let hints = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -35,8 +35,7 @@ pub fn render(f: &mut Frame, app: &App) {
     if app.mode == Mode::Images
         || app.mode == Mode::ImagePull
         || app.mode == Mode::ImageInspect
-        || (app.mode == Mode::Confirm
-            && app.confirm_action == Some(ConfirmAction::ImageRm))
+        || (app.mode == Mode::Confirm && app.confirm_action == Some(ConfirmAction::ImageRm))
     {
         render_images(f, app, chunks[0]);
     } else {
@@ -240,7 +239,11 @@ fn render_modeline(f: &mut Frame, app: &App, area: Rect) {
                     .to_string()
             } else {
                 let count = app.confirm_targets.len();
-                let noun = if count == 1 { "container" } else { "containers" };
+                let noun = if count == 1 {
+                    "container"
+                } else {
+                    "containers"
+                };
                 format!("{} {}", count, noun)
             };
             let spans = vec![
@@ -416,8 +419,12 @@ fn render_profile_picker(f: &mut Frame, app: &App, area: Rect) {
 
 fn render_inspect_overlay(f: &mut Frame, app: &App, area: Rect) {
     // Popup dimensions: 70% wide, up to 80% tall.
-    let popup_width = (area.width * 70 / 100).max(60).min(area.width.saturating_sub(4));
-    let popup_height = (area.height * 80 / 100).max(10).min(area.height.saturating_sub(4));
+    let popup_width = (area.width * 70 / 100)
+        .max(60)
+        .min(area.width.saturating_sub(4));
+    let popup_height = (area.height * 80 / 100)
+        .max(10)
+        .min(area.height.saturating_sub(4));
     let popup_x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let popup_y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
@@ -503,14 +510,8 @@ fn build_inspect_lines(c: &Container) -> Vec<Line<'static>> {
         label("STATUS"),
         Span::styled(c.status.clone(), Style::default().fg(status_color)),
     ]));
-    lines.push(Line::from(vec![
-        label("IMAGE"),
-        value(c.rootfs.clone()),
-    ]));
-    lines.push(Line::from(vec![
-        label("PID"),
-        value(c.pid.to_string()),
-    ]));
+    lines.push(Line::from(vec![label("IMAGE"), value(c.rootfs.clone())]));
+    lines.push(Line::from(vec![label("PID"), value(c.pid.to_string())]));
     lines.push(Line::from(vec![
         label("UPTIME"),
         value(format_uptime(&c.started_at)),
@@ -520,11 +521,7 @@ fn build_inspect_lines(c: &Container) -> Vec<Line<'static>> {
             label("EXIT CODE"),
             Span::styled(
                 code.to_string(),
-                Style::default().fg(if code == 0 {
-                    Color::Green
-                } else {
-                    Color::Red
-                }),
+                Style::default().fg(if code == 0 { Color::Green } else { Color::Red }),
             ),
         ]));
     }
@@ -544,10 +541,7 @@ fn build_inspect_lines(c: &Container) -> Vec<Line<'static>> {
         lines.push(inspect_section("NETWORK"));
         if let Some(ip) = &c.bridge_ip {
             lines.push(Line::from(vec![
-                Span::styled(
-                    "    bridge       ",
-                    Style::default().fg(Color::DarkGray),
-                ),
+                Span::styled("    bridge       ", Style::default().fg(Color::DarkGray)),
                 value(ip.clone()),
             ]));
         }
@@ -714,8 +708,7 @@ fn render_images(f: &mut Frame, app: &App, area: Rect) {
         let p = Paragraph::new("  loading…").style(Style::default().fg(Color::DarkGray));
         f.render_widget(p, inner);
     } else if let Some(err) = &app.images_error {
-        let p = Paragraph::new(format!("  error: {}", err))
-            .style(Style::default().fg(Color::Red));
+        let p = Paragraph::new(format!("  error: {}", err)).style(Style::default().fg(Color::Red));
         f.render_widget(p, inner);
     } else if app.images.is_empty() {
         let p = Paragraph::new("  No images. Press 'p' to pull one.")
@@ -729,8 +722,12 @@ fn render_images(f: &mut Frame, app: &App, area: Rect) {
 // ---------------------------------------------------------------------------
 
 fn render_image_inspect_overlay(f: &mut Frame, app: &App, area: Rect) {
-    let popup_width = (area.width * 70 / 100).max(60).min(area.width.saturating_sub(4));
-    let popup_height = (area.height * 80 / 100).max(10).min(area.height.saturating_sub(4));
+    let popup_width = (area.width * 70 / 100)
+        .max(60)
+        .min(area.width.saturating_sub(4));
+    let popup_height = (area.height * 80 / 100)
+        .max(10)
+        .min(area.height.saturating_sub(4));
     let popup_x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let popup_y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);

--- a/pelagos-tui/src/ui.rs
+++ b/pelagos-tui/src/ui.rs
@@ -31,7 +31,17 @@ pub fn render(f: &mut Frame, app: &App) {
         ])
         .split(area);
 
-    render_table(f, app, chunks[0]);
+    // Main content area: containers or images depending on mode.
+    if app.mode == Mode::Images
+        || app.mode == Mode::ImagePull
+        || app.mode == Mode::ImageInspect
+        || (app.mode == Mode::Confirm
+            && app.confirm_action == Some(ConfirmAction::ImageRm))
+    {
+        render_images(f, app, chunks[0]);
+    } else {
+        render_table(f, app, chunks[0]);
+    }
     render_hint_bar(f, app, chunks[1]);
     render_modeline(f, app, chunks[2]);
 
@@ -41,6 +51,10 @@ pub fn render(f: &mut Frame, app: &App) {
 
     if app.mode == Mode::Inspect {
         render_inspect_overlay(f, app, area);
+    }
+
+    if app.mode == Mode::ImageInspect {
+        render_image_inspect_overlay(f, app, area);
     }
 }
 
@@ -159,10 +173,13 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
 fn render_hint_bar(f: &mut Frame, app: &App, area: Rect) {
     let text = match app.mode {
         Mode::CommandPalette => "  [Enter]run  [Esc]cancel",
+        Mode::ImagePull => "  [Enter]pull  [Esc]cancel",
         Mode::Confirm => "  confirm action: [y]yes  [any]cancel",
         Mode::ConfirmQuit => "  quit pelagos-tui: [y/q]yes  [any]cancel",
-        Mode::Inspect => "  [j/k] scroll  [Esc/q] close",
-        _ => "  [q]quit  [a]all  [j/k]nav  [Space]sel  [s]stop  [S]restart  [d]rm  [P]prune  [r]run-i  [R]run-d  [i/Enter]inspect  [p]profile",
+        Mode::Inspect => "  [j/k]scroll  [Esc/q]close",
+        Mode::ImageInspect => "  [j/k]scroll  [Esc/q]close",
+        Mode::Images => "  [I/Esc]containers  [j/k]nav  [p]pull  [d]delete  [Enter]inspect  [r]refresh",
+        _ => "  [q]quit  [a]all  [j/k]nav  [Space]sel  [s]stop  [S]restart  [d]rm  [P]prune  [r]run-i  [R]run-d  [i/Enter]inspect  [p]profile  [I]images",
     };
     let hints = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));
     f.render_widget(hints, area);
@@ -208,17 +225,23 @@ fn render_modeline(f: &mut Frame, app: &App, area: Rect) {
     // In confirm mode the modeline shows the action + target count prompt.
     if app.mode == Mode::Confirm {
         if let Some(action) = &app.confirm_action {
-            let count = app.confirm_targets.len();
-            let noun = if count == 1 {
-                "container"
-            } else {
-                "containers"
-            };
             let action_color = match action {
-                ConfirmAction::Remove => Color::Red,
-                ConfirmAction::StopAndRemove => Color::Red,
+                ConfirmAction::Remove | ConfirmAction::StopAndRemove | ConfirmAction::ImageRm => {
+                    Color::Red
+                }
                 ConfirmAction::Stop => Color::Yellow,
                 ConfirmAction::Restart => Color::Cyan,
+            };
+            let subject = if *action == ConfirmAction::ImageRm {
+                app.confirm_targets
+                    .first()
+                    .map(|s| s.as_str())
+                    .unwrap_or("image")
+                    .to_string()
+            } else {
+                let count = app.confirm_targets.len();
+                let noun = if count == 1 { "container" } else { "containers" };
+                format!("{} {}", count, noun)
             };
             let spans = vec![
                 Span::styled(
@@ -227,10 +250,7 @@ fn render_modeline(f: &mut Frame, app: &App, area: Rect) {
                         .fg(action_color)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(
-                    format!("{} {}?  ", count, noun),
-                    Style::default().fg(Color::White),
-                ),
+                Span::styled(format!("{}?  ", subject), Style::default().fg(Color::White)),
                 Span::styled("[y/N] ", Style::default().fg(Color::Yellow)),
             ];
             let modeline = Paragraph::new(Line::from(spans))
@@ -254,6 +274,27 @@ fn render_modeline(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(Color::White),
             ),
             Span::styled(CURSOR, Style::default().fg(Color::Yellow)),
+        ];
+        let modeline = Paragraph::new(Line::from(spans))
+            .style(Style::default().bg(Color::Black).fg(Color::White));
+        f.render_widget(modeline, area);
+        return;
+    }
+
+    // In image pull mode the modeline becomes a pull input field.
+    if app.mode == Mode::ImagePull {
+        let spans = vec![
+            Span::styled(
+                "  pull> ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                app.image_pull_input.as_str(),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled(CURSOR, Style::default().fg(Color::Cyan)),
         ];
         let modeline = Paragraph::new(Line::from(spans))
             .style(Style::default().bg(Color::Black).fg(Color::White));
@@ -612,6 +653,123 @@ fn build_inspect_lines(c: &Container) -> Vec<Line<'static>> {
     }
 
     lines
+}
+
+// ---------------------------------------------------------------------------
+// Images screen
+// ---------------------------------------------------------------------------
+
+fn render_images(f: &mut Frame, app: &App, area: Rect) {
+    let header = Row::new(vec![
+        Cell::from("REPOSITORY:TAG").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("LAYERS").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("DIGEST").style(Style::default().add_modifier(Modifier::BOLD)),
+    ])
+    .height(1);
+
+    let rows: Vec<Row> = app
+        .images
+        .iter()
+        .map(|img| {
+            Row::new(vec![
+                Cell::from(img.reference.as_str()),
+                Cell::from(img.layers.len().to_string())
+                    .style(Style::default().fg(Color::DarkGray)),
+                Cell::from(img.short_digest().to_string())
+                    .style(Style::default().fg(Color::DarkGray)),
+            ])
+            .height(1)
+        })
+        .collect();
+
+    let mut table_state = TableState::default();
+    if !app.images.is_empty() {
+        table_state.select(Some(app.images_selected));
+    }
+
+    let title = format!(" images — {} ", app.profile);
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(70),
+            Constraint::Percentage(10),
+            Constraint::Percentage(20),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::ALL).title(title))
+    .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+    .highlight_symbol("▶ ");
+
+    f.render_stateful_widget(table, area, &mut table_state);
+
+    // Loading / error / empty state messages.
+    let inner = Rect {
+        x: area.x + 1,
+        y: area.y + area.height / 2,
+        width: area.width.saturating_sub(2),
+        height: 1,
+    };
+    if app.images_loading {
+        let p = Paragraph::new("  loading…").style(Style::default().fg(Color::DarkGray));
+        f.render_widget(p, inner);
+    } else if let Some(err) = &app.images_error {
+        let p = Paragraph::new(format!("  error: {}", err))
+            .style(Style::default().fg(Color::Red));
+        f.render_widget(p, inner);
+    } else if app.images.is_empty() {
+        let p = Paragraph::new("  No images. Press 'p' to pull one.")
+            .style(Style::default().fg(Color::DarkGray));
+        f.render_widget(p, inner);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Image inspect overlay
+// ---------------------------------------------------------------------------
+
+fn render_image_inspect_overlay(f: &mut Frame, app: &App, area: Rect) {
+    let popup_width = (area.width * 70 / 100).max(60).min(area.width.saturating_sub(4));
+    let popup_height = (area.height * 80 / 100).max(10).min(area.height.saturating_sub(4));
+    let popup_x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let popup_y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
+
+    f.render_widget(Clear, popup_area);
+
+    let reference = app
+        .images
+        .get(app.images_selected)
+        .map(|img| img.reference.as_str())
+        .unwrap_or("image");
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", reference))
+        .title_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
+    let inner = block.inner(popup_area);
+    f.render_widget(block, popup_area);
+
+    if app.image_inspect_loading {
+        let p = Paragraph::new("  loading…").style(Style::default().fg(Color::DarkGray));
+        f.render_widget(p, inner);
+        return;
+    }
+
+    let lines: Vec<Line> = app
+        .image_inspect_lines
+        .iter()
+        .map(|l| Line::from(Span::styled(l.as_str(), Style::default().fg(Color::White))))
+        .collect();
+
+    let max_scroll = lines.len().saturating_sub(inner.height as usize);
+    let scroll = app.image_inspect_scroll.min(max_scroll);
+    let visible: Vec<Line> = lines.into_iter().skip(scroll).collect();
+    f.render_widget(Paragraph::new(visible), inner);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Phase 1 (protocol)**: Added `ImageLs`, `ImagePull`, `ImageRm`, `ImageTag`, `ImageInspect` variants to the `GuestCommand` vsock protocol in both `pelagos-mac` and `pelagos-guest`
- **Phase 2 (CLI)**: Added `pelagos image ls|pull|rm|tag|inspect` subcommands; `image ls` defaults to human-readable table, `--json` flag for machine output; `image inspect` filters client-side by reference
- **Phase 3 (TUI)**: Full image management screen (`I` from container view) — browse images, pull, delete with confirm, inspect JSON overlay, and `R` to launch the run palette with the selected image pre-filled

## Test plan

- [ ] `cargo test` passes (106 tests)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `pelagos image ls` shows table; `pelagos image ls --json` shows JSON
- [ ] `pelagos image pull <ref>` streams pull progress
- [ ] `pelagos image inspect <ref>` returns filtered JSON for that image
- [ ] TUI: `I` opens image screen, `j`/`k` navigate, `r` refreshes, `p` pulls, `d` deletes with confirm, Enter inspects, `R` opens run palette with image pre-filled, `Esc` returns to containers

Closes #178
Closes #179
Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)