### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["skeptomai"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for the v0.5.2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)