### PR TITLE
fix(daemon): self-terminate when binary is removed from disk

### DIFF
--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -328,7 +328,22 @@ pub fn run(args: DaemonArgs) -> ! {
     }
 
     // Accept loop: use poll(2) with 1-second timeout so SIGTERM is checked promptly.
+    let mut loop_tick: u32 = 0;
     loop {
+        // Every 30 s check whether our own binary still exists.  If it has been
+        // removed (e.g. `brew uninstall`) we shut down so we don't silently
+        // consume resources on machines that rarely reboot.
+        loop_tick = loop_tick.wrapping_add(1);
+        if loop_tick.is_multiple_of(30) {
+            let binary_gone = std::env::current_exe()
+                .map(|p| !p.exists())
+                .unwrap_or(false);
+            if binary_gone {
+                log::info!("binary removed from disk — shutting down");
+                shutdown.store(true, Ordering::Relaxed);
+            }
+        }
+
         if shutdown.load(Ordering::Relaxed) {
             log::info!("shutdown requested, stopping VM...");
             dispatcher.send(DispatchCmd::Shutdown);

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -2130,9 +2130,12 @@ fn vm_init(profile: &str, vm_data: Option<&std::path::Path>, force: bool) -> std
             .parent()
             .ok_or_else(|| Error::new(ErrorKind::NotFound, "binary has no parent directory"))?;
 
-        // Check Homebrew pkgshare first, then dev out/.
+        // Check Homebrew formula layout (bin/../share/pelagos-mac), then cask
+        // layout (staged_path/share/pelagos-mac where binary sits at
+        // staged_path root), then dev out/.
         let candidates = [
             bin_dir.join("../share/pelagos-mac"),
+            bin_dir.join("share/pelagos-mac"),
             bin_dir.join("../../../out"),
         ];
         candidates


### PR DESCRIPTION
## Summary

- VM daemon polls every 30 s to check whether its own binary still exists on disk; if removed (e.g. `brew uninstall pelagos-mac`) it initiates the normal SIGTERM shutdown path instead of running indefinitely on machines that rarely reboot.
- Adds `bin_dir/share/pelagos-mac` as a vm_init artifact discovery candidate alongside the existing formula path, preparing the layout for Homebrew cask packaging.

Part of #222 — cask migration itself is blocked on obtaining a Developer ID certificate for code signing.

## Test plan

- [ ] Build and sign a development binary, start the daemon, then delete the binary from disk — confirm daemon exits cleanly within ~30 s
- [ ] Confirm existing `vm start` / `vm stop` / vsock flows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)