### PR TITLE
fix(compose): forward only allowlisted env vars over vsock

### DIFF
--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -1430,6 +1430,11 @@ fn main() {
                 );
             }
 
+            // Forward only the env vars explicitly referenced in the compose file
+            // via (env "NAME") calls.  Forwarding the full host environment would
+            // expose unrelated shell secrets over vsock.
+            let compose_env = collect_compose_env(&abs_file);
+
             let stream = connect_or_exit(&profile);
             let exit_code = passthrough_command(
                 stream,
@@ -1439,7 +1444,7 @@ fn main() {
                     working_dir,
                     project,
                     args: extra_args,
-                    env: std::env::vars().collect(),
+                    env: compose_env,
                 },
             );
 
@@ -2308,6 +2313,35 @@ fn build_command(
 /// Matches Docker Compose v2 convention: use the explicit `--project-name`
 /// flag if given, otherwise fall back to the parent directory name of the
 /// compose file (lower-cased).
+/// Scan a compose `.reml` file for `(env "NAME")` calls and return a map of
+/// NAME → value for every such variable that is set in the current process
+/// environment.  Only variables explicitly referenced in the file are included;
+/// the rest of the host environment is never forwarded.
+fn collect_compose_env(
+    file: &std::path::Path,
+) -> std::collections::HashMap<String, String> {
+    let content = match std::fs::read_to_string(file) {
+        Ok(c) => c,
+        Err(_) => return std::collections::HashMap::new(),
+    };
+    let mut result = std::collections::HashMap::new();
+    let needle = "(env \"";
+    let mut search = content.as_str();
+    while let Some(start) = search.find(needle) {
+        search = &search[start + needle.len()..];
+        if let Some(end) = search.find('"') {
+            let name = &search[..end];
+            if !name.is_empty() {
+                if let Ok(val) = std::env::var(name) {
+                    result.insert(name.to_string(), val);
+                }
+            }
+            search = &search[end + 1..];
+        }
+    }
+    result
+}
+
 fn compose_project_name(file: &std::path::Path, project_flag: Option<&str>) -> String {
     if let Some(p) = project_flag {
         return p.to_string();


### PR DESCRIPTION
## Summary

- Replaces `std::env::vars().collect()` with `collect_compose_env()` which scans the `.reml` file for `(env "NAME")` patterns
- Only env vars explicitly referenced in the compose file are forwarded over vsock to the guest
- Eliminates the accidental forwarding of unrelated host secrets (AWS keys, tokens, `PATH`, etc.)

For the home monitoring stack, the allowlist resolves to exactly the 8 vars named in `compose.reml`: `GF_SECURITY_ADMIN_PASSWORD`, `GF_SMTP_USER`, `GF_SMTP_PASSWORD`, `MIKROTIK_HOST`, `TRUENAS_HOST`, `TRUENAS_API_KEY`, `PLEX_SERVER_URL`, `PLEX_TOKEN`.

Closes #201

## Test plan

- [ ] Run home monitoring stack with `.env` secrets set; verify truenas-api-exporter starts and Grafana uses correct admin password
- [ ] Run without secrets set; verify graceful degradation (services start, missing vars are absent in guest env)
- [ ] Verify a var NOT referenced in the compose file is not forwarded even if set in the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)