### PR TITLE
feat(network): add --network/--dns passthrough to pelagos run

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -115,6 +115,12 @@ pub enum GuestCommand {
         /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
         #[serde(default)]
         publish: Vec<String>,
+        /// Network mode forwarded to `pelagos run --network`.
+        #[serde(default)]
+        network: Option<String>,
+        /// DNS servers forwarded to `pelagos run --dns`.
+        #[serde(default)]
+        dns: Vec<String>,
     },
     Exec {
         image: String,
@@ -133,6 +139,12 @@ pub enum GuestCommand {
         /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
         #[serde(default)]
         publish: Vec<String>,
+        /// Network mode forwarded to `pelagos run --network`.
+        #[serde(default)]
+        network: Option<String>,
+        /// DNS servers forwarded to `pelagos run --dns`.
+        #[serde(default)]
+        dns: Vec<String>,
     },
     /// Exec a command inside an already-running container by name.
     /// Enters the container's namespaces via setns(2) and execs the command.
@@ -510,6 +522,8 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 detach,
                 labels,
                 publish,
+                network,
+                dns,
             } => {
                 run_container(
                     &mut writer,
@@ -521,6 +535,8 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                     detach,
                     &labels,
                     &publish,
+                    network.as_deref(),
+                    &dns,
                 )?;
             }
             GuestCommand::Exec {
@@ -532,6 +548,8 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 mounts,
                 labels,
                 publish,
+                network,
+                dns,
             } => {
                 handle_exec(
                     fd,
@@ -543,6 +561,8 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                     &mounts,
                     &labels,
                     &publish,
+                    network.as_deref(),
+                    &dns,
                 )?;
                 return Ok(());
             }
