### PR TITLE
chore: bump to v0.6.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.8"
+version = "0.6.9"
 edition = "2021"
 authors = ["skeptomai"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps workspace version in `Cargo.toml` from 0.6.8 to 0.6.9

## Test plan

- [ ] Verify `cargo pkgid pelagos-mac` reports 0.6.9
- [ ] Verify `pelagos-mac --version` reports 0.6.9 after release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)