### PR TITLE
chore: cargo fmt

### DIFF
--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -88,7 +88,10 @@ pub enum DaemonCmd {
     UnregisterPort { host_port: u16 },
     /// Associate a set of host ports with a compose project name so they can
     /// be bulk-deregistered when the project stops.
-    TrackComposeProject { project: String, host_ports: Vec<u16> },
+    TrackComposeProject {
+        project: String,
+        host_ports: Vec<u16>,
+    },
     /// Deregister all ports previously associated with a compose project.
     UnregisterComposePorts { project: String },
 }
@@ -546,7 +549,10 @@ fn handle_daemon_cmd(
             }
             DaemonResponse::Ok
         }
-        DaemonCmd::TrackComposeProject { project, host_ports } => {
+        DaemonCmd::TrackComposeProject {
+            project,
+            host_ports,
+        } => {
             let mut ps = port_state.lock().unwrap();
             log::info!(
                 "[{conn_id:?}] tracking compose project '{}' with {} port(s)",

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -2317,9 +2317,7 @@ fn build_command(
 /// NAME → value for every such variable that is set in the current process
 /// environment.  Only variables explicitly referenced in the file are included;
 /// the rest of the host environment is never forwarded.
-fn collect_compose_env(
-    file: &std::path::Path,
-) -> std::collections::HashMap<String, String> {
+fn collect_compose_env(file: &std::path::Path) -> std::collections::HashMap<String, String> {
     let content = match std::fs::read_to_string(file) {
         Ok(c) => c,
         Err(_) => return std::collections::HashMap::new(),


### PR DESCRIPTION
Formatting fixes only — `cargo fmt` on daemon.rs and main.rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)