### PR TITLE
fix(bless): replace SMJobBless with osascript privilege escalation

### DIFF
--- a/pelagos-mac/assets/Info.plist.in
+++ b/pelagos-mac/assets/Info.plist.in
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>io.pelagos.mac</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+
+    <!-- SMPrivilegedExecutables: maps helper label → designated requirement for the helper.
+         @HELPER_DR@ is substituted at build time by pelagos-mac/build.rs.
+         Dev default: certificate leaf[subject.CN] = "pelagos-mac Dev"
+         Prod: anchor apple generic and identifier "com.pelagos.pfctl" and ... -->
+    <key>SMPrivilegedExecutables</key>
+    <dict>
+        <key>com.pelagos.pfctl</key>
+        <string>@HELPER_DR@</string>
+    </dict>
+</dict>
+</plist>

--- a/pelagos-mac/build.rs
+++ b/pelagos-mac/build.rs
@@ -1,6 +1,10 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
+    // Git hash for version string.
     let hash = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
@@ -9,9 +13,34 @@ fn main() {
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
-
     println!("cargo:rustc-env=GIT_HASH={}", hash);
-    // Re-run if HEAD changes (new commit).
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/heads");
+
+    // Designated requirement for the helper binary (pelagos-pfctl).
+    // Must match the SMAuthorizedClients entry in pelagos-pfctl's embedded plist.
+    // For development: matches the "pelagos-mac Dev" local certificate.
+    // For production: set PELAGOS_HELPER_DR to the Developer ID designated requirement.
+    let helper_dr = env::var("PELAGOS_HELPER_DR").unwrap_or_else(|_| {
+        r#"certificate leaf[subject.CN] = "pelagos-mac Dev""#.to_string()
+    });
+
+    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let template = fs::read_to_string(manifest.join("assets/Info.plist.in"))
+        .expect("pelagos-mac/assets/Info.plist.in not found");
+    let plist = template.replace("@HELPER_DR@", &helper_dr);
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let plist_path = out_dir.join("Info.plist");
+    fs::write(&plist_path, &plist).unwrap();
+
+    // Embed as __TEXT,__info_plist Mach-O section.
+    // SMJobBless reads this from the calling binary to validate SMPrivilegedExecutables.
+    println!(
+        "cargo:rustc-link-arg=-Wl,-sectcreate,__TEXT,__info_plist,{}",
+        plist_path.display()
+    );
+
+    println!("cargo:rerun-if-changed=assets/Info.plist.in");
+    println!("cargo:rerun-if-env-changed=PELAGOS_HELPER_DR");
 }

