### PR TITLE
chore: bump to v0.6.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 authors = ["skeptomai"]
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps workspace version from 0.6.10 to 0.6.11 ahead of the v0.6.11 release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)