### PR TITLE
docs: add uninstall section and upgrade/uninstall caveats to formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,16 @@ jobs:
                 Then verify and run a container:
                   pelagos ping
                   pelagos run alpine echo hello
+
+                To upgrade:
+                  brew upgrade pelagos-containers/tap/pelagos-mac
+                  pelagos vm init --force   # stops old VM, re-inits with new image
+                  pelagos ping
+
+                To uninstall completely:
+                  pelagos vm stop
+                  brew uninstall pelagos-containers/tap/pelagos-mac
+                  rm -rf ~/.local/share/pelagos   # OCI cache + vm.conf (not removed by brew)
               EOS
             end
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -33,14 +33,27 @@ subsequent command reuses the running VM.
 
 ```bash
 brew upgrade pelagos-containers/tap/pelagos-mac
-pelagos vm stop         # stop old VM daemon
-pelagos vm init --force # re-init with new kernel + initramfs
+pelagos vm init --force   # stops old VM, re-inits with new kernel + initramfs
 pelagos ping
 ```
 
-`--force` overwrites the existing `vm.conf` and replaces `root.img` with the
-fresh placeholder from the new release. Any cached container images on the old
-disk are lost; they will be re-pulled on next use.
+`--force` stops any running VM, overwrites `vm.conf`, and replaces `root.img`
+with the fresh placeholder from the new release. Any cached container images on
+the old disk are lost; they will be re-pulled on next use.
+
+### Uninstall
+
+```bash
+pelagos vm stop                    # stop the VM if running
+brew uninstall pelagos-containers/tap/pelagos-mac
+rm -rf ~/.local/share/pelagos      # removes OCI cache, vm.conf, and all state
+```
+
+`brew uninstall` removes the binaries and VM artifacts under `/opt/homebrew/`.
+The state directory (`~/.local/share/pelagos/`) is not managed by Homebrew and
+must be removed manually. It contains the writable disk image (OCI layer cache)
+and `vm.conf` — omit the `rm` if you want to preserve cached images for a
+reinstall.
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixes the Upgrading section in `docs/INSTALL.md`: removes the now-redundant `pelagos vm stop` step since v0.6.8 stops the running VM automatically
- Adds an Uninstall section to `docs/INSTALL.md` with the 3-command procedure
- Adds upgrade and uninstall instructions to the Homebrew formula caveats in `release.yml` so they appear in `brew info` and post-install output

## Test plan

- [ ] Verify `docs/INSTALL.md` Upgrading section no longer references manual `pelagos vm stop`
- [ ] Verify `docs/INSTALL.md` Uninstall section is present with correct commands
- [ ] Verify `release.yml` formula caveats include upgrade and uninstall instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)