--- a/pelagos-mac/src/bless.rs
+++ b/pelagos-mac/src/bless.rs
@@ -1,0 +1,315 @@
+//! SMJobBless integration — automatic privileged helper installation.
+//!
+//! On first `pelagos vm start`, if `/var/run/pelagos-pfctl.sock` is absent,
+//! `ensure_pfctl_blessed()` calls `SMJobBless` to install `com.pelagos.pfctl`.
+//! macOS shows a one-time admin credential dialog; after that the helper runs
+//! permanently as a LaunchDaemon and restarts automatically on reboot.
+//!
+//! # Signing requirements
+//!
+//! SMJobBless validates a cross-signed trust chain at install time:
+//! - The calling binary (`pelagos`) must have `SMPrivilegedExecutables` in its
+//!   embedded `__TEXT,__info_plist` section listing the helper's designated
+//!   requirement string.
+//! - The helper binary (`com.pelagos.pfctl`) must have `SMAuthorizedClients` in
+//!   its embedded `__TEXT,__launchd_plist` section listing the caller's
+//!   designated requirement string.
+//! - Both binaries must be signed with the same certificate identity.
+//!
+//! Both plists are generated at build time by their respective `build.rs` with
+//! `@CALLER_DR@` / `@HELPER_DR@` substituted from env vars. For development,
+//! create a local "pelagos-mac Dev" code-signing certificate in Keychain Access
+//! and sign both binaries with it (see `scripts/sign.sh`).
+
+use std::ffi::{CStr, CString};
+use std::io;
+use std::os::unix::fs::FileTypeExt;
+use std::time::{Duration, Instant};
+
+/// Socket path for the pfctl helper daemon.
+const PFCTL_SOCK: &str = "/var/run/pelagos-pfctl.sock";
+
+/// Bundle identifier / LaunchDaemon label for the privileged helper.
+const HELPER_LABEL: &str = "com.pelagos.pfctl";
+
+/// Ensure the pelagos-pfctl privileged helper is installed and running.
+///
+/// Fast path: if the socket already exists, return `Ok(())` immediately.
+///
+/// Install path: SMJobBless copies the helper binary to
+/// `/Library/PrivilegedHelperTools/com.pelagos.pfctl`, installs its embedded
+/// plist as a LaunchDaemon, and loads it. macOS prompts for admin credentials
+/// exactly once; subsequent calls always hit the fast path.
+pub fn ensure_pfctl_blessed() -> io::Result<()> {
+    if pfctl_socket_present() {
+        return Ok(());
+    }
+    bless_helper()
+}
+
+fn pfctl_socket_present() -> bool {
+    std::fs::metadata(PFCTL_SOCK)
+        .map(|m| m.file_type().is_socket())
+        .unwrap_or(false)
+}
+
+fn bless_helper() -> io::Result<()> {
+    // Locate the helper binary in the same directory as this executable, named
+    // exactly by its bundle identifier.  This is the conventional location that
+    // SMJobBless uses for non-app-bundle CLIs.
+    //
+    // Homebrew layout: /opt/homebrew/bin/pelagos → binary
+    //                  /opt/homebrew/bin/com.pelagos.pfctl → symlink to pkgshare/pelagos-pfctl
+    //
+    // Dev layout:      target/aarch64-apple-darwin/release/pelagos
+    //                  target/aarch64-apple-darwin/release/com.pelagos.pfctl
+    //                  (sign.sh creates the latter as a signed copy)
+    let exe = std::env::current_exe()?;
+    let exe_dir = exe
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "cannot determine exe directory"))?;
+    let helper_path = exe_dir.join(HELPER_LABEL);
+
+    if !helper_path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "privileged helper not found at {path}\n\
+                 If using Homebrew, reinstall: brew reinstall pelagos-containers/tap/pelagos-mac\n\
+                 If developing locally, run: bash scripts/sign.sh",
+                path = helper_path.display()
+            ),
+        ));
+    }
+
+    log::info!(
+        "bless: installing privileged helper — macOS will prompt for admin credentials"
+    );
+
+    // Safety: all raw pointer operations are confined to do_smjobbless().
+    unsafe { do_smjobbless() }.map_err(|e| io::Error::new(io::ErrorKind::PermissionDenied, e))?;
+
+    // SMJobBless loads the LaunchDaemon asynchronously; poll until the socket appears.
+    wait_for_socket(Duration::from_secs(10))
+}
+
+fn wait_for_socket(timeout: Duration) -> io::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if pfctl_socket_present() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "helper installed but {PFCTL_SOCK} did not appear within {}s\n\
+                     Check /var/log/pelagos-pfctl.log for errors.",
+                    timeout.as_secs()
+                ),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SMJobBless FFI
+// ---------------------------------------------------------------------------
+
+#[allow(non_camel_case_types, non_upper_case_globals)]
+mod ffi {
+    use std::ffi::c_void;
+
+    pub type OSStatus = i32;
+    pub type Boolean = u8;
+    pub type CFTypeRef = *const c_void;
+    pub type CFStringRef = *const c_void;
+    pub type CFErrorRef = *mut c_void;
+    pub type CFAllocatorRef = *const c_void;
+
+    pub const kCFAllocatorDefault: CFAllocatorRef = std::ptr::null();
+    pub const kCFStringEncodingUTF8: u32 = 0x0800_0100;
+
+    // AuthorizationRef is opaque.
+    pub type AuthorizationRef = *mut c_void;
+
+    pub const errAuthorizationSuccess: OSStatus = 0;
+
+    // Authorization flags
+    pub const kAuthorizationFlagDefaults: u32 = 0;
+    pub const kAuthorizationFlagInteractionAllowed: u32 = 1 << 0;
+    pub const kAuthorizationFlagExtendRights: u32 = 1 << 1;
+    pub const kAuthorizationFlagPreAuthorize: u32 = 1 << 2;
+
+    // The right name that allows calling SMJobBless.
+    // Value from Security/Authorization.h: kSMRightBlessPrivilegedHelper
+    pub const SM_BLESS_RIGHT: &std::ffi::CStr =
+        c"com.apple.ServiceManagement.blesshelper";
+
+    #[repr(C)]
+    pub struct AuthorizationItem {
+        pub name: *const std::ffi::c_char,
+        pub value_length: usize,
+        pub value: *mut c_void,
+        pub flags: u32,
+    }
+
+    #[repr(C)]
+    pub struct AuthorizationRights {
+        pub count: u32,
+        pub items: *mut AuthorizationItem,
+    }
+
+    #[link(name = "Security", kind = "framework")]
+    extern "C" {
+        pub fn AuthorizationCreate(
+            rights: *const AuthorizationRights,
+            environment: *const c_void,
+            flags: u32,
+            authorization: *mut AuthorizationRef,
+        ) -> OSStatus;
+        pub fn AuthorizationCopyRights(
+            authorization: AuthorizationRef,
+            rights: *const AuthorizationRights,
+            environment: *const c_void,
+            flags: u32,
+            authorized_rights: *mut *mut AuthorizationRights,
+        ) -> OSStatus;
+        pub fn AuthorizationFree(authorization: AuthorizationRef, flags: u32) -> OSStatus;
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        pub fn CFStringCreateWithCString(
+            alloc: CFAllocatorRef,
+            c_str: *const std::ffi::c_char,
+            encoding: u32,
+        ) -> CFStringRef;
+        pub fn CFStringGetCStringPtr(
+            the_string: CFStringRef,
+            encoding: u32,
+        ) -> *const std::ffi::c_char;
+        pub fn CFErrorCopyDescription(err: CFErrorRef) -> CFStringRef;
+        pub fn CFRelease(cf: CFTypeRef);
+    }
+
+    #[link(name = "ServiceManagement", kind = "framework")]
+    extern "C" {
+        // The domain constant for system (root) LaunchDaemons.
+        pub static kSMDomainSystemLaunchd: CFStringRef;
+
+        pub fn SMJobBless(
+            domain: CFStringRef,
+            job_label: CFStringRef,
+            auth: AuthorizationRef,
+            out_error: *mut CFErrorRef,
+        ) -> Boolean;
+    }
+}
+
+/// Call SMJobBless to install the privileged helper.
+///
+/// # Safety
+/// Raw pointer operations on opaque OS handles. All pointers obtained from OS
+/// APIs; lifetimes managed by explicit `CFRelease` / `AuthorizationFree` calls.
+unsafe fn do_smjobbless() -> Result<(), String> {
+    use ffi::*;
+
+    // 1. Create an empty AuthorizationRef.
+    let mut auth: AuthorizationRef = std::ptr::null_mut();
+    let status = AuthorizationCreate(
+        std::ptr::null(),
+        std::ptr::null(),
+        kAuthorizationFlagDefaults,
+        &mut auth,
+    );
+    if status != errAuthorizationSuccess {
+        return Err(format!("AuthorizationCreate failed: OSStatus {status}"));
+    }
+
+    // 2. Request kSMRightBlessPrivilegedHelper — this triggers the macOS admin
+    //    credential dialog.
+    let right_name = SM_BLESS_RIGHT.as_ptr();
+    let mut right_item = AuthorizationItem {
+        name: right_name,
+        value_length: 0,
+        value: std::ptr::null_mut(),
+        flags: 0,
+    };
+    let rights = AuthorizationRights {
+        count: 1,
+        items: &mut right_item,
+    };
+    let status = AuthorizationCopyRights(
+        auth,
+        &rights,
+        std::ptr::null(),
+        kAuthorizationFlagInteractionAllowed
+            | kAuthorizationFlagExtendRights
+            | kAuthorizationFlagPreAuthorize,
+        std::ptr::null_mut(), // we don't need the granted rights back
+    );
+    if status != errAuthorizationSuccess {
+        AuthorizationFree(auth, kAuthorizationFlagDefaults);
+        return Err(format!(
+            "Authorization failed (user may have cancelled): OSStatus {status}"
+        ));
+    }
+
+    // 3. Call SMJobBless — copies helper to /Library/PrivilegedHelperTools/,
+    //    installs the embedded plist as a LaunchDaemon, and loads it.
+    let label_cstr = CString::new(HELPER_LABEL).unwrap();
+    let label_cf = CFStringCreateWithCString(
+        kCFAllocatorDefault,
+        label_cstr.as_ptr(),
+        kCFStringEncodingUTF8,
+    );
+
+    let mut error: CFErrorRef = std::ptr::null_mut();
+    let ok = SMJobBless(kSMDomainSystemLaunchd, label_cf, auth, &mut error);
+
+    CFRelease(label_cf);
+    AuthorizationFree(auth, kAuthorizationFlagDefaults);
+
+    if ok == 0 {
+        let description = if !error.is_null() {
+            let desc_cf = CFErrorCopyDescription(error);
+            let s = cfstring_to_string(desc_cf);
+            if !desc_cf.is_null() {
+                CFRelease(desc_cf);
+            }
+            CFRelease(error as _);
+            s
+        } else {
+            "unknown error".to_string()
+        };
+        Err(format!(
+            "SMJobBless failed: {description}\n\
+             \n\
+             If developing locally: ensure both 'pelagos' and 'com.pelagos.pfctl' are\n\
+             signed with the same certificate and that the designated requirement strings\n\
+             in pelagos-mac/assets/Info.plist.in (HELPER_DR) and\n\
+             pelagos-pfctl/assets/com.pelagos.pfctl.embedded.plist.in (CALLER_DR)\n\
+             match the actual signatures.\n\
+             \n\
+             Inspect signatures: codesign -dv --verbose=4 $(which pelagos)\n\
+             Create a dev cert: Keychain Access → Certificate Assistant →\n\
+             Create a Certificate → Name: \"pelagos-mac Dev\", Type: Code Signing"
+        ))
+    } else {
+        log::info!("bless: com.pelagos.pfctl installed successfully");
+        Ok(())
+    }
+}
+
+unsafe fn cfstring_to_string(cf: ffi::CFStringRef) -> String {
+    if cf.is_null() {
+        return String::new();
+    }
+    let ptr = ffi::CFStringGetCStringPtr(cf, ffi::kCFStringEncodingUTF8);
+    if ptr.is_null() {
+        return "(non-UTF8 CFString)".to_string();
+    }
+    CStr::from_ptr(ptr).to_string_lossy().into_owned()
+}