@@ -935,6 +955,8 @@ fn run_container(
     detach: bool,
     labels: &[String],
     publish: &[String],
+    network: Option<&str>,
+    dns: &[String],
 ) -> std::io::Result<()> {
     let pelagos = pelagos_bin();
 
@@ -983,6 +1005,12 @@ fn run_container(
     }
     for port_spec in publish {
         cmd.arg("--publish").arg(port_spec);
+    }
+    if let Some(net) = network {
+        cmd.arg("--network").arg(net);
+    }
+    for server in dns {
+        cmd.arg("--dns").arg(server);
     }
     cmd.arg(image);
     if !args.is_empty() {
@@ -1674,6 +1702,8 @@ fn handle_exec(
     mounts: &[GuestMount],
     labels: &[String],
     publish: &[String],
+    network: Option<&str>,
+    dns: &[String],
 ) -> std::io::Result<()> {
     let pelagos = pelagos_bin();
 
@@ -1709,6 +1739,12 @@ fn handle_exec(
     }
     for port in publish {
         cmd.arg("--publish").arg(port);
+    }
+    if let Some(net) = network {
+        cmd.arg("--network").arg(net);
+    }
+    for server in dns {
+        cmd.arg("--dns").arg(server);
     }
     for m in mounts {
         let host_dir = if m.subpath.is_empty() {

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -111,6 +111,12 @@ enum Commands {
         /// Allocate a pseudo-TTY
         #[arg(short = 't', long)]
         tty: bool,
+        /// Network mode: none, loopback, bridge, or pasta (repeatable; first is primary)
+        #[arg(long = "network", short = 'n')]
+        network: Vec<String>,
+        /// DNS server inside the container (repeatable; requires bridge or pasta)
+        #[arg(long)]
+        dns: Vec<String>,
     },
     /// Run a command inside an already-running container (enters its namespaces).
     /// Equivalent to `docker exec`.
@@ -384,6 +390,12 @@ enum GuestCommand {
         /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         publish: Vec<String>,
+        /// Network mode forwarded to `pelagos run --network`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        network: Option<String>,
+        /// DNS servers forwarded to `pelagos run --dns`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        dns: Vec<String>,
     },
     Exec {
         image: String,
@@ -400,6 +412,12 @@ enum GuestCommand {
         /// Port mappings HOST:CONTAINER forwarded to `pelagos run --publish`.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         publish: Vec<String>,
+        /// Network mode forwarded to `pelagos run --network`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        network: Option<String>,
+        /// DNS servers forwarded to `pelagos run --dns`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        dns: Vec<String>,
     },
     ExecInto {
         container: String,
@@ -742,6 +760,8 @@ fn main() {
             ref labels,
             interactive,
             tty,
+            ref network,
+            ref dns,
         } => {
             let image = image.clone();
             let args = args.clone();
@@ -835,6 +855,8 @@ fn main() {
                         mounts,
                         labels,
                         publish: cli.ports.clone(),
+                        network: network.first().cloned(),
+                        dns: dns.clone(),
                     },
                     tty,
                 ));
@@ -851,6 +873,8 @@ fn main() {
                     env: env_map,
                     labels,
                     publish: cli.ports.clone(),
+                    network: network.first().cloned(),
+                    dns: dns.clone(),
                 },
             );
             // For foreground containers the CLI process stays alive until the
@@ -2944,6 +2968,8 @@ mod tests {
             env: std::collections::HashMap::new(),
             labels: vec![],
             publish: vec![],
+            network: None,
+            dns: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -2966,6 +2992,8 @@ mod tests {
             env: std::collections::HashMap::new(),
             labels: vec![],
             publish: vec![],
+            network: None,
+            dns: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -2989,6 +3017,8 @@ mod tests {
             env: std::collections::HashMap::new(),
             labels: vec![],
             publish: vec![],
+            network: None,
+            dns: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -3084,6 +3114,8 @@ mod tests {
             mounts: vec![],
             labels: vec![],
             publish: vec![],
+            network: None,
+            dns: vec![],
         };
         let json = serde_json::to_string(&cmd).expect("serialize failed");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -81,10 +81,13 @@ echo "[release]   $(du -sh "$DIST/$BIN_TARBALL" | awk '{print $1}')  sha256: ${B
 # Normalise names: drop ubuntu- prefix and -custom suffix.
 cp "$OUT/ubuntu-vmlinuz"      "$VM_STAGING/vmlinuz"
 cp "$OUT/initramfs-custom.gz" "$VM_STAGING/initramfs.gz"
-cp "$OUT/root.img"            "$VM_STAGING/root.img"
+# Always create a fresh sparse placeholder — never ship the local disk which
+# contains per-machine container image cache and state.  On first boot the VM
+# formats this as ext4 and populates it from the initramfs.
+truncate -s 8192m "$VM_STAGING/root.img"
 
 echo "[release] packing ${VM_TARBALL}..."
-# root.img is sparse (~8.6 GiB logical, ~126 MiB actual); zeros compress well.
+# root.img is a fresh sparse 8192 MiB placeholder; zeros compress to ~1 MiB.
 COPYFILE_DISABLE=1 tar -czf "$DIST/$VM_TARBALL" -C "$VM_STAGING" .
 VM_SHA256="$(shasum -a 256 "$DIST/$VM_TARBALL" | awk '{print $1}')"
 echo "[release]   $(du -sh "$DIST/$VM_TARBALL" | awk '{print $1}')  sha256: ${VM_SHA256}"


### PR DESCRIPTION
## Summary

- Adds `-n/--network <mode>` and `--dns <server>` flags to `pelagos run`
- Threads the values through `GuestCommand::Run` and `GuestCommand::Exec` JSON protocol
- Guest daemon passes `--network` and `--dns` to `pelagos run` inside the VM
- Also fixes `build-release.sh` to use a fresh sparse `root.img` (not the live disk)

## Test

```
pelagos run --network pasta alpine wget -qO- http://example.com
```

TCP/UDP outbound internet works via pasta userspace proxy. ICMP ping requires
a kernel sysctl (`net.ipv4.ping_group_range`) that is not set in the guest by
default — expected.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)