### PR TITLE
docs: clarify build VM usage and vm shell vs vm ssh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Contributing to pelagos-mac
+
+This project has two distinct compilation targets and two distinct build
+environments. Understanding the split is the first thing a new contributor
+needs.
+
+---
+
+## Two repos, two runtimes
+
+| Repo | What it is | Where it runs |
+|---|---|---|
+| `pelagos-mac` (this repo) | macOS CLI, VM lifecycle, AVF bindings | macOS (aarch64-apple-darwin) |
+| `pelagos` | Linux container runtime | Inside the VM (aarch64-unknown-linux-gnu) |
+
+`pelagos-mac` boots a Linux VM and forwards container commands to `pelagos`
+running inside it. Changes to the macOS side are built on macOS. Changes to
+the Linux runtime must be compiled on Linux — not cross-compiled.
+
+---
+
+## Setting up your environment
+
+### 1. Prerequisites
+
+```bash
+xcode-select --install
+curl https://sh.rustup.rs -sSf | sh
+rustup target add aarch64-unknown-linux-musl
+brew install zig squashfs
+```
+
+### 2. Clone and build pelagos-mac
+
+```bash
+git clone https://github.com/pelagos-containers/pelagos-mac
+cd pelagos-mac
+git submodule update --init
+
+cargo build --release -p pelagos-mac
+bash scripts/sign.sh        # mandatory after every build — see below
+```
+
+**Why sign.sh is mandatory:** `cargo build` replaces the binary with a
+linker-signed copy that lacks `com.apple.security.virtualization`. Without
+it, macOS silently kills the VM daemon on the first AVF call — `vm status`
+says "stopped", the log shows nothing. Run `bash scripts/sign.sh` after
+every `cargo build`.
+
+### 3. Build the Alpine VM image
+
+The Alpine initramfs is the default container VM. Build it once (or after
+modifying `pelagos-guest` or the initramfs):
+
+```bash
+bash scripts/build-vm-image.sh
+```
+
+Verify:
+
+```bash
+./target/aarch64-apple-darwin/release/pelagos ping   # → pong
+./target/aarch64-apple-darwin/release/pelagos run alpine echo hello
+```
+
+### 4. Build the Ubuntu build VM (one-time, for hacking on pelagos)
+
+If you are modifying `pelagos` (the Linux runtime), you need a Linux
+compilation environment. Provision the Ubuntu build VM once:
+
+```bash
+bash scripts/build-build-image.sh
+```
+
+This downloads Ubuntu 24.04, installs the Rust toolchain, and writes
+`out/build.img`. Takes several minutes on first run. Only needs to be
+repeated if the Ubuntu image is deleted or needs a toolchain update.
+
+---
+
+## Daily development workflow
+
+### Changing pelagos-mac (the macOS side)
+
+```bash
+cargo build --release -p pelagos-mac
+bash scripts/sign.sh
+./target/aarch64-apple-darwin/release/pelagos ping
+```
+
+### Changing pelagos (the Linux runtime)
+
+All compilation happens inside the Ubuntu build VM.
+
+```bash
+# Start the build VM (waits until SSH is ready)
+bash scripts/build-vm-start.sh
+
+# Build — no prefix needed, cargo is in PATH via /etc/environment
+pelagos --profile build vm ssh -- "cd /mnt/Projects/pelagos && cargo build --release"
+
+# Or for iterative work, open an interactive session
+pelagos --profile build vm ssh
+# Inside the VM:
+# cd /mnt/Projects/pelagos
+# cargo build --release
+
+# Stop when done (frees 4 GB RAM)
+pelagos --profile build vm stop
+```
+
+The macOS home directory is mounted at `/mnt` inside the build VM (virtiofs,
+auto-mounted by systemd). Source at `/mnt/Projects/pelagos`, build artifacts
+on your macOS filesystem.
+
+### Running tests
+
+```bash
+# pelagos-mac e2e tests
+bash scripts/test-e2e.sh
+
+# devcontainer e2e tests
+bash scripts/test-devcontainer-e2e.sh
+
+# pelagos unit tests (in build VM)
+pelagos --profile build vm ssh -- "cd /mnt/Projects/pelagos && cargo test --lib"
+```
+
+---
+
+## Git workflow
+
+Feature branch → PR → merge commit. Never push to `main` directly, never
+squash. See `CLAUDE.md` for the full workflow and PR conventions.
+
+---
+
+## Key documentation
+
+| Doc | Read when |
+|---|---|
+| [docs/INSTALL.md](docs/INSTALL.md) | Full prerequisites and build steps |
+| [docs/VM_PROFILES.md](docs/VM_PROFILES.md) | Alpine vs Ubuntu VM profiles, `vm shell` vs `vm ssh`, build VM detail |
+| [docs/DESIGN.md](docs/DESIGN.md) | Why the architecture is the way it is |
+| [docs/VM_IMAGE_DESIGN.md](docs/VM_IMAGE_DESIGN.md) | Initramfs internals |
+| [docs/ARCHITECTURE_MENTAL_MODEL.md](docs/ARCHITECTURE_MENTAL_MODEL.md) | Common misconceptions and how to think about the stack |