--- a/pelagos-mac/src/bless.rs
+++ b/pelagos-mac/src/bless.rs
@@ -1,29 +1,41 @@
-//! SMJobBless integration — automatic privileged helper installation.
+//! Privileged helper installation via osascript.
 //!
 //! On first `pelagos vm start`, if `/var/run/pelagos-pfctl.sock` is absent,
-//! `ensure_pfctl_blessed()` calls `SMJobBless` to install `com.pelagos.pfctl`.
-//! macOS shows a one-time admin credential dialog; after that the helper runs
+//! `ensure_pfctl_blessed()` runs `install-pfctl-daemon.sh` as root.  macOS
+//! shows a one-time admin credential dialog; after that the helper runs
 //! permanently as a LaunchDaemon and restarts automatically on reboot.
 //!
-//! # Signing requirements
+//! # Why osascript and not AuthorizationExecuteWithPrivileges?
 //!
-//! SMJobBless validates a cross-signed trust chain at install time:
-//! - The calling binary (`pelagos`) must have `SMPrivilegedExecutables` in its
-//!   embedded `__TEXT,__info_plist` section listing the helper's designated
-//!   requirement string.
-//! - The helper binary (`com.pelagos.pfctl`) must have `SMAuthorizedClients` in
-//!   its embedded `__TEXT,__launchd_plist` section listing the caller's
-//!   designated requirement string.
-//! - Both binaries must be signed with the same certificate identity.
+//! `AuthorizationExecuteWithPrivileges` (Security framework) is the textbook
+//! API for this use case and is what we tried first.  On macOS 26 it has been
+//! silently neutered for CLI tools: `AuthorizationCopyRights` succeeds and
+//! returns `errAuthorizationSuccess`, but the tool is launched with the
+//! calling user's UID/EUID (501/501) rather than root.
+//! `security_authtrampoline` (the SUID-root relay) is not invoked at all.
 //!
-//! Both plists are generated at build time by their respective `build.rs` with
-//! `@CALLER_DR@` / `@HELPER_DR@` substituted from env vars. For development,
-//! create a local "pelagos-mac Dev" code-signing certificate in Keychain Access
-//! and sign both binaries with it (see `scripts/sign.sh`).
+//! `osascript do shell script ... with administrator privileges` is the only
+//! automated privilege-escalation path that still works for unsigned CLI
+//! binaries on macOS 26.  It is a documented, stable macOS API — not a
+//! hack — but it does require a GUI session.  If the process is running
+//! headless (SSH, launchd non-GUI context), it fails with a clear error and
+//! we surface manual-install instructions.
+//!
+//! # Why not SMJobBless?
+//!
+//! SMJobBless (deprecated macOS 13) requires the calling binary to be part of
+//! a proper `.app` bundle.  `smd` on macOS 26 rejects CLI tool callers with
+//! `CFErrorDomainLaunchd error 2` before copying the helper binary.
+//!
+//! # Helper binary location
+//!
+//! - Dev builds: `<exe_dir>/Contents/Library/LaunchServices/com.pelagos.pfctl`
+//!   (created by `scripts/sign.sh`)
+//! - Homebrew: `<exe_dir>/../share/pelagos-mac/com.pelagos.pfctl`
 
-use std::ffi::{CStr, CString};
 use std::io;
 use std::os::unix::fs::FileTypeExt;
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 /// Socket path for the pfctl helper daemon.
@@ -32,19 +44,49 @@ const PFCTL_SOCK: &str = "/var/run/pelagos-pfctl.sock";
 /// Bundle identifier / LaunchDaemon label for the privileged helper.
 const HELPER_LABEL: &str = "com.pelagos.pfctl";
 
+/// Install destination for the helper binary (PrivilegedHelperTools convention).
+const HELPER_DST: &str = "/Library/PrivilegedHelperTools/com.pelagos.pfctl";
+
+/// LaunchDaemon plist — embedded so the binary is self-contained; written to
+/// /tmp at install time and passed as an argument to the install script.
+const LAUNCHD_PLIST: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.pelagos.pfctl</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Library/PrivilegedHelperTools/com.pelagos.pfctl</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/pelagos-pfctl.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/pelagos-pfctl.log</string>
+</dict>
+</plist>
+"#;
+
+/// Install script — embedded so the binary is self-contained regardless of
+/// install location.  Written to /tmp at install time and run as root.
+const INSTALL_SCRIPT: &str = include_str!("../../scripts/install-pfctl-daemon.sh");
+
 /// Ensure the pelagos-pfctl privileged helper is installed and running.
 ///
 /// Fast path: if the socket already exists, return `Ok(())` immediately.
 ///
