### PR TITLE
feat(nat66): pf NAT66 via privileged LaunchDaemon helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "pelagos-mac",
     "pelagos-docker",
     "pelagos-tui",
+    "pelagos-pfctl",
 ]
 resolver = "2"
 

--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -24,6 +24,8 @@ use serde::{Deserialize, Serialize};
 
 use pelagos_vz::vm::{Vm, VmConfig};
 
+use crate::nat66;
+
 use crate::port_dispatcher::{DispatchCmd, PortDispatcher};
 use crate::state::StateDir;
 
@@ -313,6 +315,36 @@ pub fn run(args: DaemonArgs) -> ! {
         Arc::clone(&port_state),
     );
 
+    // Load IPv6 NAT66 rule if the host has a global IPv6 address and the
+    // pelagos-pfctl helper is installed.  Non-fatal: if the helper is absent
+    // the VM starts normally without IPv6 NAT.
+    let nat66_iface: Option<String> = match nat66::detect_global_ipv6_iface() {
+        None => {
+            log::info!("nat66: host has no global IPv6 address — NAT66 not loaded");
+            None
+        }
+        Some((iface, addr)) => {
+            log::info!("nat66: host IPv6 detected: {addr} on {iface}");
+            match nat66::load(&iface) {
+                Ok(true) => {
+                    log::info!("nat66: rule loaded for {iface}");
+                    Some(iface)
+                }
+                Ok(false) => {
+                    log::debug!(
+                        "nat66: helper not installed — IPv6 NAT disabled \
+                         (run: sudo pelagos nat66 install)"
+                    );
+                    None
+                }
+                Err(e) => {
+                    log::warn!("nat66: load failed: {e}");
+                    None
+                }
+            }
+        }
+    };
+
     // Install SIGTERM handler: sets flag, SIGINT terminates immediately.
     let shutdown = Arc::new(AtomicBool::new(false));
     {
@@ -346,6 +378,16 @@ pub fn run(args: DaemonArgs) -> ! {
 
         if shutdown.load(Ordering::Relaxed) {
             log::info!("shutdown requested, stopping VM...");
+
+            // Remove the NAT66 rule before tearing down the VM.
+            if let Some(ref iface) = nat66_iface {
+                if let Err(e) = nat66::unload() {
+                    log::warn!("nat66: unload failed: {e}");
+                } else {
+                    log::info!("nat66: rule removed (was on {iface})");
+                }
+            }
+
             dispatcher.send(DispatchCmd::Shutdown);
             drop(dispatcher);
             // Drop the Arc. If no proxy threads are active, Vm::drop runs stop().

--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -317,29 +317,34 @@ pub fn run(args: DaemonArgs) -> ! {
 
     // Load IPv6 NAT66 rule if the host has a global IPv6 address and the
     // pelagos-pfctl helper is installed.  Non-fatal: if the helper is absent
-    // the VM starts normally without IPv6 NAT.
-    let nat66_iface: Option<String> = match nat66::detect_global_ipv6_iface() {
-        None => {
-            log::info!("nat66: host has no global IPv6 address — NAT66 not loaded");
-            None
-        }
-        Some((iface, addr)) => {
-            log::info!("nat66: host IPv6 detected: {addr} on {iface}");
-            match nat66::load(&iface) {
-                Ok(true) => {
-                    log::info!("nat66: rule loaded for {iface}");
-                    Some(iface)
-                }
-                Ok(false) => {
-                    log::debug!(
-                        "nat66: helper not installed — IPv6 NAT disabled \
-                         (run: sudo pelagos nat66 install)"
-                    );
-                    None
-                }
-                Err(e) => {
-                    log::warn!("nat66: load failed: {e}");
-                    None
+    // or the user has disabled NAT66, the VM starts normally.
+    let nat66_iface: Option<String> = if nat66::is_disabled_by_user() {
+        log::debug!("nat66: disabled by user — skipping");
+        None
+    } else {
+        match nat66::detect_global_ipv6_iface() {
+            None => {
+                log::info!("nat66: host has no global IPv6 address — NAT66 not loaded");
+                None
+            }
+            Some((iface, addr)) => {
+                log::info!("nat66: host IPv6 detected: {addr} on {iface}");
+                match nat66::load(&iface) {
+                    Ok(true) => {
+                        log::info!("nat66: rule loaded for {iface}");
+                        Some(iface)
+                    }
+                    Ok(false) => {
+                        log::debug!(
+                            "nat66: helper not installed — IPv6 NAT disabled \
+                             (run: pelagos nat66 enable)"
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        log::warn!("nat66: load failed: {e}");
+                        None
+                    }
                 }
             }
         }

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -15,6 +15,7 @@ use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 
 mod daemon;
+mod nat66;
 mod port_dispatcher;
 mod state;
 
@@ -286,6 +287,12 @@ enum Commands {
         #[command(subcommand)]
         sub: VmCommands,
     },
+    /// Manage IPv6 NAT66 (outbound IPv6 from VM to internet via pf).
+    Nat66 {
+        #[command(subcommand)]
+        sub: Nat66Commands,
+    },
+
     /// Internal: run as the persistent VM daemon. Not for direct use.
     #[command(hide = true)]
     VmDaemonInternal,
@@ -445,6 +452,18 @@ enum VmCommands {
 enum ContainerCommands {
     /// Remove all exited containers
     Prune,
+}
+
+#[derive(Subcommand)]
+enum Nat66Commands {
+    /// Install the pelagos-pfctl privileged helper and register it as a system
+    /// LaunchDaemon.  Requires root: run with sudo.
+    Install,
+    /// Remove the pelagos-pfctl helper and its LaunchDaemon registration.
+    /// Requires root: run with sudo.
+    Uninstall,
+    /// Show IPv6 availability and current NAT66 rule status.
+    Status,
 }
 
 // ---------------------------------------------------------------------------
@@ -730,6 +749,30 @@ fn main() {
     let profile = cli.profile.clone();
 
     match cli.command {
+        Commands::Nat66 {
+            sub: Nat66Commands::Install,
+        } => {
+            if let Err(e) = nat66::cmd_install() {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        }
+
+        Commands::Nat66 {
+            sub: Nat66Commands::Uninstall,
+        } => {
+            if let Err(e) = nat66::cmd_uninstall() {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        }
+
+        Commands::Nat66 {
+            sub: Nat66Commands::Status,
+        } => {
+            nat66::cmd_status();
+        }
+
         Commands::VmDaemonInternal => {
             let args = daemon_args_from_cli(&cli);
             daemon::run(args); // -> !

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -456,14 +456,26 @@ enum ContainerCommands {
 
 #[derive(Subcommand)]
 enum Nat66Commands {
-    /// Install the pelagos-pfctl privileged helper and register it as a system
-    /// LaunchDaemon.  Requires root: run with sudo.
+    /// Enable IPv6 NAT66: install the privileged helper if needed (shows a
+    /// macOS authorization dialog), then load the pf rule.  Safe to invoke
+    /// from a GUI — no terminal or sudo required.
+    Enable,
+    /// Disable IPv6 NAT66: unload the active pf rule and suppress auto-load
+    /// on future VM starts.  Does not uninstall the helper.
+    Disable,
+    /// Show IPv6 availability and current NAT66 rule status.
+    Status {
+        /// Output machine-readable JSON (for GUI integration).
+        #[arg(long)]
+        json: bool,
+    },
+    /// Install the pelagos-pfctl privileged helper and register it as a
+    /// system LaunchDaemon.  Requires root: run with sudo.
+    /// Prefer `pelagos nat66 enable` from a GUI — it handles elevation.
     Install,
     /// Remove the pelagos-pfctl helper and its LaunchDaemon registration.
     /// Requires root: run with sudo.
     Uninstall,
-    /// Show IPv6 availability and current NAT66 rule status.
-    Status,
 }
 
 // ---------------------------------------------------------------------------
@@ -750,6 +762,30 @@ fn main() {
 
     match cli.command {
         Commands::Nat66 {
+            sub: Nat66Commands::Enable,
+        } => {
+            if let Err(e) = nat66::cmd_enable() {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        }
+
+        Commands::Nat66 {
+            sub: Nat66Commands::Disable,
+        } => {
+            if let Err(e) = nat66::cmd_disable() {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        }
+
+        Commands::Nat66 {
+            sub: Nat66Commands::Status { json },
+        } => {
+            nat66::cmd_status(json);
+        }
+
+        Commands::Nat66 {
             sub: Nat66Commands::Install,
         } => {
             if let Err(e) = nat66::cmd_install() {
@@ -765,12 +801,6 @@ fn main() {
                 eprintln!("error: {e}");
                 process::exit(1);
             }
-        }
-
-        Commands::Nat66 {
-            sub: Nat66Commands::Status,
-        } => {
-            nat66::cmd_status();
         }
 
         Commands::VmDaemonInternal => {

--- a/pelagos-mac/src/nat66.rs
+++ b/pelagos-mac/src/nat66.rs
@@ -329,10 +329,29 @@ pub fn cmd_install() -> Result<(), String> {
 
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
-        // "service already loaded" is not an error.
-        if !stderr.contains("already loaded") && !stderr.contains("service exists") {
+        // Error 5 ("Bootstrap failed: 5: Input/output error") means the service
+        // is already registered — not a real error.
+        let already_loaded = stderr.contains("already loaded")
+            || stderr.contains("service exists")
+            || out.status.code() == Some(5)
+            || stderr.contains(": 5:");
+        if !already_loaded {
             return Err(format!("launchctl bootstrap: {stderr}"));
         }
+    }
+
+    // Wait for the daemon to start accepting connections (launchctl bootstrap
+    // returns before the process is ready).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if helper_available() {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("warning: helper installed but socket not yet available; check /var/log/pelagos-pfctl.log");
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
     }
 
     println!("pelagos-pfctl installed and running.");

--- a/pelagos-mac/src/nat66.rs
+++ b/pelagos-mac/src/nat66.rs
@@ -1,0 +1,327 @@
+//! IPv6 NAT66 management via the pelagos-pfctl LaunchDaemon helper.
+//!
+//! The helper runs as root and owns all pfctl invocations.  This module is
+//! the client side: it detects the host's global IPv6 address, sends
+//! load/unload requests over the helper's Unix socket, and exposes the
+//! install/uninstall/status subcommand implementations.
+
+use std::ffi::CStr;
+use std::io::{BufRead, BufReader, Write};
+use std::net::Ipv6Addr;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+/// Unix socket exposed by the pelagos-pfctl LaunchDaemon.
+const SOCK_PATH: &str = "/var/run/pelagos-pfctl.sock";
+
+/// Where the helper binary is installed by `pelagos nat66 install`.
+const HELPER_INSTALL_PATH: &str = "/usr/local/lib/pelagos/pelagos-pfctl";
+
+/// LaunchDaemon plist path.
+const PLIST_PATH: &str = "/Library/LaunchDaemons/com.pelagos.pfctl.plist";
+
+/// LaunchDaemon label.
+const LAUNCHD_LABEL: &str = "com.pelagos.pfctl";
+
+// ---------------------------------------------------------------------------
+// Wire types (must match pelagos-pfctl/src/main.rs)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum Request<'a> {
+    Load { iface: &'a str },
+    Unload,
+    Status,
+}
+
+#[derive(Deserialize)]
+struct Response {
+    ok: bool,
+    error: Option<String>,
+    active: Option<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// IPv6 host detection
+// ---------------------------------------------------------------------------
+
+/// Find the first network interface carrying a globally-routable IPv6 address
+/// (not link-local, not ULA, not loopback).
+///
+/// Returns `(interface_name, address)` or `None` if no such interface exists.
+pub fn detect_global_ipv6_iface() -> Option<(String, Ipv6Addr)> {
+    unsafe {
+        let mut ifap: *mut libc::ifaddrs = std::ptr::null_mut();
+        if libc::getifaddrs(&mut ifap) != 0 {
+            return None;
+        }
+        let mut result = None;
+        let mut cur = ifap;
+        while !cur.is_null() {
+            let ifa = &*cur;
+            if !ifa.ifa_addr.is_null()
+                && (*ifa.ifa_addr).sa_family == libc::AF_INET6 as libc::sa_family_t
+            {
+                let sin6 = &*(ifa.ifa_addr as *const libc::sockaddr_in6);
+                let bytes = sin6.sin6_addr.s6_addr;
+                if is_global_unicast(&bytes) {
+                    let name = CStr::from_ptr(ifa.ifa_name)
+                        .to_string_lossy()
+                        .into_owned();
+                    result = Some((name, Ipv6Addr::from(bytes)));
+                    break;
+                }
+            }
+            cur = ifa.ifa_next;
+        }
+        libc::freeifaddrs(ifap);
+        result
+    }
+}
+
+/// Returns true for addresses in the global unicast range (2000::/3), i.e.
+/// not loopback (::1), not link-local (fe80::/10), not ULA (fc00::/7).
+fn is_global_unicast(b: &[u8; 16]) -> bool {
+    if *b == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] {
+        return false; // loopback ::1
+    }
+    if b[0] == 0xfe && (b[1] & 0xc0) == 0x80 {
+        return false; // link-local fe80::/10
+    }
+    if (b[0] & 0xfe) == 0xfc {
+        return false; // ULA fc00::/7
+    }
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Helper socket client
+// ---------------------------------------------------------------------------
+
+fn send_request<'a>(req: &Request<'a>) -> Result<Response, String> {
+    let stream = UnixStream::connect(SOCK_PATH)
+        .map_err(|e| format!("connect {SOCK_PATH}: {e}"))?;
+    let mut writer = &stream;
+    let mut line = serde_json::to_string(req).map_err(|e| e.to_string())?;
+    line.push('\n');
+    writer.write_all(line.as_bytes()).map_err(|e| e.to_string())?;
+
+    let mut reader = BufReader::new(&stream);
+    let mut resp = String::new();
+    reader.read_line(&mut resp).map_err(|e| e.to_string())?;
+
+    let r: Response = serde_json::from_str(resp.trim()).map_err(|e| e.to_string())?;
+    if r.ok {
+        Ok(r)
+    } else {
+        Err(r.error.unwrap_or_else(|| "helper returned error".into()))
+    }
+}
+
+/// Ask the helper to install the NAT66 rule for `iface`.
+///
+/// Returns `Ok(true)` on success, `Ok(false)` if the helper is not installed
+/// (non-fatal — IPv6 NAT is optional), `Err` if the helper is present but
+/// the pfctl operation failed.
+pub fn load(iface: &str) -> Result<bool, String> {
+    match send_request(&Request::Load { iface }) {
+        Ok(r) => Ok(r.active.unwrap_or(true)),
+        Err(e) if e.contains("connect") => Ok(false), // helper not installed
+        Err(e) => Err(e),
+    }
+}
+
+/// Ask the helper to remove the NAT66 rule.  Silently succeeds if the helper
+/// is not installed.
+pub fn unload() -> Result<(), String> {
+    match send_request(&Request::Unload) {
+        Ok(_) => Ok(()),
+        Err(e) if e.contains("connect") => Ok(()), // helper not installed
+        Err(e) => Err(e),
+    }
+}
+
+/// Returns true if the helper daemon socket is reachable.
+pub fn helper_available() -> bool {
+    UnixStream::connect(SOCK_PATH).is_ok()
+}
+
+/// Query whether a NAT66 rule is currently active.  Returns None if the
+/// helper is not running.
+pub fn status_active() -> Option<bool> {
+    send_request(&Request::Status).ok()?.active
+}
+
+// ---------------------------------------------------------------------------
+// `pelagos nat66 install` / `uninstall` / `status`
+// ---------------------------------------------------------------------------
+
+/// Install the pelagos-pfctl helper binary and register it as a system
+/// LaunchDaemon.  Must be called as root (sudo).
+pub fn cmd_install() -> Result<(), String> {
+    if unsafe { libc::getuid() } != 0 {
+        return Err(
+            "pelagos nat66 install must run as root.\nRun: sudo pelagos nat66 install".into(),
+        );
+    }
+
+    // Locate the pelagos-pfctl binary alongside the running pelagos binary.
+    let helper_src = find_helper_binary()?;
+    log::debug!("helper binary source: {}", helper_src.display());
+
+    // Create destination directory.
+    let dest_dir = Path::new(HELPER_INSTALL_PATH).parent().unwrap();
+    std::fs::create_dir_all(dest_dir)
+        .map_err(|e| format!("mkdir {}: {e}", dest_dir.display()))?;
+
+    // Copy binary.
+    std::fs::copy(&helper_src, HELPER_INSTALL_PATH)
+        .map_err(|e| format!("copy to {HELPER_INSTALL_PATH}: {e}"))?;
+
+    // Ensure it is root-owned and executable.
+    unsafe {
+        let path = std::ffi::CString::new(HELPER_INSTALL_PATH).unwrap();
+        libc::chown(path.as_ptr(), 0, 0);
+        libc::chmod(path.as_ptr(), 0o755);
+    }
+
+    // Write the LaunchDaemon plist.
+    let plist = plist_content();
+    std::fs::write(PLIST_PATH, &plist)
+        .map_err(|e| format!("write {PLIST_PATH}: {e}"))?;
+
+    // Bootstrap the service.
+    let out = Command::new("/bin/launchctl")
+        .args(["bootstrap", "system", PLIST_PATH])
+        .output()
+        .map_err(|e| format!("launchctl bootstrap: {e}"))?;
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        // "service already loaded" is not an error.
+        if !stderr.contains("already loaded") && !stderr.contains("service exists") {
+            return Err(format!("launchctl bootstrap: {stderr}"));
+        }
+    }
+
+    println!("pelagos-pfctl installed and running.");
+    println!("  binary:  {HELPER_INSTALL_PATH}");
+    println!("  plist:   {PLIST_PATH}");
+    println!("  socket:  {SOCK_PATH}");
+    Ok(())
+}
+
+/// Remove the LaunchDaemon and helper binary.  Must be called as root.
+pub fn cmd_uninstall() -> Result<(), String> {
+    if unsafe { libc::getuid() } != 0 {
+        return Err("pelagos nat66 uninstall must run as root.\nRun: sudo pelagos nat66 uninstall".into());
+    }
+
+    // Unload the LaunchDaemon (ignore errors — might not be loaded).
+    let _ = Command::new("/bin/launchctl")
+        .args(["bootout", "system", LAUNCHD_LABEL])
+        .output();
+
+    // Remove plist and binary.
+    for path in [PLIST_PATH, HELPER_INSTALL_PATH] {
+        if Path::new(path).exists() {
+            std::fs::remove_file(path)
+                .map_err(|e| format!("remove {path}: {e}"))?;
+        }
+    }
+
+    // Remove socket if stale.
+    let _ = std::fs::remove_file(SOCK_PATH);
+
+    println!("pelagos-pfctl uninstalled.");
+    Ok(())
+}
+
+/// Print current NAT66 status.
+pub fn cmd_status() {
+    // Host IPv6 detection.
+    match detect_global_ipv6_iface() {
+        Some((iface, addr)) => println!("host IPv6:  {addr} on {iface}"),
+        None => println!("host IPv6:  none (IPv4-only network — NAT66 not available)"),
+    }
+
+    // Helper daemon.
+    let installed = Path::new(PLIST_PATH).exists();
+    let running = helper_available();
+    println!(
+        "helper:     {}",
+        if running {
+            "running"
+        } else if installed {
+            "installed but not responding"
+        } else {
+            "not installed (run: sudo pelagos nat66 install)"
+        }
+    );
+
+    // Active rule.
+    match status_active() {
+        Some(true) => println!("nat66:      active"),
+        Some(false) => println!("nat66:      inactive"),
+        None => println!("nat66:      unknown (helper not running)"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn find_helper_binary() -> Result<std::path::PathBuf, String> {
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("current_exe: {e}"))?;
+    let bin_dir = exe.parent()
+        .ok_or("binary has no parent directory")?;
+
+    // Development layout: target/<triple>/release/pelagos-pfctl
+    // Homebrew layout: bin/pelagos and bin/pelagos-pfctl are siblings
+    let candidates = [
+        bin_dir.join("pelagos-pfctl"),
+        bin_dir.join("../lib/pelagos/pelagos-pfctl"),
+        bin_dir.join("../share/pelagos-mac/pelagos-pfctl"),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|p| p.exists())
+        .ok_or(
+            "pelagos-pfctl binary not found next to pelagos.\n\
+             Build it with: cargo build -p pelagos-pfctl --release"
+                .to_string(),
+        )
+}
+
+fn plist_content() -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LAUNCHD_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{HELPER_INSTALL_PATH}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/pelagos-pfctl.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/pelagos-pfctl.log</string>
+</dict>
+</plist>
+"#
+    )
+}

--- a/pelagos-mac/src/nat66.rs
+++ b/pelagos-mac/src/nat66.rs
@@ -3,7 +3,21 @@
 //! The helper runs as root and owns all pfctl invocations.  This module is
 //! the client side: it detects the host's global IPv6 address, sends
 //! load/unload requests over the helper's Unix socket, and exposes the
-//! install/uninstall/status subcommand implementations.
+//! subcommand implementations.
+//!
+//! GUI-friendly API
+//! ----------------
+//! `pelagos nat66 enable`   — install helper if needed (macOS auth dialog),
+//!                            clear any disable flag, load rule.  Safe to call
+//!                            from a GUI button without any terminal.
+//! `pelagos nat66 disable`  — unload rule, write disable flag so the daemon
+//!                            does not auto-reload on next VM start.
+//! `pelagos nat66 status [--json]` — human or machine-readable status.
+//!
+//! Low-level plumbing
+//! ------------------
+//! `pelagos nat66 install`   — privileged install (requires sudo / root).
+//! `pelagos nat66 uninstall` — privileged removal.
 
 use std::ffi::CStr;
 use std::io::{BufRead, BufReader, Write};
@@ -83,19 +97,47 @@ pub fn detect_global_ipv6_iface() -> Option<(String, Ipv6Addr)> {
     }
 }
 
-/// Returns true for addresses in the global unicast range (2000::/3), i.e.
-/// not loopback (::1), not link-local (fe80::/10), not ULA (fc00::/7).
+/// Returns true for addresses in the global unicast range: not loopback (::1),
+/// not link-local (fe80::/10), not ULA (fc00::/7).
 fn is_global_unicast(b: &[u8; 16]) -> bool {
     if *b == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] {
-        return false; // loopback ::1
+        return false; // ::1 loopback
     }
     if b[0] == 0xfe && (b[1] & 0xc0) == 0x80 {
-        return false; // link-local fe80::/10
+        return false; // fe80::/10 link-local
     }
     if (b[0] & 0xfe) == 0xfc {
-        return false; // ULA fc00::/7
+        return false; // fc00::/7 ULA
     }
     true
+}
+
+// ---------------------------------------------------------------------------
+// Disable flag
+// ---------------------------------------------------------------------------
+
+/// Touch file that suppresses automatic NAT66 loading at VM start.
+/// Written by `disable`, removed by `enable`.
+fn disable_flag_path() -> Option<std::path::PathBuf> {
+    crate::state::pelagos_base()
+        .ok()
+        .map(|b| b.join("nat66-disabled"))
+}
+
+/// Returns true if the user has explicitly disabled NAT66 via `pelagos nat66 disable`.
+pub fn is_disabled_by_user() -> bool {
+    disable_flag_path()
+        .map(|p| p.exists())
+        .unwrap_or(false)
+}
+
+fn set_disabled_flag(disabled: bool) {
+    let Some(path) = disable_flag_path() else { return };
+    if disabled {
+        let _ = std::fs::write(&path, b"");
+    } else {
+        let _ = std::fs::remove_file(&path);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +196,91 @@ pub fn helper_available() -> bool {
 /// helper is not running.
 pub fn status_active() -> Option<bool> {
     send_request(&Request::Status).ok()?.active
+}
+
+// ---------------------------------------------------------------------------
+// `pelagos nat66 enable` — GUI-friendly: installs helper via osascript if
+// needed, then loads the rule.  No terminal or sudo required from the user.
+// ---------------------------------------------------------------------------
+
+pub fn cmd_enable() -> Result<(), String> {
+    // If the helper is not yet installed, elevate via the macOS auth dialog.
+    if !helper_available() {
+        elevate_and_install()?;
+        // Give the LaunchDaemon a moment to start and create the socket.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while std::time::Instant::now() < deadline {
+            if helper_available() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        if !helper_available() {
+            return Err("helper installed but socket not yet available — try again in a moment".into());
+        }
+    }
+
+    // Remove the user-disable flag so the daemon auto-loads on next VM start.
+    set_disabled_flag(false);
+
+    // Load the rule now.
+    let iface = detect_global_ipv6_iface()
+        .map(|(i, _)| i)
+        .ok_or("no global IPv6 address on this host — cannot enable NAT66")?;
+
+    match load(&iface) {
+        Ok(true) => {
+            println!("IPv6 NAT66 enabled (rule loaded on {iface}).");
+            Ok(())
+        }
+        Ok(false) => Err("helper did not confirm rule was loaded".into()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Run `pelagos nat66 install` as root using the macOS authorization dialog
+/// (`osascript ... with administrator privileges`).  The dialog is shown by
+/// the OS and is identical to the standard "enter your password" prompt that
+/// macOS presents for any privileged installer.
+fn elevate_and_install() -> Result<(), String> {
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("current_exe: {e}"))?;
+    // Escape single quotes in the path (unlikely, but safe).
+    let exe_str = exe.to_string_lossy().replace('\'', "'\\''");
+    let script = format!(
+        "do shell script \"'{exe_str}' nat66 install\" with administrator privileges"
+    );
+    let out = Command::new("/usr/bin/osascript")
+        .args(["-e", &script])
+        .output()
+        .map_err(|e| format!("osascript: {e}"))?;
+
+    if out.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        // Exit code 1 with "User canceled" means the user dismissed the dialog.
+        if stderr.contains("User canceled") || stderr.contains("(-128)") {
+            Err("authorization cancelled by user".into())
+        } else {
+            Err(format!("install failed: {stderr}"))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `pelagos nat66 disable` — unload rule + set flag (no privilege required)
+// ---------------------------------------------------------------------------
+
+pub fn cmd_disable() -> Result<(), String> {
+    // Write the flag so the daemon skips auto-load on next VM start.
+    set_disabled_flag(true);
+
+    // Unload the active rule if any.
+    unload()?;
+
+    println!("IPv6 NAT66 disabled.");
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -218,7 +345,9 @@ pub fn cmd_install() -> Result<(), String> {
 /// Remove the LaunchDaemon and helper binary.  Must be called as root.
 pub fn cmd_uninstall() -> Result<(), String> {
     if unsafe { libc::getuid() } != 0 {
-        return Err("pelagos nat66 uninstall must run as root.\nRun: sudo pelagos nat66 uninstall".into());
+        return Err(
+            "pelagos nat66 uninstall must run as root.\nRun: sudo pelagos nat66 uninstall".into(),
+        );
     }
 
     // Unload the LaunchDaemon (ignore errors — might not be loaded).
@@ -241,33 +370,72 @@ pub fn cmd_uninstall() -> Result<(), String> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Status output
+// ---------------------------------------------------------------------------
+
+/// Machine-readable status record for `pelagos nat66 status --json`.
+#[derive(Serialize)]
+pub struct Nat66Status {
+    /// Host has a globally-routable IPv6 address.
+    pub ipv6_available: bool,
+    /// Interface and address, if available.
+    pub ipv6_iface: Option<String>,
+    pub ipv6_addr: Option<String>,
+    /// pelagos-pfctl LaunchDaemon is installed (plist present).
+    pub helper_installed: bool,
+    /// pelagos-pfctl socket is reachable.
+    pub helper_running: bool,
+    /// User has explicitly disabled NAT66 (`pelagos nat66 disable`).
+    pub user_disabled: bool,
+    /// pf NAT66 rule is currently active.
+    pub active: bool,
+}
+
+/// Gather current status without printing.
+pub fn gather_status() -> Nat66Status {
+    let ipv6 = detect_global_ipv6_iface();
+    let active = status_active().unwrap_or(false);
+    Nat66Status {
+        ipv6_available: ipv6.is_some(),
+        ipv6_iface: ipv6.as_ref().map(|(i, _)| i.clone()),
+        ipv6_addr: ipv6.as_ref().map(|(_, a)| a.to_string()),
+        helper_installed: Path::new(PLIST_PATH).exists(),
+        helper_running: helper_available(),
+        user_disabled: is_disabled_by_user(),
+        active,
+    }
+}
+
 /// Print current NAT66 status.
-pub fn cmd_status() {
-    // Host IPv6 detection.
-    match detect_global_ipv6_iface() {
-        Some((iface, addr)) => println!("host IPv6:  {addr} on {iface}"),
-        None => println!("host IPv6:  none (IPv4-only network — NAT66 not available)"),
+pub fn cmd_status(json: bool) {
+    let s = gather_status();
+    if json {
+        println!("{}", serde_json::to_string(&s).unwrap_or_default());
+        return;
     }
 
-    // Helper daemon.
-    let installed = Path::new(PLIST_PATH).exists();
-    let running = helper_available();
+    match (&s.ipv6_iface, &s.ipv6_addr) {
+        (Some(iface), Some(addr)) => println!("host IPv6:  {addr} on {iface}"),
+        _ => println!("host IPv6:  none (IPv4-only network — NAT66 not available)"),
+    }
     println!(
         "helper:     {}",
-        if running {
+        if s.helper_running {
             "running"
-        } else if installed {
+        } else if s.helper_installed {
             "installed but not responding"
         } else {
-            "not installed (run: sudo pelagos nat66 install)"
+            "not installed  (run: pelagos nat66 enable)"
         }
     );
-
-    // Active rule.
-    match status_active() {
-        Some(true) => println!("nat66:      active"),
-        Some(false) => println!("nat66:      inactive"),
-        None => println!("nat66:      unknown (helper not running)"),
+    if s.user_disabled {
+        println!("nat66:      disabled by user (run: pelagos nat66 enable to re-enable)");
+    } else {
+        println!(
+            "nat66:      {}",
+            if s.active { "active" } else { "inactive" }
+        );
     }
 }
 
@@ -276,12 +444,10 @@ pub fn cmd_status() {
 // ---------------------------------------------------------------------------
 
 fn find_helper_binary() -> Result<std::path::PathBuf, String> {
-    let exe = std::env::current_exe()
-        .map_err(|e| format!("current_exe: {e}"))?;
-    let bin_dir = exe.parent()
-        .ok_or("binary has no parent directory")?;
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let bin_dir = exe.parent().ok_or("binary has no parent directory")?;
 
-    // Development layout: target/<triple>/release/pelagos-pfctl
+    // Development layout: target/<triple>/release/pelagos-pfctl (sibling)
     // Homebrew layout: bin/pelagos and bin/pelagos-pfctl are siblings
     let candidates = [
         bin_dir.join("pelagos-pfctl"),

--- a/pelagos-pfctl/Cargo.toml
+++ b/pelagos-pfctl/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pelagos-pfctl"
+version.workspace = true
+edition.workspace = true
+description = "Privileged pf NAT66 helper daemon for pelagos-mac"
+
+[[bin]]
+name = "pelagos-pfctl"
+path = "src/main.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+log.workspace = true
+env_logger.workspace = true
+libc.workspace = true

--- a/pelagos-pfctl/src/main.rs
+++ b/pelagos-pfctl/src/main.rs
@@ -1,0 +1,209 @@
+//! pelagos-pfctl — privileged pf NAT66 helper daemon.
+//!
+//! Runs as root via a LaunchDaemon.  Listens on a Unix socket and executes
+//! pfctl commands on behalf of the pelagos-mac CLI and daemon.
+//!
+//! Protocol: newline-delimited JSON.
+//!   Request:  {"action":"load","iface":"en0"} | {"action":"unload"} | {"action":"status"}
+//!   Response: {"ok":true} | {"ok":false,"error":"..."}
+
+use std::ffi::CString;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+const SOCK_PATH: &str = "/var/run/pelagos-pfctl.sock";
+
+/// Named anchor under com.apple/* so no /etc/pf.conf modification is needed —
+/// the wildcard `nat-anchor "com.apple/*"` in the default macOS pf.conf picks
+/// it up automatically.
+const ANCHOR: &str = "com.apple/pelagos-nat66";
+const ANCHOR_FILE: &str = "/etc/pf.anchors/pelagos-nat66";
+
+/// ULA source prefix used by the pelagos VM.
+const VM_PREFIX: &str = "fd00::/64";
+
+#[derive(Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum Request {
+    Load { iface: String },
+    Unload,
+    Status,
+}
+
+#[derive(Serialize)]
+struct Response {
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    active: Option<bool>,
+}
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    if unsafe { libc::getuid() } != 0 {
+        eprintln!("pelagos-pfctl: must run as root (uid 0)");
+        std::process::exit(1);
+    }
+
+    // Remove stale socket from a previous run.
+    let _ = std::fs::remove_file(SOCK_PATH);
+
+    let listener = UnixListener::bind(SOCK_PATH).unwrap_or_else(|e| {
+        eprintln!("pelagos-pfctl: bind {SOCK_PATH}: {e}");
+        std::process::exit(1);
+    });
+
+    // 0660 chgrp admin — any admin-group member (i.e. all normal Mac users
+    // via the default %admin sudoers membership) can send requests.
+    set_socket_permissions();
+
+    log::info!("listening on {SOCK_PATH}");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(s) => handle_connection(s),
+            Err(e) => log::warn!("accept: {e}"),
+        }
+    }
+}
+
+fn set_socket_permissions() {
+    let path = CString::new(SOCK_PATH).unwrap();
+    unsafe {
+        libc::chmod(path.as_ptr(), 0o660);
+        let grnam = CString::new("admin").unwrap();
+        let grp = libc::getgrnam(grnam.as_ptr());
+        if !grp.is_null() {
+            // uid -1 (u32::MAX) means "don't change owner"
+            libc::chown(path.as_ptr(), u32::MAX, (*grp).gr_gid);
+        }
+    }
+}
+
+fn handle_connection(stream: std::os::unix::net::UnixStream) {
+    let mut reader = BufReader::new(&stream);
+    let mut writer = &stream;
+    let mut line = String::new();
+
+    if let Err(e) = reader.read_line(&mut line) {
+        log::warn!("read: {e}");
+        return;
+    }
+
+    let resp = match serde_json::from_str::<Request>(line.trim()) {
+        Ok(Request::Load { iface }) => handle_load(&iface),
+        Ok(Request::Unload) => handle_unload(),
+        Ok(Request::Status) => handle_status(),
+        Err(e) => Response {
+            ok: false,
+            error: Some(format!("parse error: {e}")),
+            active: None,
+        },
+    };
+
+    if let Ok(mut out) = serde_json::to_string(&resp) {
+        out.push('\n');
+        let _ = writer.write_all(out.as_bytes());
+    }
+}
+
+fn handle_load(iface: &str) -> Response {
+    // Reject interface names that could be used for shell injection.
+    if !iface.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+        return Response {
+            ok: false,
+            error: Some(format!("invalid interface name: {iface:?}")),
+            active: None,
+        };
+    }
+
+    // Write the anchor rule file.
+    let rule = format!("nat on {iface} inet6 from {VM_PREFIX} to any -> ({iface})\n");
+    if let Err(e) = std::fs::write(ANCHOR_FILE, &rule) {
+        return Response {
+            ok: false,
+            error: Some(format!("write {ANCHOR_FILE}: {e}")),
+            active: None,
+        };
+    }
+
+    // Ensure pf is enabled.  The exit code is 1 when already enabled ("pf
+    // already enabled"), which is fine — ignore that.
+    let _ = Command::new("/sbin/pfctl").arg("-e").output();
+
+    // Load the anchor.
+    let out = Command::new("/sbin/pfctl")
+        .args(["-a", ANCHOR, "-f", ANCHOR_FILE])
+        .output();
+
+    match out {
+        Ok(o) if o.status.success() => {
+            log::info!("nat66 loaded on {iface}: {}", rule.trim());
+            Response { ok: true, error: None, active: Some(true) }
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr).into_owned();
+            log::warn!("pfctl load failed: {stderr}");
+            Response {
+                ok: false,
+                error: Some(format!("pfctl: {stderr}")),
+                active: None,
+            }
+        }
+        Err(e) => Response {
+            ok: false,
+            error: Some(format!("exec /sbin/pfctl: {e}")),
+            active: None,
+        },
+    }
+}
+
+fn handle_unload() -> Response {
+    let out = Command::new("/sbin/pfctl")
+        .args(["-a", ANCHOR, "-F", "all"])
+        .output();
+
+    match out {
+        Ok(o) if o.status.success() => {
+            log::info!("nat66 unloaded");
+            Response { ok: true, error: None, active: Some(false) }
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr).into_owned();
+            // "Anchor does not exist" is fine — means the anchor was never loaded.
+            if stderr.contains("Anchor does not exist") || stderr.contains("pfctl: ") {
+                log::info!("nat66: anchor was not active (ok)");
+                Response { ok: true, error: None, active: Some(false) }
+            } else {
+                log::warn!("pfctl unload: {stderr}");
+                Response {
+                    ok: false,
+                    error: Some(format!("pfctl: {stderr}")),
+                    active: None,
+                }
+            }
+        }
+        Err(e) => Response {
+            ok: false,
+            error: Some(format!("exec /sbin/pfctl: {e}")),
+            active: None,
+        },
+    }
+}
+
+fn handle_status() -> Response {
+    let out = Command::new("/sbin/pfctl")
+        .args(["-a", ANCHOR, "-s", "nat"])
+        .output();
+
+    let active = match out {
+        Ok(o) if o.status.success() => !String::from_utf8_lossy(&o.stdout).trim().is_empty(),
+        _ => false,
+    };
+    Response { ok: true, error: None, active: Some(active) }
+}

--- a/scripts/diagnose-nat66.sh
+++ b/scripts/diagnose-nat66.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# diagnose-nat66.sh — check pelagos-pfctl LaunchDaemon status
+
+set -uo pipefail
+
+echo "=== pelagos-pfctl diagnostics ==="
+echo ""
+
+echo "--- binary ---"
+ls -la /usr/local/lib/pelagos/pelagos-pfctl 2>/dev/null || echo "MISSING"
+
+echo ""
+echo "--- plist ---"
+ls -la /Library/LaunchDaemons/com.pelagos.pfctl.plist 2>/dev/null || echo "MISSING"
+
+echo ""
+echo "--- socket ---"
+ls -la /var/run/pelagos-pfctl.sock 2>/dev/null || echo "MISSING"
+
+echo ""
+echo "--- launchctl list (system) ---"
+sudo launchctl list com.pelagos.pfctl 2>&1 || true
+
+echo ""
+echo "--- process ---"
+pgrep -lf pelagos-pfctl || echo "not running"
+
+echo ""
+echo "--- log ---"
+sudo cat /var/log/pelagos-pfctl.log 2>/dev/null || echo "(empty or missing)"
+
+echo ""
+echo "--- plist contents ---"
+sudo cat /Library/LaunchDaemons/com.pelagos.pfctl.plist 2>/dev/null || echo "MISSING"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# install-dev.sh — build, sign, and install a development pelagos-mac build for local testing.
+#
+# Builds release binaries, signs pelagos with the virtualization entitlement,
+# installs them to /opt/homebrew/bin, installs the pelagos-pfctl LaunchDaemon,
+# and launches pelagos-ui in dev mode.
+#
+# Usage:
+#   bash scripts/install-dev.sh
+#
+# Requires: sudo (prompted once via a single sudo -v at the start)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(dirname "$SCRIPT_DIR")"
+RELEASE="$REPO/target/aarch64-apple-darwin/release"
+
+cd "$REPO"
+
+echo "=== pelagos-mac dev install ==="
+
+# ── 1. Build ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- build ---"
+cargo build --release -p pelagos-mac -p pelagos-pfctl
+
+# ── 2. Sign pelagos ───────────────────────────────────────────────────────────
+echo ""
+echo "--- sign ---"
+bash "$SCRIPT_DIR/sign.sh"
+
+# ── 3. Privileged install (single sudo prompt) ───────────────────────────────
+echo ""
+echo "--- install (requires sudo) ---"
+sudo bash -s <<EOF
+set -euo pipefail
+
+# Install pelagos CLI
+cp "$RELEASE/pelagos" /opt/homebrew/bin/pelagos
+echo "  installed: /opt/homebrew/bin/pelagos"
+
+# Stage pelagos-pfctl next to pelagos so 'pelagos nat66 install' can find it
+cp "$RELEASE/pelagos-pfctl" /opt/homebrew/bin/pelagos-pfctl
+echo "  staged:    /opt/homebrew/bin/pelagos-pfctl"
+
+# Install the LaunchDaemon (copies binary to /usr/local/lib/pelagos/, writes plist, bootstraps)
+/opt/homebrew/bin/pelagos nat66 install
+EOF
+
+# ── 4. Verify ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- verify ---"
+echo -n "  pelagos version: "
+pelagos --version
+
+echo ""
+pelagos nat66 status
+
+echo ""
+echo -n "  LaunchDaemon PID: "
+launchctl list com.pelagos.pfctl 2>/dev/null | grep '"PID"' || echo "not running"
+
+# ── 5. Start VM ───────────────────────────────────────────────────────────────
+echo ""
+echo "--- VM ---"
+pelagos vm start && echo "  VM running" || echo "  VM already running or failed — check: pelagos vm status"
+
+# ── 6. pelagos-ui ─────────────────────────────────────────────────────────────
+UI_DIR="$HOME/Projects/pelagos-ui"
+if [ -d "$UI_DIR" ]; then
+    echo ""
+    echo "--- pelagos-ui ---"
+    echo "  Starting pelagos-ui dev server in a new Terminal window..."
+    osascript -e "tell application \"Terminal\" to do script \"cd '$UI_DIR' && npm run tauri dev\""
+else
+    echo ""
+    echo "  pelagos-ui not found at $UI_DIR — skipping"
+fi
+
+echo ""
+echo "=== done ==="
+echo ""
+echo "Test the NAT66 toggle:"
+echo "  pelagos nat66 enable"
+echo "  pfctl -a com.apple/pelagos-nat66 -s nat"
+echo "  pelagos nat66 disable"
+echo "  pelagos nat66 status"


### PR DESCRIPTION
## Summary

- **pelagos-pfctl** (new crate): root daemon on `/var/run/pelagos-pfctl.sock`. Handles `load {iface}`, `unload`, `status` JSON requests. Uses `com.apple/pelagos-nat66` anchor — picked up automatically by the default macOS `nat-anchor "com.apple/*"`. No `/etc/pf.conf` edit needed.
- **nat66 module** in pelagos-mac: `detect_global_ipv6_iface()` (getifaddrs), socket client (`load`/`unload`), `cmd_install`/`cmd_uninstall`/`cmd_status` subcommand implementations.
- **Daemon hooks**: load NAT66 at VM start if host has global IPv6 and helper is installed; unload at VM stop. Non-fatal if helper absent.
- **New subcommands**: `sudo pelagos nat66 install/uninstall`, `pelagos nat66 status`

## Test plan

- [ ] `sudo pelagos nat66 install` — socket at `/var/run/pelagos-pfctl.sock`, binary at `/usr/local/lib/pelagos/pelagos-pfctl`
- [ ] `pelagos nat66 status` — shows host IPv6 + helper running + rule inactive
- [ ] `pelagos vm start` — logs "nat66: rule loaded for en0"
- [ ] `pfctl -a com.apple/pelagos-nat66 -s nat` — shows rule
- [ ] `pelagos vm stop` — rule removed, pfctl confirms empty
- [ ] Without helper: VM starts normally, logs "helper not installed"
- [ ] Without root: `pelagos nat66 install` prints clear error

Closes part of #229 (Phase 4 — outbound IPv6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)