--- a/ONGOING_TASKS.md
+++ b/ONGOING_TASKS.md
@@ -1,6 +1,6 @@
 # pelagos-mac — Ongoing Tasks
 
-*Last updated: 2026-04-09 — distribution pipeline complete; v0.6.5 released; brew install + vm init + run verified end-to-end*
+*Last updated: 2026-04-14 — build VM provisioning fixed + verified; contributor docs added; two PRs open*
 
 ---
 
@@ -91,6 +91,52 @@ to any client connecting at any time. `pelagos vm console [--profile build]` wor
 ---
 
 ## Remaining Work
+
+### Completed this session (2026-04-12 / 2026-04-14)
+
+- **pelagos-ui v0.1.6 tap update** ✅
+  - CI had built+notarized the DMG but tap update job failed (expired TAP_GITHUB_TOKEN)
+  - Manually computed SHA256 of existing DMG, updated homebrew-tap cask via GitHub API
+  - Removed obsolete `postflight` quarantine strip (notarized apps don't need it)
+  - Deleted two stale v0.1.6 draft releases; promoted pelagos-mac v0.6.14 from draft to latest
+
+- **`pelagos image pull` auth error hint** ✅ — pelagos PR #201 (open, `fix/image-auth-error-hint`)
+  - Raw `OciDistributionError` messages (e.g. "error sending request for url") gave no
+    indication of auth failure
+  - Added `oci_err()` helper in `src/cli/image.rs` that matches on error variant and appends
+    `pelagos image login <registry>` hint for auth-related failures
+  - Tested three cases: ECR rate limit (no spurious hint), DNS failure (no hint), ghcr.io 401 (hint)
+
+- **build-build-image.sh provisioning bugs fixed** ✅ — pelagos-mac PR #227 (open)
+  - Backtick in unquoted heredoc comment → `vm: command not found` noise on every run
+  - `apk add zstd` silently failed (Alpine initramfs has no apk database) → Ubuntu 24.04
+    `.ko.zst` modules could not be decompressed; fixed by using `chroot $MNT zstd`
+  - PATH prepend in `/etc/environment` was not idempotent → added grep guard
+  - `mnt.mount` systemd unit for virtiofs share was missing from provisioning script;
+    was only in the old disk from a forgotten manual step; added explicitly
+  - Also fixed: backtick in comment caused `vm: command not found` on every provisioning run
+
+- **Build VM rebuilt from scratch and verified** ✅
+  - Clean single PATH entry, virtiofs auto-mounted at `/mnt`, `cargo check` passes
+    with no `source /root/.cargo/env` prefix required
+
+- **Contributor documentation** ✅ — pelagos-mac PR #227
+  - `CONTRIBUTING.md` (new): two-repo split, full setup sequence, daily dev workflow,
+    key doc references
+  - `docs/INSTALL.md`: added Ubuntu build VM section (one-time provisioning + daily use)
+  - `README.md`: fixed wrong CLI syntax (`pelagos vm ssh --profile build` →
+    `pelagos --profile build vm ssh`), added CONTRIBUTING.md to docs table
+  - `docs/VM_PROFILES.md`: added `vm shell` vs `vm ssh` section; added build VM
+    workflow section; fixed virtiofs mount claim (auto-mounted, no manual step)
+  - `docs/ARCHITECTURE_MENTAL_MODEL.md`: False Assumption 2 now honestly acknowledges
+    build VM is used in practice
+
+### Open PRs (as of 2026-04-14)
+
+| PR | Repo | Branch | Status |
+|---|---|---|---|
+| #201 | pelagos | `fix/image-auth-error-hint` | Open, ready to merge |
+| #227 | pelagos-mac | `docs/build-vm-and-ssh-clarifications` | Open, ready to merge |
 
 ### Completed this session (2026-04-09)
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ pelagos vm ssh                             # SSH into Alpine VM
 # Build VM — native compilation environment
 bash scripts/build-build-image.sh         # provision Ubuntu build VM (one-time)
 bash scripts/build-vm-start.sh            # start and wait for SSH-ready
-pelagos vm ssh --profile build            # SSH in
-pelagos vm ssh --profile build -- rustc --version
-pelagos vm stop --profile build           # stop when done (frees 4 GB RAM)
+pelagos --profile build vm ssh            # SSH in
+pelagos --profile build vm ssh -- rustc --version
+pelagos --profile build vm stop           # stop when done (frees 4 GB RAM)
 ```
 
 The Alpine VM uses **vsock → pelagos-guest** as its control plane. The Ubuntu
@@ -141,6 +141,7 @@ bash scripts/test-devcontainer-e2e.sh --suite D   # postCreateCommand
 
 | Doc | Contents |
 |---|---|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | **Contributor setup** — two-repo split, build workflow, daily dev loop |
 | [docs/INSTALL.md](docs/INSTALL.md) | **Install guide** — Homebrew, upgrade, and build-from-source |
 | [docs/USER_GUIDE.md](docs/USER_GUIDE.md) | Running containers, VM management, build VM, devcontainers |
 | [docs/DESIGN.md](docs/DESIGN.md) | Architecture rationale, options evaluated, security analysis |

--- a/docs/ARCHITECTURE_MENTAL_MODEL.md
+++ b/docs/ARCHITECTURE_MENTAL_MODEL.md
@@ -42,7 +42,7 @@ any Alpine-specific constraints.
 
 ## False Assumption 2: "We need a persistent build VM to compile pelagos"
 
-The reasoning that led here:
+The original reasoning that led here:
 
 1. Alpine uses musl libc (not glibc)
 2. pelagos links against libseccomp and libcap which require glibc
@@ -54,20 +54,18 @@ not link against libseccomp or libcap. It uses the pure-Rust
 `seccompiler` crate and raw `SYS_capset` syscalls. Both pelagos and
 pelagos-guest are static musl binaries, released as such.
 
-The correct answer: pelagos can be built inside a `rust:alpine` container
-in the default Alpine VM. No glibc needed. The source tree is mounted
-from macOS via virtiofs (`-v`). Build artifacts land on the macOS
-filesystem and persist across container restarts.
+**The architectural answer:** pelagos can be built inside a
+`debian:bookworm-slim` container in the default Alpine VM — no persistent
+VM is architecturally required. The source tree mounts from macOS via
+virtiofs; build artifacts land on the macOS filesystem and persist across
+container restarts.
 
-```bash
-pelagos run --rm \
-  -v $HOME/Projects/pelagos:/workspace \
-  -w /workspace \
-  debian:bookworm-slim \
-  bash -c "apt-get install -y build-essential libseccomp-dev libcap-dev && cargo build"
-```
-
-No persistent VM needed. The default Alpine VM runs this fine.
+**What we actually use:** The `build` profile (Ubuntu persistent VM) exists
+and is used in practice, not because it is architecturally necessary but
+because direct SSH access with a persistent toolchain is a more natural
+interactive workflow than running a container for every build. Both paths
+are valid; the build profile is simply more convenient for iterative
+development. See `VM_PROFILES.md` for the full comparison.
 
 ---
 
@@ -78,7 +76,7 @@ is a custom image — not a persistent VM. Write a Remfile:
 
 ```
 FROM debian:bookworm-slim
-RUN apt-get install -y build-essential libseccomp-dev libcap-dev pkg-config curl git
+RUN apt-get install -y build-essential pkg-config curl git
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ```
 
@@ -91,11 +89,16 @@ pelagos build -t my-build-env:latest
 Use it repeatedly:
 
 ```bash
-pelagos run --rm -v $HOME/Projects/pelagos:/workspace -w /workspace my-build-env:latest cargo build
+pelagos run -v $HOME/Projects/pelagos:/workspace my-build-env:latest \
+  sh -c "cd /workspace && cargo build"
 ```
 
 The toolchain is baked into the image. Source and artifacts persist on
 macOS via virtiofs. The default Alpine VM handles all of it.
+
+This is the architecturally clean answer. In practice the `build` profile
+is often more ergonomic for interactive work — but it is a convenience
+choice, not a requirement.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -104,6 +104,52 @@ The built binary runs directly from the workspace:
 It auto-discovers VM artifacts in `out/` when run from the workspace root (or
 when `out/` is in `../../../out` relative to the binary location).
 
+### Ubuntu build VM (for compiling pelagos)
+
+pelagos (the Linux container runtime that runs inside the VM) must be
+compiled on Linux — not cross-compiled from macOS. The `build` profile is
+a persistent Ubuntu 24.04 VM that serves as the native compilation
+environment. It is a one-time setup.
+
+**Why not cross-compile from macOS?** The Linux standard library is not
+available on macOS. `cargo check --target aarch64-unknown-linux-gnu` fails
+immediately on a macOS host.
+
+**First-time provisioning** (downloads Ubuntu 24.04, installs Rust toolchain,
+takes several minutes):
+
+```bash
+bash scripts/build-build-image.sh
+```
+
+This provisions `out/build.img` (a 20 GB Ubuntu disk image) and writes
+`~/.local/share/pelagos/profiles/build/vm.conf`. Only needs to be run
+once, or after a kernel/toolchain update.
+
+**Daily use:**
+
+```bash
+# Start the build VM (takes ~30 s for SSH to be ready on first boot)
+bash scripts/build-vm-start.sh
+
+# Build pelagos non-interactively
+pelagos --profile build vm ssh -- "cd /mnt/Projects/pelagos && cargo build --release"
+
+# Or open an interactive shell
+pelagos --profile build vm ssh
+
+# Stop when done (frees 4 GB RAM)
+pelagos --profile build vm stop
+```
+
+The macOS home directory is available at `/mnt` inside the build VM via
+virtiofs (auto-mounted by systemd on boot). The pelagos source tree is at
+`/mnt/Projects/pelagos`. Build artifacts land on the macOS filesystem and
+persist across VM restarts.
+
+See [VM_PROFILES.md](VM_PROFILES.md) for the full breakdown of the two VM
+profiles (Alpine container VM vs Ubuntu build VM) and how they differ.
+
 ### Testing
 
 ```bash

--- a/docs/VM_PROFILES.md
+++ b/docs/VM_PROFILES.md
@@ -76,6 +76,80 @@ SSH-accessible VM. They solve different problems.
 
 ---
 
+## `vm shell` vs `vm ssh`
+
+Two commands provide interactive access; they work differently and apply
+to different profiles.
+
+### `pelagos vm shell`
+
+```bash
+pelagos vm shell                        # default profile
+pelagos --profile myprofile vm shell    # any vsock profile
+```
+
+Sends a `Shell` command over vsock to pelagos-guest, which forks a shell
+inside the VM. **Requires vsock + pelagos-guest** — works only for profiles
+with `ping_mode = vsock` (i.e. the `default` Alpine profile).
+
+Does **not** require an SSH key. No SSH involved at all.
+
+### `pelagos vm ssh`
+
+```bash
+pelagos vm ssh                          # default profile
+pelagos --profile build vm ssh          # build profile (most common use)
+pelagos --profile build vm ssh -- "cmd" # run a non-interactive command
+```
+
+Runs a real SSH session routed through the smoltcp NAT relay proxy — the
+host has no direct route to the VM's 192.168.105.2 address, so SSH is
+tunnelled through a local proxy port that pelagos manages. Works for **any**
+profile that has an SSH daemon, including the `default` Alpine profile
+(dropbear) and the `build` Ubuntu profile (openssh).
+
+**Requires `~/.local/share/pelagos/vm_key`** — an ed25519 key pair generated
+by `build-vm-image.sh` and baked into the VM image as `root/.ssh/authorized_keys`.
+The key is a global artifact shared by all profiles.
+
+### The key after a brew install or upgrade
+
+`vm_key` is **not shipped** in the Homebrew formula — it is generated once
+locally by `build-vm-image.sh` and lives only on the developer's machine.
+After a fresh install or a brew upgrade that replaces the VM image, the
+key baked into the new initramfs was generated in CI and is not available.
+
+To restore `vm ssh` access after a brew upgrade:
+
+```bash
+# Rebuild the default VM image locally — generates a new key pair and
+# bakes the public half into the initramfs:
+bash scripts/build-vm-image.sh
+
+# Re-initialise so the daemon picks up the new initramfs:
+pelagos vm stop
+pelagos vm init --force
+pelagos ping
+```
+
+The `build` profile's `build.img` has its `authorized_keys` updated by
+`build-build-image.sh` from the same key, so running `build-vm-image.sh`
+first (which sets the key) before `build-build-image.sh` keeps everything
+in sync.
+
+### Summary
+
+| | `vm shell` | `vm ssh` |
+|---|---|---|
+| Transport | vsock → pelagos-guest | SSH → smoltcp relay → VM port 22 |
+| Requires key | No | Yes (`~/.local/share/pelagos/vm_key`) |
+| Works on `default` (Alpine) | Yes | Yes (dropbear) |
+| Works on `build` (Ubuntu) | **No** (no pelagos-guest) | Yes (openssh) |
+| Non-interactive commands | No | Yes (`-- "cmd"`) |
+| Primary use case | Quick Alpine shell | Build VM access, scripted commands |
+
+---
+
 ## Container Image Choice Inside the `default` VM
 
 When you run `pelagos run <image>`, the container image's userspace determines

--- a/docs/VM_PROFILES.md
+++ b/docs/VM_PROFILES.md
@@ -62,11 +62,11 @@ attempt to cross-compile from macOS — the Linux standard library is not
 available there, and `cargo check --target aarch64-unknown-linux-gnu` will
 fail immediately.
 
-**Two critical facts about the build VM environment:**
+**One critical fact about the build VM environment:**
 
-1. **Rust toolchain PATH.** The toolchain lives at `/root/.cargo/bin` and is
-   NOT in the default SSH PATH. Every non-interactive SSH command must begin
-   with `source /root/.cargo/env`.
+1. **Rust toolchain PATH.** `/root/.cargo/bin` is in PATH for all session
+   types — interactive, login, and non-interactive SSH — via `/etc/environment`,
+   `profile.d/rust.sh`, and `.bashrc`.
 
 2. **virtiofs mount.** The macOS home directory is available inside the VM
    at `/mnt` via a virtiofs share tagged `share0`. It is auto-mounted by a
@@ -77,16 +77,13 @@ fail immediately.
 
 ```bash
 # Full release build
-pelagos --profile build vm ssh -- \
-  "source /root/.cargo/env; cd /mnt/Projects/pelagos && cargo build --release"
+pelagos --profile build vm ssh -- "cd /mnt/Projects/pelagos && cargo build --release"
 
 # Clippy
-pelagos --profile build vm ssh -- \
-  "source /root/.cargo/env; cd /mnt/Projects/pelagos && cargo clippy -- -D warnings"
+pelagos --profile build vm ssh -- "cd /mnt/Projects/pelagos && cargo clippy -- -D warnings"
 
 # Unit tests
-pelagos --profile build vm ssh -- \
-  "source /root/.cargo/env; cd /mnt/Projects/pelagos && cargo test --lib"
+pelagos --profile build vm ssh -- "cd /mnt/Projects/pelagos && cargo test --lib"
 ```
 
 **Interactive session (iterative development):**
@@ -94,7 +91,6 @@ pelagos --profile build vm ssh -- \
 ```bash
 pelagos --profile build vm ssh
 # Inside the VM:
-source /root/.cargo/env
 cd /mnt/Projects/pelagos
 cargo build --release
 ```

--- a/docs/VM_PROFILES.md
+++ b/docs/VM_PROFILES.md
@@ -69,10 +69,9 @@ fail immediately.
    with `source /root/.cargo/env`.
 
 2. **virtiofs mount.** The macOS home directory is available inside the VM
-   at `/mnt` via a virtiofs share tagged `share0`. It may not be auto-mounted
-   on fresh sessions. If `/mnt` is empty, run `mount -t virtiofs share0 /mnt`
-   before accessing source files. The pelagos source tree is therefore at
-   `/mnt/Projects/pelagos`.
+   at `/mnt` via a virtiofs share tagged `share0`. It is auto-mounted by a
+   systemd unit (`mnt.mount`) on boot — no manual step needed. The pelagos
+   source tree is therefore at `/mnt/Projects/pelagos`.
 
 **Non-interactive commands (scripting / CI):**
 
@@ -95,7 +94,6 @@ pelagos --profile build vm ssh -- \
 ```bash
 pelagos --profile build vm ssh
 # Inside the VM:
-mount -t virtiofs share0 /mnt   # if not already mounted
 source /root/.cargo/env
 cd /mnt/Projects/pelagos
 cargo build --release

--- a/docs/VM_PROFILES.md
+++ b/docs/VM_PROFILES.md
@@ -55,6 +55,56 @@ The two kernel cmdline flags are necessary for Ubuntu + AVF stability:
 Suited for: long-running builds that need a persistent toolchain, workflows
 where direct shell access (not container-mediated) is more natural.
 
+### Building pelagos in the build VM
+
+This is the standard workflow for compiling pelagos on macOS. Do not
+attempt to cross-compile from macOS — the Linux standard library is not
+available there, and `cargo check --target aarch64-unknown-linux-gnu` will
+fail immediately.
+
+**Two critical facts about the build VM environment:**
+
+1. **Rust toolchain PATH.** The toolchain lives at `/root/.cargo/bin` and is
+   NOT in the default SSH PATH. Every non-interactive SSH command must begin
+   with `source /root/.cargo/env`.
+
+2. **virtiofs mount.** The macOS home directory is available inside the VM
+   at `/mnt` via a virtiofs share tagged `share0`. It may not be auto-mounted
+   on fresh sessions. If `/mnt` is empty, run `mount -t virtiofs share0 /mnt`
+   before accessing source files. The pelagos source tree is therefore at
+   `/mnt/Projects/pelagos`.
+
+**Non-interactive commands (scripting / CI):**
+
+```bash
+# Full release build
+pelagos --profile build vm ssh -- \
+  "source /root/.cargo/env; cd /mnt/Projects/pelagos && cargo build --release"
+
+# Clippy
+pelagos --profile build vm ssh -- \
+  "source /root/.cargo/env; cd /mnt/Projects/pelagos && cargo clippy -- -D warnings"
+
+# Unit tests
+pelagos --profile build vm ssh -- \
+  "source /root/.cargo/env; cd /mnt/Projects/pelagos && cargo test --lib"
+```
+
+**Interactive session (iterative development):**
+
+```bash
+pelagos --profile build vm ssh
+# Inside the VM:
+mount -t virtiofs share0 /mnt   # if not already mounted
+source /root/.cargo/env
+cd /mnt/Projects/pelagos
+cargo build --release
+```
+
+Build artifacts land on the macOS filesystem (via virtiofs) and persist
+across VM restarts. The VM disk only holds the installed toolchain and
+Ubuntu system packages — not build output.
+
 ---
 
 ## The Dividing Lines

--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -266,7 +266,7 @@ chroot "\$MNT" env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-instal
     iproute2 nftables iptables openssh-server sudo \
     systemd systemd-sysv systemd-timesyncd \
     pkg-config libssl-dev \
-    rsync file strace \
+    rsync file strace zstd \
     initramfs-tools \
     linux-image-6.11.0-29-generic linux-modules-6.11.0-29-generic
 
@@ -337,6 +337,31 @@ printf '127.0.1.1\tubuntu-build\n' >> "\$MNT/etc/hosts"
 # so it must be explicitly loaded.  /etc/modules is read by systemd-modules-load.
 printf 'overlay\n' >> "\$MNT/etc/modules"
 
+# ---- virtiofs mount ----
+
+# Mount the AVF host directory share (tag: share0) at /mnt on boot.
+# AVF exposes the macOS home directory via virtiofs; the tag is "share0".
+# A systemd .mount unit named after the mount point handles this automatically.
+mkdir -p "\$MNT/etc/systemd/system"
+cat > "\$MNT/etc/systemd/system/mnt.mount" << 'MOUNTUNIT'
+[Unit]
+Description=Mount virtiofs share0 at /mnt
+DefaultDependencies=no
+After=local-fs-pre.target
+Before=local-fs.target
+
+[Mount]
+What=share0
+Where=/mnt
+Type=virtiofs
+Options=defaults
+
+[Install]
+WantedBy=local-fs.target
+MOUNTUNIT
+mkdir -p "\$MNT/etc/systemd/system/local-fs.target.wants"
+ln -sf /etc/systemd/system/mnt.mount "\$MNT/etc/systemd/system/local-fs.target.wants/mnt.mount"
+
 # Disable predictable interface renaming (belt-and-suspenders alongside
 # net.ifnames=0 in the kernel cmdline).  Without this, udev renames eth0
 # to enp0sN, bringing it down while networkd is trying to configure it.
@@ -363,14 +388,17 @@ chroot "\$MNT" env HOME=/root \
 
 # Make rustc/cargo available system-wide for all shell types:
 #
-#   /etc/environment      — non-interactive SSH (e.g. `vm ssh -- "cargo build"`)
+#   /etc/environment      — non-interactive SSH (e.g. vm ssh -- "cargo build")
 #                           read by PAM; does not support shell expansion
 #   /etc/profile.d/rust.sh — login shells
 #   /root/.bashrc          — non-login interactive shells
 #
 # /etc/environment uses literal string assignment — no shell expansion, so we
 # hard-code the cargo bin path rather than sourcing /root/.cargo/env.
-sed -i 's|^PATH="\(.*\)"$|PATH="/root/.cargo/bin:\1"|' "\$MNT/etc/environment"
+# Guard with grep so repeated provisioning runs don't prepend the path twice.
+if ! grep -q '/root/.cargo/bin' "\$MNT/etc/environment"; then
+    sed -i 's|^PATH="\(.*\)"$|PATH="/root/.cargo/bin:\1"|' "\$MNT/etc/environment"
+fi
 
 printf '%s\n' '. /root/.cargo/env' > "\$MNT/etc/profile.d/rust.sh"
 chmod +x "\$MNT/etc/profile.d/rust.sh"
@@ -420,19 +448,19 @@ if [ -n "\$KVER" ]; then
     #   nftables       — port-forward DNAT rules (pelagos network.rs)
     #
     # Ubuntu 24.04 (6.11+) ships modules as .ko.zst (zstd-compressed).
-    # Earlier Ubuntu releases used plain .ko.  copy_ko() handles both: it tries
-    # .ko first, then .ko.zst (decompressing to .ko via zstd -d).  zstd is
-    # installed below for the .ko.zst case.
-    apk add -q --no-progress zstd 2>/dev/null || true
+    # Earlier Ubuntu releases used plain .ko.  copy_ko() handles both.
+    # zstd is decompressed via chroot into the Ubuntu image — the Alpine
+    # initramfs does not have a working apk database so apk add zstd fails.
     copy_ko() {
-        local src="\$1"   # full path including .ko extension
+        local src="\$1"   # full path including .ko extension (host-side, under \$MNT)
         local dest_dir="\$2"
         local name="\$(basename \$src)"
         if [ -f "\$src" ]; then
             cp "\$src" "\$dest_dir/\$name"
             echo "  module: \$name"
         elif [ -f "\${src}.zst" ]; then
-            zstd -d -q "\${src}.zst" -o "\$dest_dir/\$name"
+            chroot "\$MNT" zstd -d -q "\${src#\$MNT}.zst" -o "/tmp/\$name"
+            mv "\$MNT/tmp/\$name" "\$dest_dir/\$name"
             echo "  module: \$name (from .ko.zst)"
         fi
     }

--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -361,13 +361,20 @@ chroot "\$MNT" env HOME=/root \
     bash -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
              | sh -s -- -y --default-toolchain stable --no-modify-path'
 
-# Make rustc/cargo available system-wide for login and non-login shells.
-# Use '. /root/.cargo/env' rather than baking in $PATH — the OUTER_EOF heredoc
-# is unquoted so $PATH would expand to the macOS host PATH at provisioning time.
+# Make rustc/cargo available system-wide for all shell types:
+#
+#   /etc/environment      — non-interactive SSH (e.g. `vm ssh -- "cargo build"`)
+#                           read by PAM; does not support shell expansion
+#   /etc/profile.d/rust.sh — login shells
+#   /root/.bashrc          — non-login interactive shells
+#
+# /etc/environment uses literal string assignment — no shell expansion, so we
+# hard-code the cargo bin path rather than sourcing /root/.cargo/env.
+sed -i 's|^PATH="\(.*\)"$|PATH="/root/.cargo/bin:\1"|' "\$MNT/etc/environment"
+
 printf '%s\n' '. /root/.cargo/env' > "\$MNT/etc/profile.d/rust.sh"
 chmod +x "\$MNT/etc/profile.d/rust.sh"
 
-# Append to root's .bashrc so non-login interactive shells also get cargo.
 printf '\n# Rust toolchain\nsource /root/.cargo/env\n' >> "\$MNT/root/.bashrc"
 
 # git needs an explicit CA bundle path on Ubuntu 22.04 — without this, git


### PR DESCRIPTION
## Summary

- `ARCHITECTURE_MENTAL_MODEL.md`: "False Assumption 2" now honestly acknowledges the `build` profile is used in practice for interactive development (convenience, not architecture requirement)
- `VM_PROFILES.md`: New section explaining `vm shell` (vsock → pelagos-guest, no key) vs `vm ssh` (SSH via smoltcp relay, requires `vm_key`), including key restoration steps after brew upgrade

## Test plan

- [ ] Read both docs end-to-end and verify no contradictions with actual behaviour
- [ ] Confirm the brew-upgrade key restoration steps match `build-vm-image.sh` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)