### PR TITLE
chore: bump to v0.6.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.9"
+version = "0.6.10"
 edition = "2021"
 authors = ["skeptomai"]
 license = "Apache-2.0"


### PR DESCRIPTION
Bump workspace version from 0.6.9 to 0.6.10.