-/// Install path: SMJobBless copies the helper binary to
-/// `/Library/PrivilegedHelperTools/com.pelagos.pfctl`, installs its embedded
-/// plist as a LaunchDaemon, and loads it. macOS prompts for admin credentials
-/// exactly once; subsequent calls always hit the fast path.
+/// Install path: uses `osascript` to run the install script as root.
+/// macOS prompts for admin credentials exactly once.
 pub fn ensure_pfctl_blessed() -> io::Result<()> {
     if pfctl_socket_present() {
         return Ok(());
     }
-    bless_helper()
+    install_helper()
 }
 
 fn pfctl_socket_present() -> bool {
@@ -53,44 +95,109 @@ fn pfctl_socket_present() -> bool {
         .unwrap_or(false)
 }
 
-fn bless_helper() -> io::Result<()> {
-    // Locate the helper binary in the same directory as this executable, named
-    // exactly by its bundle identifier.  This is the conventional location that
-    // SMJobBless uses for non-app-bundle CLIs.
-    //
-    // Homebrew layout: /opt/homebrew/bin/pelagos → binary
-    //                  /opt/homebrew/bin/com.pelagos.pfctl → symlink to pkgshare/pelagos-pfctl
-    //
-    // Dev layout:      target/aarch64-apple-darwin/release/pelagos
-    //                  target/aarch64-apple-darwin/release/com.pelagos.pfctl
-    //                  (sign.sh creates the latter as a signed copy)
-    let exe = std::env::current_exe()?;
-    let exe_dir = exe
-        .parent()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "cannot determine exe directory"))?;
-    let helper_path = exe_dir.join(HELPER_LABEL);
+fn install_helper() -> io::Result<()> {
+    let helper_src = find_helper_binary()?;
 
-    if !helper_path.exists() {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            format!(
-                "privileged helper not found at {path}\n\
-                 If using Homebrew, reinstall: brew reinstall pelagos-containers/tap/pelagos-mac\n\
-                 If developing locally, run: bash scripts/sign.sh",
-                path = helper_path.display()
-            ),
-        ));
-    }
+    // Write plist and install script to /tmp (not $TMPDIR — the per-user
+    // sandbox at /var/folders — which macOS prevents from being exec'd with
+    // elevated privileges).
+    use std::os::unix::fs::PermissionsExt;
+
+    let plist_tmp = PathBuf::from("/tmp/com.pelagos.pfctl.plist");
+    std::fs::write(&plist_tmp, LAUNCHD_PLIST)?;
+
+    let script_tmp = PathBuf::from("/tmp/pelagos-install-pfctl.sh");
+    std::fs::write(&script_tmp, INSTALL_SCRIPT)?;
+    std::fs::set_permissions(&script_tmp, std::fs::Permissions::from_mode(0o755))?;
 
     log::info!(
         "bless: installing privileged helper — macOS will prompt for admin credentials"
     );
 
-    // Safety: all raw pointer operations are confined to do_smjobbless().
-    unsafe { do_smjobbless() }.map_err(|e| io::Error::new(io::ErrorKind::PermissionDenied, e))?;
+    // Build the shell command.  All three paths are in /tmp or a standard
+    // Homebrew/release directory; none contain single quotes or spaces, so
+    // single-quoting each token is sufficient.
+    let shell_cmd = format!(
+        "'{script}' '{helper}' '{plist}'",
+        script = script_tmp.display(),
+        helper = helper_src.display(),
+        plist  = plist_tmp.display(),
+    );
+    // osascript runs the shell command synchronously as root and returns only
+    // after the script exits — no async race with temp-file cleanup.
+    let applescript = format!(
+        "do shell script {shell_cmd:?} with administrator privileges"
+    );
 
-    // SMJobBless loads the LaunchDaemon asynchronously; poll until the socket appears.
-    wait_for_socket(Duration::from_secs(10))
+    let output = std::process::Command::new("osascript")
+        .args(["-e", &applescript])
+        .output()
+        .map_err(|e| io::Error::other(format!("osascript: {e}")))?;
+
+    let _ = std::fs::remove_file(&plist_tmp);
+    let _ = std::fs::remove_file(&script_tmp);
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "privileged install failed (user may have cancelled, or no GUI session).\n\
+                 osascript: {stderr}\n\
+                 \n\
+                 To install manually:\n\
+                   sudo bash scripts/install-pfctl-daemon.sh\n\
+                 Or (Homebrew):\n\
+                   sudo bash \"$(brew --prefix)/share/pelagos-mac/install-pfctl-daemon.sh\"\n\
+                 \n\
+                 The daemon installs to {HELPER_DST} and runs as a system LaunchDaemon."
+            ),
+        ));
+    }
+
+    // osascript is synchronous; the install script checks for the socket
+    // before exiting, so it should already be present.
+    wait_for_socket(Duration::from_secs(5))?;
+    log::info!("bless: com.pelagos.pfctl installed successfully");
+    Ok(())
+}
+
+/// Locate the helper binary to install.
+///
+/// Search order:
+/// 1. Dev: `<exe_dir>/Contents/Library/LaunchServices/com.pelagos.pfctl` (sign.sh)
+/// 2. Homebrew: `<exe_dir>/../share/pelagos-mac/com.pelagos.pfctl`
+fn find_helper_binary() -> io::Result<PathBuf> {
+    let exe = std::env::current_exe()?;
+    let exe_dir = exe.parent().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, "cannot determine exe directory")
+    })?;
+
+    let dev_path = exe_dir
+        .join("Contents/Library/LaunchServices")
+        .join(HELPER_LABEL);
+    if dev_path.exists() {
+        return Ok(dev_path);
+    }
+
+    let brew_path = exe_dir.join("../share/pelagos-mac").join(HELPER_LABEL);
+    if let Ok(p) = brew_path.canonicalize() {
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!(
+            "privileged helper not found.\n\
+             Expected at {dev} (dev) or {brew} (Homebrew).\n\
+             If using Homebrew: brew reinstall pelagos-containers/tap/pelagos-mac\n\
+             If developing locally: run scripts/sign.sh",
+            dev = dev_path.display(),
+            brew = brew_path.display(),
+        ),
+    ))
 }
 
 fn wait_for_socket(timeout: Duration) -> io::Result<()> {
@@ -111,205 +218,4 @@ fn wait_for_socket(timeout: Duration) -> io::Result<()> {
         }
         std::thread::sleep(Duration::from_millis(200));
     }
