### PR TITLE
feat(compose): forward host environment variables to the VM guest

### DIFF
--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -308,6 +308,10 @@ pub enum GuestCommand {
         /// Extra arguments forwarded verbatim (e.g. `["--foreground"]`, `["--follow", "grafana"]`).
         #[serde(default)]
         args: Vec<String>,
+        /// Environment variables from the macOS host, forwarded so that REML `(env ...)` calls
+        /// in the compose file can resolve secrets set in the caller's shell environment.
+        #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+        env: std::collections::HashMap<String, String>,
     },
 }
 
@@ -814,6 +818,7 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                 working_dir,
                 project,
                 args,
+                env,
             } => {
                 handle_compose(
                     &mut writer,
@@ -822,6 +827,7 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                     &working_dir,
                     project.as_deref(),
                     &args,
+                    &env,
                 )?;
             }
         }
@@ -856,6 +862,7 @@ fn handle_compose(
     working_dir: &str,
     project: Option<&str>,
     args: &[String],
+    env: &std::collections::HashMap<String, String>,
 ) -> std::io::Result<()> {
     let pelagos = pelagos_bin();
     let mut cmd = Command::new(&pelagos);
@@ -866,6 +873,9 @@ fn handle_compose(
     }
     for a in args {
         cmd.arg(a);
+    }
+    for (k, v) in env {
+        cmd.env(k, v);
     }
     cmd.current_dir(working_dir);
     spawn_and_stream(writer, cmd)

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -603,6 +603,10 @@ enum GuestCommand {
         project: Option<String>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         args: Vec<String>,
+        /// Host environment variables forwarded so that REML `(env ...)` calls
+        /// in the compose file resolve secrets from the caller's shell environment.
+        #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+        env: std::collections::HashMap<String, String>,
     },
 }
 
@@ -1435,6 +1439,7 @@ fn main() {
                     working_dir,
                     project,
                     args: extra_args,
+                    env: std::env::vars().collect(),
                 },
             );
 


### PR DESCRIPTION
Closes #201

## Problem

`GuestCommand::Compose` had no `env` field. When the macOS CLI sent a
compose request over vsock, the host environment was not included. The
REML `(env ...)` function runs inside the VM guest process, where the
caller's shell environment is absent — so every `(env "SECRET")` call
returned nil.

Services with non-empty fallbacks appeared to work:
- `grafana-password` falls back to `"admin"` — grafana starts, but with the wrong password
- `mikrotik-host` falls back to a hardcoded IP — works by coincidence

Services with empty-string fallbacks failed visibly:
- `truenas-api-key` falls back to `""` — Python script exits with *"TRUENAS_API_KEY is required"*

## Fix

Add `env: HashMap<String, String>` to `GuestCommand::Compose` (with
`#[serde(default, skip_serializing_if = "...is_empty")]` for backwards
compatibility). Populated from `std::env::vars()` on the macOS side.
The guest daemon sets these on the `pelagos compose` child process.

## Verified

All 7 monitoring stack services now start correctly, including
`truenas-api-exporter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)