### PR TITLE
fix(compose): deregister ports on compose up/down exit

### DIFF
--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -86,6 +86,11 @@ pub enum DaemonCmd {
     RegisterPort { host_port: u16, container_port: u16 },
     /// Stop listening on `host_port`.  Active connections are not affected.
     UnregisterPort { host_port: u16 },
+    /// Associate a set of host ports with a compose project name so they can
+    /// be bulk-deregistered when the project stops.
+    TrackComposeProject { project: String, host_ports: Vec<u16> },
+    /// Deregister all ports previously associated with a compose project.
+    UnregisterComposePorts { project: String },
 }
 
 /// One-line JSON response to a `DaemonCmd`.
@@ -101,12 +106,15 @@ pub enum DaemonResponse {
 struct PortState {
     /// Maps host_port → container_port for every currently active forward.
     active: HashMap<u16, u16>,
+    /// Maps compose project name → list of host ports it registered.
+    compose_projects: HashMap<String, Vec<u16>>,
 }
 
 impl PortState {
     fn new() -> Self {
         Self {
             active: HashMap::new(),
+            compose_projects: HashMap::new(),
         }
     }
 }
@@ -535,6 +543,32 @@ fn handle_daemon_cmd(
             if ps.active.remove(&host_port).is_some() {
                 dispatcher.send(DispatchCmd::Remove { host_port });
                 log::info!("[{conn_id:?}] unregistered port {}", host_port);
+            }
+            DaemonResponse::Ok
+        }
+        DaemonCmd::TrackComposeProject { project, host_ports } => {
+            let mut ps = port_state.lock().unwrap();
+            log::info!(
+                "[{conn_id:?}] tracking compose project '{}' with {} port(s)",
+                project,
+                host_ports.len()
+            );
+            ps.compose_projects.insert(project, host_ports);
+            DaemonResponse::Ok
+        }
+        DaemonCmd::UnregisterComposePorts { project } => {
+            let mut ps = port_state.lock().unwrap();
+            if let Some(ports) = ps.compose_projects.remove(&project) {
+                for host_port in ports {
+                    if ps.active.remove(&host_port).is_some() {
+                        dispatcher.send(DispatchCmd::Remove { host_port });
+                        log::info!(
+                            "[{conn_id:?}] compose '{}': unregistered port {}",
+                            project,
+                            host_port
+                        );
+                    }
+                }
             }
             DaemonResponse::Ok
         }

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -1385,7 +1385,12 @@ fn main() {
                 process::exit(1);
             }
 
+            // Derive the compose project name (used for port tracking).
+            let project_name = compose_project_name(&abs_file, project.as_deref());
+
             // Register macOS-side port listeners before the stack starts.
+            // Track which ports we successfully register so we can roll back on failure.
+            let mut registered_ports: Vec<u16> = vec![];
             for spec in &cli.ports {
                 if let Some(pf) = daemon::parse_port_spec(spec) {
                     if let Err(e) = send_daemon_cmd(
@@ -1395,10 +1400,30 @@ fn main() {
                             container_port: pf.container_port,
                         },
                     ) {
+                        // Roll back any ports we already registered.
+                        for &hp in &registered_ports {
+                            let _ = send_daemon_cmd(
+                                &profile,
+                                daemon::DaemonCmd::UnregisterPort { host_port: hp },
+                            );
+                        }
                         log::error!("port registration failed: {}", e);
                         process::exit(1);
                     }
+                    registered_ports.push(pf.host_port);
                 }
+            }
+
+            // Associate registered ports with this project so they can be
+            // bulk-deregistered on exit (issue #161).
+            if !registered_ports.is_empty() {
+                let _ = send_daemon_cmd(
+                    &profile,
+                    daemon::DaemonCmd::TrackComposeProject {
+                        project: project_name.clone(),
+                        host_ports: registered_ports,
+                    },
+                );
             }
 
             let stream = connect_or_exit(&profile);
@@ -1412,6 +1437,16 @@ fn main() {
                     args: extra_args,
                 },
             );
+
+            // Deregister ports on any exit (success or failure).
+            // For `compose down` this is a no-op if `up` already cleaned up.
+            let _ = send_daemon_cmd(
+                &profile,
+                daemon::DaemonCmd::UnregisterComposePorts {
+                    project: project_name,
+                },
+            );
+
             process::exit(exit_code);
         }
 
@@ -2260,6 +2295,24 @@ fn build_command(
 }
 
 // ---------------------------------------------------------------------------
+// compose helpers
+// ---------------------------------------------------------------------------
+
+/// Derive the compose project name for port-tracking purposes.
+///
+/// Matches Docker Compose v2 convention: use the explicit `--project-name`
+/// flag if given, otherwise fall back to the parent directory name of the
+/// compose file (lower-cased).
+fn compose_project_name(file: &std::path::Path, project_flag: Option<&str>) -> String {
+    if let Some(p) = project_flag {
+        return p.to_string();
+    }
+    file.parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_lowercase())
+        .unwrap_or_else(|| "default".to_string())
+}
+
 // docker cp helpers
 // ---------------------------------------------------------------------------
 

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -1049,8 +1049,10 @@ echo 'nameserver 8.8.4.4' >> /etc/resolv.conf
 # Container workloads write to their own overlayfs (on /dev/vda), not here.
 busybox mkdir -p /tmp /run /run/pelagos
 # pelagos looks for /run/netns/{name}; Alpine iproute2 creates /var/run/netns.
-# Symlink so both paths resolve to the same directory.
+# Mount as tmpfs so stale netns files do not survive a VM restart (issue #161).
+# Symlink /run/netns → /var/run/netns so both paths resolve to the same tmpfs.
 busybox mkdir -p /var/run/netns
+busybox mount -t tmpfs -o size=4m tmpfs /var/run/netns
 busybox ln -sf /var/run/netns /run/netns
 busybox mount -t tmpfs -o size=512m tmpfs /tmp
 


### PR DESCRIPTION
Fixes #161

## Summary

- **`DaemonCmd`**: add `TrackComposeProject` and `UnregisterComposePorts` variants; `PortState` gains a `compose_projects: HashMap<String, Vec<u16>>` for bulk deregistration by project name
- **`compose up`**: registers ports then sends `TrackComposeProject`; on any exit (success, failure, or Ctrl-C forwarded from guest) sends `UnregisterComposePorts`; rolls back already-registered ports on registration failure
- **`compose down`**: sends `UnregisterComposePorts` after the down command completes (no-op if `up` already cleaned up)
- **`compose_project_name()`**: new helper — uses `--project-name` flag if given, else parent directory name (matches Docker Compose v2 convention)
- **`build-vm-image.sh`**: mount `/var/run/netns` as tmpfs so stale netns files do not survive a VM restart

## Test plan

- [x] `cargo build -p pelagos-mac --release` — clean
- [x] `cargo clippy -p pelagos-mac -- -D warnings` — clean
- [x] `compose up` (core stack) — starts cleanly, prometheus healthy
- [x] `compose down` — stops cleanly, ports deregistered
- [x] `compose up` again **without VM restart** — no "port already registered" error ✅