-}
-
-// ---------------------------------------------------------------------------
-// SMJobBless FFI
-// ---------------------------------------------------------------------------
-
-#[allow(non_camel_case_types, non_upper_case_globals)]
-mod ffi {
-    use std::ffi::c_void;
-
-    pub type OSStatus = i32;
-    pub type Boolean = u8;
-    pub type CFTypeRef = *const c_void;
-    pub type CFStringRef = *const c_void;
-    pub type CFErrorRef = *mut c_void;
-    pub type CFAllocatorRef = *const c_void;
-
-    pub const kCFAllocatorDefault: CFAllocatorRef = std::ptr::null();
-    pub const kCFStringEncodingUTF8: u32 = 0x0800_0100;
-
-    // AuthorizationRef is opaque.
-    pub type AuthorizationRef = *mut c_void;
-
-    pub const errAuthorizationSuccess: OSStatus = 0;
-
-    // Authorization flags
-    pub const kAuthorizationFlagDefaults: u32 = 0;
-    pub const kAuthorizationFlagInteractionAllowed: u32 = 1 << 0;
-    pub const kAuthorizationFlagExtendRights: u32 = 1 << 1;
-    pub const kAuthorizationFlagPreAuthorize: u32 = 1 << 2;
-
-    // The right name that allows calling SMJobBless.
-    // Value from Security/Authorization.h: kSMRightBlessPrivilegedHelper
-    pub const SM_BLESS_RIGHT: &std::ffi::CStr =
-        c"com.apple.ServiceManagement.blesshelper";
-
-    #[repr(C)]
-    pub struct AuthorizationItem {
-        pub name: *const std::ffi::c_char,
-        pub value_length: usize,
-        pub value: *mut c_void,
-        pub flags: u32,
-    }
-
-    #[repr(C)]
-    pub struct AuthorizationRights {
-        pub count: u32,
-        pub items: *mut AuthorizationItem,
-    }
-
-    #[link(name = "Security", kind = "framework")]
-    extern "C" {
-        pub fn AuthorizationCreate(
-            rights: *const AuthorizationRights,
-            environment: *const c_void,
-            flags: u32,
-            authorization: *mut AuthorizationRef,
-        ) -> OSStatus;
-        pub fn AuthorizationCopyRights(
-            authorization: AuthorizationRef,
-            rights: *const AuthorizationRights,
-            environment: *const c_void,
-            flags: u32,
-            authorized_rights: *mut *mut AuthorizationRights,
-        ) -> OSStatus;
-        pub fn AuthorizationFree(authorization: AuthorizationRef, flags: u32) -> OSStatus;
-    }
-
-    #[link(name = "CoreFoundation", kind = "framework")]
-    extern "C" {
-        pub fn CFStringCreateWithCString(
-            alloc: CFAllocatorRef,
-            c_str: *const std::ffi::c_char,
-            encoding: u32,
-        ) -> CFStringRef;
-        pub fn CFStringGetCStringPtr(
-            the_string: CFStringRef,
-            encoding: u32,
-        ) -> *const std::ffi::c_char;
-        pub fn CFErrorCopyDescription(err: CFErrorRef) -> CFStringRef;
-        pub fn CFRelease(cf: CFTypeRef);
-    }
-
-    #[link(name = "ServiceManagement", kind = "framework")]
-    extern "C" {
-        // The domain constant for system (root) LaunchDaemons.
-        pub static kSMDomainSystemLaunchd: CFStringRef;
-
-        pub fn SMJobBless(
-            domain: CFStringRef,
-            job_label: CFStringRef,
-            auth: AuthorizationRef,
-            out_error: *mut CFErrorRef,
-        ) -> Boolean;
-    }
-}
-
-/// Call SMJobBless to install the privileged helper.
-///
-/// # Safety
-/// Raw pointer operations on opaque OS handles. All pointers obtained from OS
-/// APIs; lifetimes managed by explicit `CFRelease` / `AuthorizationFree` calls.
-unsafe fn do_smjobbless() -> Result<(), String> {
-    use ffi::*;
-
-    // 1. Create an empty AuthorizationRef.
-    let mut auth: AuthorizationRef = std::ptr::null_mut();
-    let status = AuthorizationCreate(
-        std::ptr::null(),
-        std::ptr::null(),
-        kAuthorizationFlagDefaults,
-        &mut auth,
-    );
-    if status != errAuthorizationSuccess {
-        return Err(format!("AuthorizationCreate failed: OSStatus {status}"));
-    }
-
-    // 2. Request kSMRightBlessPrivilegedHelper — this triggers the macOS admin
-    //    credential dialog.
-    let right_name = SM_BLESS_RIGHT.as_ptr();
-    let mut right_item = AuthorizationItem {
-        name: right_name,
-        value_length: 0,
-        value: std::ptr::null_mut(),
-        flags: 0,
-    };
-    let rights = AuthorizationRights {
-        count: 1,
-        items: &mut right_item,
-    };
-    let status = AuthorizationCopyRights(
-        auth,
-        &rights,
-        std::ptr::null(),
-        kAuthorizationFlagInteractionAllowed
-            | kAuthorizationFlagExtendRights
-            | kAuthorizationFlagPreAuthorize,
-        std::ptr::null_mut(), // we don't need the granted rights back
-    );
-    if status != errAuthorizationSuccess {
-        AuthorizationFree(auth, kAuthorizationFlagDefaults);
-        return Err(format!(
-            "Authorization failed (user may have cancelled): OSStatus {status}"
-        ));
-    }
-
-    // 3. Call SMJobBless — copies helper to /Library/PrivilegedHelperTools/,
-    //    installs the embedded plist as a LaunchDaemon, and loads it.
-    let label_cstr = CString::new(HELPER_LABEL).unwrap();
-    let label_cf = CFStringCreateWithCString(
-        kCFAllocatorDefault,
-        label_cstr.as_ptr(),
-        kCFStringEncodingUTF8,
-    );
-
-    let mut error: CFErrorRef = std::ptr::null_mut();
-    let ok = SMJobBless(kSMDomainSystemLaunchd, label_cf, auth, &mut error);
-
-    CFRelease(label_cf);
-    AuthorizationFree(auth, kAuthorizationFlagDefaults);
-
-    if ok == 0 {
-        let description = if !error.is_null() {
-            let desc_cf = CFErrorCopyDescription(error);
-            let s = cfstring_to_string(desc_cf);
-            if !desc_cf.is_null() {
-                CFRelease(desc_cf);
-            }
-            CFRelease(error as _);
-            s
-        } else {
-            "unknown error".to_string()
-        };
-        Err(format!(
-            "SMJobBless failed: {description}\n\
-             \n\
-             If developing locally: ensure both 'pelagos' and 'com.pelagos.pfctl' are\n\
-             signed with the same certificate and that the designated requirement strings\n\
-             in pelagos-mac/assets/Info.plist.in (HELPER_DR) and\n\
-             pelagos-pfctl/assets/com.pelagos.pfctl.embedded.plist.in (CALLER_DR)\n\
-             match the actual signatures.\n\
-             \n\
-             Inspect signatures: codesign -dv --verbose=4 $(which pelagos)\n\
-             Create a dev cert: Keychain Access → Certificate Assistant →\n\
-             Create a Certificate → Name: \"pelagos-mac Dev\", Type: Code Signing"
-        ))
-    } else {
-        log::info!("bless: com.pelagos.pfctl installed successfully");
-        Ok(())
-    }
-}
-
-unsafe fn cfstring_to_string(cf: ffi::CFStringRef) -> String {
-    if cf.is_null() {
-        return String::new();
-    }
-    let ptr = ffi::CFStringGetCStringPtr(cf, ffi::kCFStringEncodingUTF8);
-    if ptr.is_null() {
-        return "(non-UTF8 CFString)".to_string();
-    }
-    CStr::from_ptr(ptr).to_string_lossy().into_owned()
 }

--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -173,6 +173,12 @@ pub struct DaemonArgs {
 pub fn ensure_running(args: &DaemonArgs) -> io::Result<()> {
     let state = StateDir::open_profile(&args.profile)?;
 
+    // Ensure the privileged pf/utun helper is installed and running.
+    // SMJobBless installs it on first use — macOS prompts for admin credentials
+    // once; every subsequent call hits the fast path (socket stat only).
+    crate::bless::ensure_pfctl_blessed()
+        .map_err(|e| io::Error::other(format!("pfctl helper: {e}")))?;
+
     if state.is_daemon_alive() {
         // Verify that the running daemon was started with the same mounts.
         // (virtiofs shares are part of the VM config and cannot change at runtime.)

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -14,6 +14,7 @@ use std::process;
 use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 
+mod bless;
 mod daemon;
 mod state;
 
@@ -1970,14 +1971,11 @@ fn vm_init(profile: &str, vm_data: Option<&std::path::Path>, force: bool) -> std
     if !force {
         if let Ok(st) = state::StateDir::open_profile(profile) {
             if let Some(pid) = st.running_pid() {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    format!(
-                        "VM is running (pid {pid}). \
-                         Stop it first with 'pelagos vm stop', then re-run \
-                         'pelagos vm init', or pass --force to stop it automatically."
-                    ),
-                ));
+                return Err(Error::other(format!(
+                    "VM is running (pid {pid}). \
+                     Stop it first with 'pelagos vm stop', then re-run \
+                     'pelagos vm init', or pass --force to stop it automatically."
+                )));
             }
         }
     }

--- a/pelagos-pfctl/assets/com.pelagos.pfctl.embedded.plist.in
+++ b/pelagos-pfctl/assets/com.pelagos.pfctl.embedded.plist.in
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Label must match the binary's bundle identifier and the key in
+         pelagos-mac's SMPrivilegedExecutables Info.plist. -->
+    <key>Label</key>
+    <string>com.pelagos.pfctl</string>
+
+    <!-- SMJobBless installs the binary to /Library/PrivilegedHelperTools/.
+         ProgramArguments must reference that path, not the source location. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Library/PrivilegedHelperTools/com.pelagos.pfctl</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Designated requirement for the calling binary (pelagos).
+         @CALLER_DR@ is substituted at build time by pelagos-pfctl/build.rs.
+         Dev default: certificate leaf[subject.CN] = "pelagos-mac Dev"
+         Prod: anchor apple generic and identifier "io.pelagos.mac" and ... -->
+    <key>SMAuthorizedClients</key>
+    <array>
+        <string>@CALLER_DR@</string>
+    </array>
+
+    <key>StandardOutPath</key>
+    <string>/var/log/pelagos-pfctl.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/pelagos-pfctl.log</string>
+</dict>
+</plist>

--- a/pelagos-pfctl/build.rs
+++ b/pelagos-pfctl/build.rs
@@ -1,0 +1,37 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    // Designated requirement for the calling binary (pelagos-mac).
+    // For development: create a local "pelagos-mac Dev" certificate in Keychain Access
+    //   (Keychain Access → Certificate Assistant → Create a Certificate →
+    //    Name: "pelagos-mac Dev", Certificate Type: Code Signing).
+    // For production: set PELAGOS_CALLER_DR to the Developer ID designated requirement.
+    let caller_dr = env::var("PELAGOS_CALLER_DR").unwrap_or_else(|_| {
+        r#"certificate leaf[subject.CN] = "pelagos-mac Dev""#.to_string()
+    });
+
+    // Substitute @CALLER_DR@ in the template and write to OUT_DIR.
+    let template =
+        fs::read_to_string(manifest.join("assets/com.pelagos.pfctl.embedded.plist.in"))
+            .expect("pelagos-pfctl/assets/com.pelagos.pfctl.embedded.plist.in not found");
+    let plist = template.replace("@CALLER_DR@", &caller_dr);
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let plist_path = out_dir.join("com.pelagos.pfctl.embedded.plist");
+    fs::write(&plist_path, &plist).unwrap();
+
+    // Embed as __TEXT,__launchd_plist Mach-O section.
+    // SMJobBless reads this section from the helper binary to obtain the
+    // LaunchDaemon plist and validate SMAuthorizedClients.
+    println!(
+        "cargo:rustc-link-arg=-Wl,-sectcreate,__TEXT,__launchd_plist,{}",
+        plist_path.display()
+    );
+
+    println!("cargo:rerun-if-changed=assets/com.pelagos.pfctl.embedded.plist.in");
+    println!("cargo:rerun-if-env-changed=PELAGOS_CALLER_DR");
+}

--- a/pelagos-pfctl/entitlements.plist
+++ b/pelagos-pfctl/entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -84,9 +84,11 @@ trap 'rm -rf "$BIN_STAGING" "$VM_STAGING"' EXIT
 cp "$REPO/target/aarch64-apple-darwin/release/pelagos"        "$BIN_STAGING/pelagos"
 cp "$REPO/target/aarch64-apple-darwin/release/pelagos-docker" "$BIN_STAGING/pelagos-docker"
 cp "$REPO/target/aarch64-apple-darwin/release/pelagos-tui"    "$BIN_STAGING/pelagos-tui"
-cp "$REPO/target/aarch64-apple-darwin/release/pelagos-pfctl"  "$BIN_STAGING/pelagos-pfctl"
-# Entitlements, LaunchDaemon plist, and privileged daemon install script
-# are shipped in share/pelagos-mac for the post-install steps.
+# The helper is named by its bundle identifier.  SMJobBless looks for it
+# in the same directory as the calling binary using this exact name.
+cp "$REPO/target/aarch64-apple-darwin/release/pelagos-pfctl"  "$BIN_STAGING/com.pelagos.pfctl"
+# Entitlements, LaunchDaemon plist, and fallback install script shipped in
+# share/pelagos-mac.  The install script is a last-resort fallback only.
 mkdir -p "$BIN_STAGING/share"
 cp "$REPO/pelagos-mac/entitlements.plist"                      "$BIN_STAGING/share/entitlements.plist"
 cp "$REPO/scripts/com.pelagos.pfctl.plist"                     "$BIN_STAGING/share/com.pelagos.pfctl.plist"
@@ -146,32 +148,35 @@ class PelagosMac < Formula
     bin.install "pelagos"
     bin.install "pelagos-docker"
     bin.install "pelagos-tui"
-    # pelagos-pfctl is a privileged root daemon; ship it in pkgshare so the
-    # post-install script can copy it to /usr/local/lib/pelagos/.
-    (pkgshare).install "pelagos-pfctl"
-    (pkgshare).install "share/entitlements.plist"
-    (pkgshare).install "share/com.pelagos.pfctl.plist"
-    (pkgshare).install "share/install-pfctl-daemon.sh"
+    # SMJobBless convention for non-bundle CLIs: the helper binary must be in
+    # the same directory as the calling binary, named by its bundle identifier.
+    # Install as bin/com.pelagos.pfctl (symlink to pkgshare copy).
+    pkgshare.install "com.pelagos.pfctl"
+    bin.install_symlink pkgshare/"com.pelagos.pfctl"
+    pkgshare.install "share/entitlements.plist"
+    pkgshare.install "share/com.pelagos.pfctl.plist"
+    pkgshare.install "share/install-pfctl-daemon.sh"
     resource("vm").stage { pkgshare.install Dir["*"] }
   end
 
   def post_install
     # macOS 26 taskgated validates the AVF entitlement signature at the binary's
-    # actual run path.  Re-sign after install so the signature covers the Cellar path.
+    # actual run path.  Re-sign both binaries after install.
     entitlements = pkgshare/"entitlements.plist"
     system "codesign", "--sign", "-", "--entitlements", entitlements.to_s,
            "--force", (bin/"pelagos").to_s
+    # Re-sign the helper at its pkgshare path and the bin symlink target.
+    system "codesign", "--sign", "-", "--force", (pkgshare/"com.pelagos.pfctl").to_s
   end
 
   def caveats
     <<~EOS
-      pelagos requires a privileged helper daemon (pelagos-pfctl) to create
-      the utun interface and load pf NAT rules.  Run once after install:
+      On first 'pelagos vm start', pelagos will automatically install the
+      privileged helper daemon (pelagos-pfctl) via SMJobBless.  macOS will
+      prompt for admin credentials once.
 
+      If SMJobBless fails (e.g. signing requirements don't match), run manually:
         sudo bash #{pkgshare}/install-pfctl-daemon.sh
-
-      This installs /usr/local/lib/pelagos/pelagos-pfctl and registers
-      the com.pelagos.pfctl LaunchDaemon (starts automatically on reboot).
     EOS
   end
 

--- a/scripts/com.pelagos.pfctl.plist
+++ b/scripts/com.pelagos.pfctl.plist
@@ -7,7 +7,7 @@
     <string>com.pelagos.pfctl</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/lib/pelagos/pelagos-pfctl</string>
+        <string>/Library/PrivilegedHelperTools/com.pelagos.pfctl</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/scripts/install-pfctl-daemon.sh
+++ b/scripts/install-pfctl-daemon.sh
@@ -1,59 +1,76 @@
 #!/usr/bin/env bash
-# install-pfctl-daemon.sh — privileged post-install step for pelagos-mac.
+# install-pfctl-daemon.sh — Install the pelagos-pfctl privileged helper daemon.
 #
-# Installs the pelagos-pfctl helper daemon and its LaunchDaemon plist, then
-# loads the daemon so it is running immediately.
+# Called automatically by `pelagos` via AuthorizationExecuteWithPrivileges.
+# Can also be run manually as root.
 #
-# Must be run as root (sudo).
+# Usage (automatic — called by pelagos):
+#   bash install-pfctl-daemon.sh <helper_binary> <launchd_plist>
 #
-# Usage (after brew install skeptomai/tap/pelagos-mac):
+# Usage (manual fallback — e.g. SSH session, cancelled dialog):
 #   sudo bash "$(brew --prefix)/share/pelagos-mac/install-pfctl-daemon.sh"
-#
-# Or during development:
 #   sudo bash scripts/install-pfctl-daemon.sh
 
 set -euo pipefail
 
 if [[ "$(id -u)" != "0" ]]; then
-    echo "ERROR: must run as root: sudo bash $0"
+    echo "ERROR: must run as root: sudo bash $0" >&2
     exit 1
 fi
 
-# ---------------------------------------------------------------------------
-# Locate the pelagos-pfctl binary.
-# Prefer Homebrew pkgshare, fall back to local build tree.
-# ---------------------------------------------------------------------------
-BREW_PREFIX="$(brew --prefix 2>/dev/null || echo /opt/homebrew)"
-PKGSHARE="$BREW_PREFIX/share/pelagos-mac"
-
-if [[ -f "$PKGSHARE/pelagos-pfctl" ]]; then
-    SRC_PFCTL="$PKGSHARE/pelagos-pfctl"
-    SRC_PLIST="$PKGSHARE/com.pelagos.pfctl.plist"
-else
-    # Development fallback — repo working copy
-    REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-    SRC_PFCTL="$REPO/target/aarch64-apple-darwin/release/pelagos-pfctl"
-    SRC_PLIST="$REPO/scripts/com.pelagos.pfctl.plist"
-    if [[ ! -f "$SRC_PFCTL" ]]; then
-        echo "ERROR: pelagos-pfctl not found at $SRC_PFCTL"
-        echo "       Run 'brew install skeptomai/tap/pelagos-mac' or 'cargo build -p pelagos-pfctl --release' first."
-        exit 1
-    fi
-fi
-
-INSTALL_DIR="/usr/local/lib/pelagos"
-DAEMON_DST="$INSTALL_DIR/pelagos-pfctl"
+HELPER_DST="/Library/PrivilegedHelperTools/com.pelagos.pfctl"
 PLIST_DST="/Library/LaunchDaemons/com.pelagos.pfctl.plist"
 LABEL="com.pelagos.pfctl"
 
 # ---------------------------------------------------------------------------
+# Resolve helper binary and plist paths.
+#
+# When called by pelagos (AuthorizationExecuteWithPrivileges):
+#   $1 = absolute path to the helper binary
+#   $2 = absolute path to a pre-written launchd plist (in /tmp)
+#
+# When called manually (no arguments):
+#   auto-detect from Homebrew pkgshare or repo working copy.
+# ---------------------------------------------------------------------------
+if [[ $# -ge 2 ]]; then
+    SRC_PFCTL="$1"
+    SRC_PLIST="$2"
+else
+    BREW_PREFIX="$(brew --prefix 2>/dev/null || echo /opt/homebrew)"
+    PKGSHARE="$BREW_PREFIX/share/pelagos-mac"
+
+    if [[ -f "$PKGSHARE/com.pelagos.pfctl" ]]; then
+        SRC_PFCTL="$PKGSHARE/com.pelagos.pfctl"
+        SRC_PLIST="$PKGSHARE/com.pelagos.pfctl.plist"
+    else
+        REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+        SRC_PFCTL="$REPO/target/aarch64-apple-darwin/release/Contents/Library/LaunchServices/com.pelagos.pfctl"
+        SRC_PLIST="$REPO/scripts/com.pelagos.pfctl.plist"
+        if [[ ! -f "$SRC_PFCTL" ]]; then
+            echo "ERROR: helper binary not found at $SRC_PFCTL" >&2
+            echo "       Run 'brew install skeptomai/tap/pelagos-mac' or 'scripts/sign.sh' first." >&2
+            exit 1
+        fi
+    fi
+fi
+
+if [[ ! -f "$SRC_PFCTL" ]]; then
+    echo "ERROR: helper binary not found: $SRC_PFCTL" >&2
+    exit 1
+fi
+if [[ ! -f "$SRC_PLIST" ]]; then
+    echo "ERROR: launchd plist not found: $SRC_PLIST" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
 # Install binary
 # ---------------------------------------------------------------------------
-mkdir -p "$INSTALL_DIR"
-cp "$SRC_PFCTL" "$DAEMON_DST"
-chown root:wheel "$DAEMON_DST"
-chmod 755 "$DAEMON_DST"
-echo "==> installed $DAEMON_DST"
+mkdir -p /Library/PrivilegedHelperTools
+cp "$SRC_PFCTL" "$HELPER_DST"
+chown root:wheel "$HELPER_DST"
+chmod 755 "$HELPER_DST"
+echo "==> installed $HELPER_DST"
 
 # ---------------------------------------------------------------------------
 # Install plist
@@ -79,7 +96,7 @@ sleep 1
 if [[ -S /var/run/pelagos-pfctl.sock ]]; then
     echo "==> daemon OK (socket present)"
 else
-    echo "ERROR: socket /var/run/pelagos-pfctl.sock not present after start"
-    echo "       Check /var/log/pelagos-pfctl.log for errors."
+    echo "ERROR: socket /var/run/pelagos-pfctl.sock not present after start" >&2
+    echo "       Check /var/log/pelagos-pfctl.log for errors." >&2
     exit 1
 fi

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -1,24 +1,56 @@
 #!/usr/bin/env bash
-# sign.sh — Ad-hoc sign the pelagos binary with the AVF virtualization entitlement.
+# sign.sh — Sign pelagos and the pelagos-pfctl privileged helper.
 #
-# Signs target/aarch64-apple-darwin/release/pelagos in-place.
 # NOTE: sign AFTER installing, not before — macOS 26 taskgated validates the
 # signature at the binary's actual run path.
 #
-# For development an ad-hoc signature (-) is sufficient.
-# For distribution, replace "-" with your Developer ID Application identity.
+# Both binaries must be signed with the same certificate identity so that
+# SMJobBless can validate the cross-signed trust chain at install time:
+#   pelagos (SMPrivilegedExecutables DR) ↔ com.pelagos.pfctl (SMAuthorizedClients DR)
+#
+# For development: create a local "pelagos-mac Dev" certificate in Keychain Access
+#   (Certificate Assistant → Create a Certificate → Name: "pelagos-mac Dev",
+#    Type: Code Signing) and set PELAGOS_SIGN_IDENTITY="pelagos-mac Dev".
+#
+# For ad-hoc (no SMJobBless): PELAGOS_SIGN_IDENTITY="-" (default).
+#   Ad-hoc signatures allow the VM to start but SMJobBless will not work
+#   because ad-hoc has no stable identity for the designated requirement strings.
+#
+# For distribution: set PELAGOS_SIGN_IDENTITY to your Developer ID Application identity.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BINARY="$REPO_ROOT/target/aarch64-apple-darwin/release/pelagos"
-ENTITLEMENTS="$REPO_ROOT/pelagos-mac/entitlements.plist"
+RELEASE="$REPO_ROOT/target/aarch64-apple-darwin/release"
+IDENTITY="${PELAGOS_SIGN_IDENTITY:-"-"}"
+
+BINARY="$RELEASE/pelagos"
+PFCTL_BINARY="$RELEASE/pelagos-pfctl"
+MAIN_ENTITLEMENTS="$REPO_ROOT/pelagos-mac/entitlements.plist"
+PFCTL_ENTITLEMENTS="$REPO_ROOT/pelagos-pfctl/entitlements.plist"
 
 if [ ! -f "$BINARY" ]; then
     echo "ERROR: binary not found: $BINARY"
     echo "Build it first:  cargo build --release -p pelagos-mac"
     exit 1
 fi
+if [ ! -f "$PFCTL_BINARY" ]; then
+    echo "ERROR: binary not found: $PFCTL_BINARY"
+    echo "Build it first:  cargo build --release -p pelagos-pfctl"
+    exit 1
+fi
 
-codesign --sign - --entitlements "$ENTITLEMENTS" --force "$BINARY"
+codesign --sign "$IDENTITY" --entitlements "$MAIN_ENTITLEMENTS" --force "$BINARY"
 echo "Signed: $BINARY"
+
+codesign --sign "$IDENTITY" --entitlements "$PFCTL_ENTITLEMENTS" --force "$PFCTL_BINARY"
+echo "Signed: $PFCTL_BINARY"
+
+# SMJobBless looks for the helper in the same directory as the calling binary,
+# named exactly by its bundle identifier.  Create a signed copy named
+# com.pelagos.pfctl adjacent to pelagos so the dev workflow works without
+# a Homebrew install.
+HELPER_COPY="$RELEASE/com.pelagos.pfctl"
+cp "$PFCTL_BINARY" "$HELPER_COPY"
+codesign --sign "$IDENTITY" --entitlements "$PFCTL_ENTITLEMENTS" --force "$HELPER_COPY"
+echo "Signed: $HELPER_COPY"

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -50,7 +50,16 @@ echo "Signed: $PFCTL_BINARY"
 # named exactly by its bundle identifier.  Create a signed copy named
 # com.pelagos.pfctl adjacent to pelagos so the dev workflow works without
 # a Homebrew install.
-HELPER_COPY="$RELEASE/com.pelagos.pfctl"
+# SMJobBless looks for the helper at Contents/Library/LaunchServices/<label>
+# relative to the main bundle path.  For a CLI binary, NSBundle.mainBundle.bundlePath
+# is the executable's directory — so the helper must live at:
+#   <release_dir>/Contents/Library/LaunchServices/com.pelagos.pfctl
+HELPER_DIR="$RELEASE/Contents/Library/LaunchServices"
+HELPER_COPY="$HELPER_DIR/com.pelagos.pfctl"
+mkdir -p "$HELPER_DIR"
 cp "$PFCTL_BINARY" "$HELPER_COPY"
-codesign --sign "$IDENTITY" --entitlements "$PFCTL_ENTITLEMENTS" --force "$HELPER_COPY"
+# --identifier is mandatory: codesign otherwise strips the last dot-segment as
+# a file extension (com.pelagos.pfctl → com.pelagos).
+codesign --sign "$IDENTITY" --identifier "com.pelagos.pfctl" \
+         --entitlements "$PFCTL_ENTITLEMENTS" --force "$HELPER_COPY"
 echo "Signed: $HELPER_COPY"


### PR DESCRIPTION
## Summary

- SMJobBless requires a proper `.app` bundle caller — `smd` on macOS 26 rejects CLI tools with `CFErrorDomainLaunchd error 2`
- `AuthorizationExecuteWithPrivileges` was tried next: confirmed **neutered on macOS 26** — forks as calling user (uid/euid 501), `security_authtrampoline` never invoked
- `osascript do shell script ... with administrator privileges` is the only automated privilege escalation path that still works for CLI tools on macOS 26

## Changes

- `bless.rs`: full rewrite to `osascript`; detailed module doc explains why each API was rejected; temp files go to `/tmp` (not `$TMPDIR`/`/var/folders`)
- `install-pfctl-daemon.sh`: accepts `$1`/`$2` args from pelagos; auto-detects Homebrew/repo paths when called manually without args
- `com.pelagos.pfctl.plist`: fix install path to `/Library/PrivilegedHelperTools`
- `sign.sh`: add `--identifier` to codesign helper copy (prevents codesign stripping last dot-segment as file extension)

## Developer certificate requirement

None. `osascript` is a system binary — the calling process needs no special certificate. Ad-hoc signing (the default in `scripts/sign.sh`) is sufficient for all developers.

## Test plan

- [x] `sudo rm /var/run/pelagos-pfctl.sock` → `pelagos ping` → admin dialog appears → `pong` returned
- [x] Second `pelagos ping` skips install (fast path: socket present)
- [x] `cargo clippy -p pelagos-mac -- -D warnings` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)