### PR TITLE
feat(networking): per-profile VM subnet — each profile gets a distinct /24

### DIFF
--- a/pelagos-mac/build.rs
+++ b/pelagos-mac/build.rs
@@ -21,9 +21,8 @@ fn main() {
     // Must match the SMAuthorizedClients entry in pelagos-pfctl's embedded plist.
     // For development: matches the "pelagos-mac Dev" local certificate.
     // For production: set PELAGOS_HELPER_DR to the Developer ID designated requirement.
-    let helper_dr = env::var("PELAGOS_HELPER_DR").unwrap_or_else(|_| {
-        r#"certificate leaf[subject.CN] = "pelagos-mac Dev""#.to_string()
-    });
+    let helper_dr = env::var("PELAGOS_HELPER_DR")
+        .unwrap_or_else(|_| r#"certificate leaf[subject.CN] = "pelagos-mac Dev""#.to_string());
 
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let template = fs::read_to_string(manifest.join("assets/Info.plist.in"))

--- a/pelagos-mac/src/bless.rs
+++ b/pelagos-mac/src/bless.rs
@@ -110,9 +110,7 @@ fn install_helper() -> io::Result<()> {
     std::fs::write(&script_tmp, INSTALL_SCRIPT)?;
     std::fs::set_permissions(&script_tmp, std::fs::Permissions::from_mode(0o755))?;
 
-    log::info!(
-        "bless: installing privileged helper — macOS will prompt for admin credentials"
-    );
+    log::info!("bless: installing privileged helper — macOS will prompt for admin credentials");
 
     // Build the shell command.  All three paths are in /tmp or a standard
     // Homebrew/release directory; none contain single quotes or spaces, so
@@ -121,13 +119,11 @@ fn install_helper() -> io::Result<()> {
         "'{script}' '{helper}' '{plist}'",
         script = script_tmp.display(),
         helper = helper_src.display(),
-        plist  = plist_tmp.display(),
+        plist = plist_tmp.display(),
     );
     // osascript runs the shell command synchronously as root and returns only
     // after the script exits — no async race with temp-file cleanup.
-    let applescript = format!(
-        "do shell script {shell_cmd:?} with administrator privileges"
-    );
+    let applescript = format!("do shell script {shell_cmd:?} with administrator privileges");
 
     let output = std::process::Command::new("osascript")
         .args(["-e", &applescript])
@@ -169,9 +165,9 @@ fn install_helper() -> io::Result<()> {
 /// 2. Homebrew: `<exe_dir>/../share/pelagos-mac/com.pelagos.pfctl`
 fn find_helper_binary() -> io::Result<PathBuf> {
     let exe = std::env::current_exe()?;
-    let exe_dir = exe.parent().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::NotFound, "cannot determine exe directory")
-    })?;
+    let exe_dir = exe
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "cannot determine exe directory"))?;
 
     let dev_path = exe_dir
         .join("Contents/Library/LaunchServices")

--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -179,6 +179,12 @@ pub fn ensure_running(args: &DaemonArgs) -> io::Result<()> {
     crate::bless::ensure_pfctl_blessed()
         .map_err(|e| io::Error::other(format!("pfctl helper: {e}")))?;
 
+    // Ensure this profile has a stable per-VM subnet IP assigned and persisted
+    // in vm.conf before the daemon subprocess is spawned.  The daemon subprocess
+    // re-reads vm.conf and uses the IP to configure the tun relay.
+    crate::state::ensure_vm_ip(&args.profile)
+        .map_err(|e| io::Error::other(format!("subnet allocation: {e}")))?;
+
     if state.is_daemon_alive() {
         // Verify that the running daemon was started with the same mounts.
         // (virtiofs shares are part of the VM config and cannot change at runtime.)
@@ -818,12 +824,19 @@ pub(crate) fn daemon_subprocess_args(args: &DaemonArgs) -> Vec<std::ffi::OsStrin
 }
 
 fn build_vm_config(args: &DaemonArgs) -> VmConfig {
+    let profile_conf = crate::state::VmProfileConfig::load(&args.profile)
+        .unwrap_or_default();
+    let guest_ip = profile_conf
+        .vm_ip
+        .unwrap_or(crate::state::DEFAULT_GUEST_IP)
+        .octets();
     let mut b = VmConfig::builder()
         .kernel(&args.kernel)
         .disk(&args.disk)
         .cmdline(build_cmdline(args))
         .memory_mib(args.memory_mib)
-        .cpus(args.cpus);
+        .cpus(args.cpus)
+        .guest_ip(guest_ip);
     if let Some(ref initrd) = args.initrd {
         b = b.initrd(initrd);
     }

--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -824,8 +824,7 @@ pub(crate) fn daemon_subprocess_args(args: &DaemonArgs) -> Vec<std::ffi::OsStrin
 }
 
 fn build_vm_config(args: &DaemonArgs) -> VmConfig {
-    let profile_conf = crate::state::VmProfileConfig::load(&args.profile)
-        .unwrap_or_default();
+    let profile_conf = crate::state::VmProfileConfig::load(&args.profile).unwrap_or_default();
     let guest_ip = profile_conf
         .vm_ip
         .unwrap_or(crate::state::DEFAULT_GUEST_IP)

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -838,8 +838,12 @@ fn main() {
                 .arg("-o")
                 .arg("LogLevel=ERROR");
 
-            // utun relay: the VM is directly routable at VM_IP4 via the utun interface.
-            cmd.arg(format!("root@{}", pelagos_vz::vm::VM_IP4));
+            // utun relay: the VM is directly routable at its per-profile guest IP.
+            let guest_ip = state::VmProfileConfig::load(&profile)
+                .ok()
+                .and_then(|c| c.vm_ip)
+                .unwrap_or(state::DEFAULT_GUEST_IP);
+            cmd.arg(format!("root@{}", guest_ip));
 
             for arg in &extra {
                 cmd.arg(arg);

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -289,7 +289,6 @@ enum Commands {
     /// Internal: run as the persistent VM daemon. Not for direct use.
     #[command(hide = true)]
     VmDaemonInternal,
-
 }
 
 #[derive(Subcommand, Debug)]
@@ -1520,10 +1519,8 @@ fn main() {
                 process::exit(1);
             }
         }
-
     }
 }
-
 
 fn daemon_args_from_cli(cli: &Cli) -> daemon::DaemonArgs {
     // Load per-profile vm.conf as a fallback layer below CLI flags.
@@ -2204,9 +2201,16 @@ fn discover_vm_artifacts() -> Option<DiscoveredArtifacts> {
         disk_dirs.push(base);
     }
     disk_dirs.extend(kernel_dirs.iter().cloned());
-    let disk = disk_dirs.iter().map(|d| d.join("root.img")).find(|p| p.exists())?;
+    let disk = disk_dirs
+        .iter()
+        .map(|d| d.join("root.img"))
+        .find(|p| p.exists())?;
 
-    Some(DiscoveredArtifacts { kernel, initrd, disk })
+    Some(DiscoveredArtifacts {
+        kernel,
+        initrd,
+        disk,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -3444,8 +3448,8 @@ fn read_winsize() -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        recv_frame, send_frame, Cli, Commands, GuestCommand, GuestMount, GuestResponse,
-        FRAME_EXIT, FRAME_RESIZE, FRAME_STDIN, FRAME_STDOUT,
+        recv_frame, send_frame, Cli, Commands, GuestCommand, GuestMount, GuestResponse, FRAME_EXIT,
+        FRAME_RESIZE, FRAME_STDIN, FRAME_STDOUT,
     };
     use clap::Parser as _;
     use std::io::Cursor;

--- a/pelagos-mac/src/state.rs
+++ b/pelagos-mac/src/state.rs
@@ -3,6 +3,7 @@
 //! ~/.local/share/pelagos/profiles/<name>/ (named profiles).
 
 use std::io;
+use std::net::Ipv4Addr;
 use std::path::PathBuf;
 
 pub struct StateDir {
@@ -57,6 +58,11 @@ pub struct VmProfileConfig {
     /// Override the kernel cmdline. When set, replaces the `--cmdline` default
     /// (`console=hvc0`). The `clock.utc=` token is still appended by the daemon.
     pub cmdline: Option<String>,
+    /// Per-profile guest IPv4 for the VM's virtio-net interface.
+    /// When set, the host-side utun gets `.1` of the same /24, eliminating
+    /// subnet conflicts when multiple profiles run simultaneously.
+    /// Absent → `192.168.105.2` (backward-compatible default).
+    pub vm_ip: Option<Ipv4Addr>,
 }
 
 impl VmProfileConfig {
@@ -97,6 +103,7 @@ impl VmProfileConfig {
                     }
                 }
                 "cmdline" => cfg.cmdline = Some(val.to_string()),
+                "vm_ip" => cfg.vm_ip = val.parse::<Ipv4Addr>().ok(),
                 _ => {}
             }
         }
@@ -243,6 +250,92 @@ pub fn profile_dir(name: &str) -> io::Result<PathBuf> {
     } else {
         Ok(base.join("profiles").join(name))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Per-profile subnet allocation
+// ---------------------------------------------------------------------------
+
+/// Default guest IP for the "default" profile (backward-compatible).
+pub const DEFAULT_GUEST_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 105, 2);
+
+/// Assign (and persist) a per-profile guest IP if one is not already set.
+///
+/// The "default" profile always receives `192.168.105.2`.  Other profiles
+/// receive the lowest available `192.168.N.2` (N ∈ 106–254) not in use by
+/// any existing profile's `vm.conf`.  The chosen IP is written to the
+/// profile's `vm.conf` so subsequent daemon starts are stable.
+///
+/// Returns the guest IP that should be used for this boot.
+pub fn ensure_vm_ip(profile: &str) -> io::Result<Ipv4Addr> {
+    // Fast path: already configured.
+    let conf = VmProfileConfig::load(profile)?;
+    if let Some(ip) = conf.vm_ip {
+        return Ok(ip);
+    }
+
+    // The default profile is always 192.168.105.2 — no allocation needed.
+    if profile == "default" {
+        append_vm_ip_to_conf(profile, DEFAULT_GUEST_IP)?;
+        return Ok(DEFAULT_GUEST_IP);
+    }
+
+    // Collect IPs already in use by all profiles (including default).
+    let base = pelagos_base()?;
+    let mut taken: std::collections::HashSet<u8> = std::collections::HashSet::new();
+
+    // Default profile.
+    if let Ok(c) = VmProfileConfig::load("default") {
+        if let Some(ip) = c.vm_ip {
+            taken.insert(ip.octets()[2]);
+        } else {
+            taken.insert(105);
+        }
+    } else {
+        taken.insert(105);
+    }
+
+    // Named profiles.
+    let profiles_dir = base.join("profiles");
+    if let Ok(entries) = std::fs::read_dir(&profiles_dir) {
+        for entry in entries.flatten() {
+            let entry_name = entry.file_name();
+            let pname = entry_name.to_string_lossy();
+            if pname == profile {
+                continue; // skip ourselves
+            }
+            if let Ok(c) = VmProfileConfig::load(&pname) {
+                if let Some(ip) = c.vm_ip {
+                    taken.insert(ip.octets()[2]);
+                }
+            }
+        }
+    }
+
+    // Pick the lowest unused N in 106–254.
+    let n = (106u8..=254)
+        .find(|n| !taken.contains(n))
+        .ok_or_else(|| io::Error::other("no available VM subnet (all 192.168.106–254 in use)"))?;
+
+    let ip = Ipv4Addr::new(192, 168, n, 2);
+    append_vm_ip_to_conf(profile, ip)?;
+    log::info!("subnet: assigned {} to profile '{}'", ip, profile);
+    Ok(ip)
+}
+
+/// Append `vm_ip = <ip>` to the profile's `vm.conf`, creating the file and
+/// directory if necessary.
+fn append_vm_ip_to_conf(profile: &str, ip: Ipv4Addr) -> io::Result<()> {
+    let dir = profile_dir(profile)?;
+    std::fs::create_dir_all(&dir)?;
+    let conf_path = dir.join("vm.conf");
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&conf_path)?;
+    use std::io::Write;
+    writeln!(f, "vm_ip = {}", ip)?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-pfctl/build.rs
+++ b/pelagos-pfctl/build.rs
@@ -10,14 +10,12 @@ fn main() {
     //   (Keychain Access → Certificate Assistant → Create a Certificate →
     //    Name: "pelagos-mac Dev", Certificate Type: Code Signing).
     // For production: set PELAGOS_CALLER_DR to the Developer ID designated requirement.
-    let caller_dr = env::var("PELAGOS_CALLER_DR").unwrap_or_else(|_| {
-        r#"certificate leaf[subject.CN] = "pelagos-mac Dev""#.to_string()
-    });
+    let caller_dr = env::var("PELAGOS_CALLER_DR")
+        .unwrap_or_else(|_| r#"certificate leaf[subject.CN] = "pelagos-mac Dev""#.to_string());
 
     // Substitute @CALLER_DR@ in the template and write to OUT_DIR.
-    let template =
-        fs::read_to_string(manifest.join("assets/com.pelagos.pfctl.embedded.plist.in"))
-            .expect("pelagos-pfctl/assets/com.pelagos.pfctl.embedded.plist.in not found");
+    let template = fs::read_to_string(manifest.join("assets/com.pelagos.pfctl.embedded.plist.in"))
+        .expect("pelagos-pfctl/assets/com.pelagos.pfctl.embedded.plist.in not found");
     let plist = template.replace("@CALLER_DR@", &caller_dr);
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/pelagos-pfctl/src/main.rs
+++ b/pelagos-pfctl/src/main.rs
@@ -373,7 +373,10 @@ fn handle_teardown_utun(iface: &str, state: &mut DaemonState) -> Response {
     // Remove the P2P IPv4 address by bringing the interface down — on macOS
     // bringing a P2P utun down removes its inet address and associated routes.
     let _ = run_ifconfig(&[iface, "down"]);
-    log::info!("utun relay teardown: iface={iface} (remaining={})", state.active_utun_count);
+    log::info!(
+        "utun relay teardown: iface={iface} (remaining={})",
+        state.active_utun_count
+    );
     ok_resp()
 }
 

--- a/pelagos-pfctl/src/main.rs
+++ b/pelagos-pfctl/src/main.rs
@@ -283,6 +283,21 @@ fn handle_setup_utun(
     }
 
     // 1. Assign IPv4 (point-to-point: local peer)
+    //
+    // macOS utun interfaces are NOT automatically destroyed when their file
+    // descriptors close (unlike Linux tun/tap).  A zombie utun from a crashed
+    // or unclean previous session retains its IPv4 P2P address and keeps a
+    // host route for ipv4_peer pointing at itself.  Delete any lingering host
+    // route for ipv4_peer before assigning; the kernel will add a fresh route
+    // for the new interface when `ifconfig ... up` runs.
+    //
+    // NOTE: we do NOT remove IPv4 addresses from other utun interfaces here
+    // because those may belong to concurrently-running VM relays on different
+    // subnets.  Per-profile subnet allocation guarantees that no two running
+    // VMs share the same ipv4_peer, so only stale/zombie utuns would have a
+    // conflicting route — and deleting the route is sufficient.
+    let _ = run_route(&["delete", "-host", ipv4_peer]);
+
     if let Err(e) = run_ifconfig(&[iface, "inet", ipv4_addr, ipv4_peer, "up"]) {
         return err_resp(format!("ifconfig inet: {e}"));
     }
@@ -345,10 +360,18 @@ fn handle_teardown_utun(iface: &str, state: &mut DaemonState) -> Response {
         state.egress_iface = None;
         state.rdr_rules.clear();
     }
-    // Explicitly remove the IPv6 gateway address so it doesn't linger if the
-    // relay fd is closed without a clean teardown (e.g. daemon crash/restart).
+    // Explicitly remove both IPv4 and IPv6 gateway addresses so they don't
+    // linger on the interface after a crash/restart.  macOS utun interfaces
+    // are NOT automatically destroyed when their relay fd closes; the interface
+    // persists as a zombie and its addresses block the next VM start from
+    // getting the correct routing.  Removing addresses here (even on clean
+    // teardown) prevents the zombie from holding a stale route for the guest IP.
+    //
+    // The peer IPv4 address (ipv4_peer) is not passed into teardown; we instead
+    // remove all inet addresses via "inet delete" which strips any P2P address.
     let _ = run_ifconfig(&[iface, "inet6", "fd00::1", "-alias"]);
-    // Try to bring down the interface (it's destroyed when the relay fd closes anyway).
+    // Remove the P2P IPv4 address by bringing the interface down — on macOS
+    // bringing a P2P utun down removes its inet address and associated routes.
     let _ = run_ifconfig(&[iface, "down"]);
     log::info!("utun relay teardown: iface={iface} (remaining={})", state.active_utun_count);
     ok_resp()
@@ -590,6 +613,18 @@ fn run_sysctl_set(key: &str, val: &str) -> Result<(), String> {
         .args(["-w", &format!("{key}={val}")])
         .output()
         .map_err(|e| format!("exec /usr/sbin/sysctl: {e}"))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).into_owned())
+    }
+}
+
+fn run_route(args: &[&str]) -> Result<(), String> {
+    let out = Command::new("/sbin/route")
+        .args(args)
+        .output()
+        .map_err(|e| format!("exec /sbin/route: {e}"))?;
     if out.status.success() {
         Ok(())
     } else {

--- a/pelagos-vz/src/tun_relay.rs
+++ b/pelagos-vz/src/tun_relay.rs
@@ -14,7 +14,7 @@
 //!   utunN (kernel L3 interface, e.g. utun5)
 //!        │  fd00::1/64 assigned by pelagos-pfctl (ip6.forwarding=1)
 //!        │
-//!  macOS pf  ──  NAT44: 192.168.105.0/24 → egress IP
+//!  macOS pf  ──  NAT44: 192.168.N.0/24 → egress IP   (N = profile subnet)
 //!           ├─  NAT66: fd00::/64 → egress IPv6 (GUA)
 //!           └─  RDR port-forward rules (managed by pelagos-pfctl)
 //!        │
@@ -25,12 +25,16 @@
 //!
 //! ```text
 //! Gateway MAC:      02:00:00:00:00:01   (relay answers ARP/NDP with this)
-//! Gateway IPv4:     192.168.105.1       (host-side utun address)
-//! VM IPv4:          192.168.105.2/24    (configured in guest)
+//! Gateway IPv4:     192.168.N.1         (host-side utun; N chosen per profile)
+//! VM IPv4:          192.168.N.2/24      (configured in guest)
 //! Gateway IPv6 ULA: fd00::1/64          (host-side utun address; pf NAT66 source)
 //! Gateway IPv6 LL:  fe80::1             (relay answers NDP for this)
 //! VM IPv6 ULA:      fd00::2/64          (configured in guest; NAT66 via pf)
 //! ```
+//!
+//! IPv4 addressing is per-profile so multiple VMs can run simultaneously
+//! without routing conflicts.  IPv6 is fixed (fd00::/64) because each VM gets
+//! its own utun interface and the NAT rules are scoped to that interface.
 
 use std::io::{BufRead, BufReader, Write};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
@@ -43,9 +47,35 @@ use serde::Serialize;
 // ---------------------------------------------------------------------------
 
 const GATEWAY_MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
-const GATEWAY_IP4: [u8; 4] = [192, 168, 105, 1];
+// GATEWAY_IP4 is now per-VM (stored in RelayState); IPv6 is fixed across all profiles.
 const GATEWAY_IP6_ULA: [u8; 16] = [0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 const GATEWAY_IP6_LL: [u8; 16] = [0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+
+// ---------------------------------------------------------------------------
+// Per-VM subnet
+// ---------------------------------------------------------------------------
+
+/// IPv4 subnet assigned to one VM profile.
+///
+/// Each profile gets a distinct `/24` from `192.168.105.0/24` – `192.168.254.0/24`
+/// so multiple VMs can run simultaneously without macOS routing conflicts.
+pub struct VmSubnet {
+    /// Host-side gateway IP on the utun interface (e.g. `[192, 168, 105, 1]`).
+    pub host_ip4: [u8; 4],
+    /// Guest IP inside the VM (e.g. `[192, 168, 105, 2]`).
+    pub guest_ip4: [u8; 4],
+    /// CIDR notation for pf NAT44 rule (e.g. `"192.168.105.0/24"`).
+    pub cidr: String,
+}
+
+impl VmSubnet {
+    /// Build a subnet from the guest IP.  Host IP = `X.X.X.1`, CIDR = `X.X.X.0/24`.
+    pub fn from_guest_ip(guest: [u8; 4]) -> Self {
+        let host = [guest[0], guest[1], guest[2], 1];
+        let cidr = format!("{}.{}.{}.0/24", guest[0], guest[1], guest[2]);
+        VmSubnet { host_ip4: host, guest_ip4: guest, cidr }
+    }
+}
 
 // 4-byte tun packet prefix (network byte order AF value).
 const TUN_HDR_IPV4: [u8; 4] = [0, 0, 0, 2]; // AF_INET  = 2
@@ -64,7 +94,7 @@ const PFCTL_SOCK: &str = "/var/run/pelagos-pfctl.sock";
 /// - `avf_fd` is one end of a `socketpair(AF_UNIX, SOCK_DGRAM)` ready to be
 ///   wrapped in `NSFileHandle` and passed to `VZFileHandleNetworkDeviceAttachment`.
 /// - `relay` holds the relay thread and utun fd.  Drop it to initiate shutdown.
-pub fn start() -> Result<(RawFd, TunRelayHandle), crate::Error> {
+pub fn start(subnet: VmSubnet) -> Result<(RawFd, TunRelayHandle), crate::Error> {
     let (avf_fd, relay_fd) = create_socketpair()?;
 
     // 128 KB / 512 KB per AVF documentation.
@@ -82,7 +112,7 @@ pub fn start() -> Result<(RawFd, TunRelayHandle), crate::Error> {
         .ok_or_else(|| crate::Error::Runtime("could not detect default route interface".into()))?;
 
     // Ask pelagos-pfctl to assign IPs to the utun interface and load pf NAT44 rules.
-    pfctl_setup_utun(&utun_iface, &egress)?;
+    pfctl_setup_utun(&utun_iface, &egress, &subnet)?;
 
     log::info!("tun_relay: started utun={utun_iface} egress={egress}");
 
@@ -91,9 +121,10 @@ pub fn start() -> Result<(RawFd, TunRelayHandle), crate::Error> {
     set_nonblocking(utun_fd);
 
     let iface_clone = utun_iface.clone();
+    let gateway_ip4 = subnet.host_ip4;
     let thread = std::thread::Builder::new()
         .name("tun-relay".into())
-        .spawn(move || run_relay(relay_fd, utun_fd, &iface_clone))
+        .spawn(move || run_relay(relay_fd, utun_fd, &iface_clone, gateway_ip4))
         .expect("spawn tun-relay");
 
     Ok((
@@ -269,11 +300,13 @@ fn pfctl_create_utun() -> Result<(OwnedFd, String), crate::Error> {
 struct RelayState {
     /// VM MAC address, learned from the first Ethernet frame received from the VM.
     vm_mac: Option<[u8; 6]>,
+    /// Host-side gateway IPv4 for this VM (per-profile; used in ARP replies).
+    gateway_ip4: [u8; 4],
 }
 
-fn run_relay(relay_fd: RawFd, utun_fd: RawFd, utun_iface: &str) {
+fn run_relay(relay_fd: RawFd, utun_fd: RawFd, utun_iface: &str, gateway_ip4: [u8; 4]) {
     log::info!("tun_relay: relay loop started (relay_fd={relay_fd} utun_fd={utun_fd})");
-    let mut state = RelayState { vm_mac: None };
+    let mut state = RelayState { vm_mac: None, gateway_ip4 };
     let mut avf_buf = vec![0u8; 65536 + 14]; // MTU + Ethernet header
     let mut tun_buf = vec![0u8; 65536 + 4]; // MTU + 4-byte tun prefix
 
@@ -405,7 +438,7 @@ fn handle_arp(frame: &[u8], relay_fd: RawFd, state: &RelayState) {
         return; // only reply to requests
     }
     let target_ip = &frame[38..42];
-    if target_ip != GATEWAY_IP4 {
+    if target_ip != state.gateway_ip4 {
         return; // not asking for our IP
     }
 
@@ -415,7 +448,7 @@ fn handle_arp(frame: &[u8], relay_fd: RawFd, state: &RelayState) {
         .unwrap_or_else(|| frame[22..28].try_into().unwrap_or([0u8; 6]));
     let sender_ip: [u8; 4] = frame[28..32].try_into().unwrap_or([0u8; 4]);
 
-    let reply = build_arp_reply(&vm_mac, &sender_ip);
+    let reply = build_arp_reply(&vm_mac, &sender_ip, &state.gateway_ip4);
     send_to_avf(relay_fd, &reply);
 }
 
@@ -520,8 +553,8 @@ fn send_to_avf(relay_fd: RawFd, frame: &[u8]) {
 // ARP and NDP packet construction
 // ---------------------------------------------------------------------------
 
-/// Build an ARP reply advertising GATEWAY_MAC as the owner of GATEWAY_IP4.
-fn build_arp_reply(vm_mac: &[u8; 6], vm_ip4: &[u8; 4]) -> Vec<u8> {
+/// Build an ARP reply advertising GATEWAY_MAC as the owner of `gateway_ip4`.
+fn build_arp_reply(vm_mac: &[u8; 6], vm_ip4: &[u8; 4], gateway_ip4: &[u8; 4]) -> Vec<u8> {
     let mut f = vec![0u8; 42]; // 14 eth + 28 arp
                                // Ethernet
     f[0..6].copy_from_slice(vm_mac);
@@ -538,7 +571,7 @@ fn build_arp_reply(vm_mac: &[u8; 6], vm_ip4: &[u8; 4]) -> Vec<u8> {
     f[20] = 0x00;
     f[21] = 0x02; // reply
     f[22..28].copy_from_slice(&GATEWAY_MAC);
-    f[28..32].copy_from_slice(&GATEWAY_IP4);
+    f[28..32].copy_from_slice(gateway_ip4);
     f[32..38].copy_from_slice(vm_mac);
     f[38..42].copy_from_slice(vm_ip4);
     f
@@ -661,22 +694,24 @@ fn pfctl_send(json: &str) -> Result<(), crate::Error> {
     }
 }
 
-fn pfctl_setup_utun(iface: &str, egress: &str) -> Result<(), crate::Error> {
+fn pfctl_setup_utun(iface: &str, egress: &str, subnet: &VmSubnet) -> Result<(), crate::Error> {
     #[derive(Serialize)]
     struct Req<'a> {
         action: &'static str,
         iface: &'a str,
-        ipv4_addr: &'static str,
-        ipv4_peer: &'static str,
-        ipv4_cidr: &'static str,
+        ipv4_addr: String,
+        ipv4_peer: String,
+        ipv4_cidr: &'a str,
         egress_iface: &'a str,
     }
+    let host = subnet.host_ip4;
+    let guest = subnet.guest_ip4;
     let json = serde_json::to_string(&Req {
         action: "setup_utun",
         iface,
-        ipv4_addr: "192.168.105.1",
-        ipv4_peer: "192.168.105.2",
-        ipv4_cidr: "192.168.105.0/24",
+        ipv4_addr: format!("{}.{}.{}.{}", host[0], host[1], host[2], host[3]),
+        ipv4_peer: format!("{}.{}.{}.{}", guest[0], guest[1], guest[2], guest[3]),
+        ipv4_cidr: &subnet.cidr,
         egress_iface: egress,
     })
     .map_err(|e| crate::Error::Runtime(e.to_string()))?;

--- a/pelagos-vz/src/tun_relay.rs
+++ b/pelagos-vz/src/tun_relay.rs
@@ -73,7 +73,11 @@ impl VmSubnet {
     pub fn from_guest_ip(guest: [u8; 4]) -> Self {
         let host = [guest[0], guest[1], guest[2], 1];
         let cidr = format!("{}.{}.{}.0/24", guest[0], guest[1], guest[2]);
-        VmSubnet { host_ip4: host, guest_ip4: guest, cidr }
+        VmSubnet {
+            host_ip4: host,
+            guest_ip4: guest,
+            cidr,
+        }
     }
 }
 
@@ -306,7 +310,10 @@ struct RelayState {
 
 fn run_relay(relay_fd: RawFd, utun_fd: RawFd, utun_iface: &str, gateway_ip4: [u8; 4]) {
     log::info!("tun_relay: relay loop started (relay_fd={relay_fd} utun_fd={utun_fd})");
-    let mut state = RelayState { vm_mac: None, gateway_ip4 };
+    let mut state = RelayState {
+        vm_mac: None,
+        gateway_ip4,
+    };
     let mut avf_buf = vec![0u8; 65536 + 14]; // MTU + Ethernet header
     let mut tun_buf = vec![0u8; 65536 + 4]; // MTU + 4-byte tun prefix
 

--- a/pelagos-vz/src/vm.rs
+++ b/pelagos-vz/src/vm.rs
@@ -310,7 +310,12 @@ impl Vm {
     ///
     /// Connections to `127.0.0.1:host_port` (and the egress interface) are
     /// kernel-redirected to the guest IP of this VM at `vm_port`.
-    pub fn add_port_forward(&self, proto: &str, host_port: u16, vm_port: u16) -> Result<(), crate::Error> {
+    pub fn add_port_forward(
+        &self,
+        proto: &str,
+        host_port: u16,
+        vm_port: u16,
+    ) -> Result<(), crate::Error> {
         let ip = self.guest_ip;
         let ip_str = format!("{}.{}.{}.{}", ip[0], ip[1], ip[2], ip[3]);
         self._relay.add_rdr(proto, host_port, &ip_str, vm_port)

--- a/pelagos-vz/src/vm.rs
+++ b/pelagos-vz/src/vm.rs
@@ -54,6 +54,9 @@ pub struct VmConfig {
     pub virtiofs_shares: Vec<(PathBuf, String, bool)>,
     /// Enable Rosetta for x86_64 Linux binaries (macOS 13+).
     pub rosetta: bool,
+    /// Guest IPv4 address assigned to the VM's virtio-net interface.
+    /// Defaults to `192.168.105.2`; override via `vm_ip` in `vm.conf`.
+    pub guest_ip: [u8; 4],
 }
 
 impl VmConfig {
@@ -74,6 +77,7 @@ pub struct VmConfigBuilder {
     vsock_port: Option<u32>,
     virtiofs_shares: Vec<(PathBuf, String, bool)>,
     rosetta: bool,
+    guest_ip: Option<[u8; 4]>,
 }
 
 impl VmConfigBuilder {
@@ -123,6 +127,10 @@ impl VmConfigBuilder {
         self.rosetta = enabled;
         self
     }
+    pub fn guest_ip(mut self, ip: [u8; 4]) -> Self {
+        self.guest_ip = Some(ip);
+        self
+    }
     pub fn build(self) -> Result<VmConfig, &'static str> {
         Ok(VmConfig {
             kernel: self.kernel.ok_or("kernel required")?,
@@ -137,6 +145,7 @@ impl VmConfigBuilder {
             vsock_port: self.vsock_port.unwrap_or(1024),
             virtiofs_shares: self.virtiofs_shares,
             rosetta: self.rosetta,
+            guest_ip: self.guest_ip.unwrap_or(DEFAULT_GUEST_IP4),
         })
     }
 }
@@ -171,9 +180,9 @@ unsafe impl Sync for SendQueue {}
 // Vm
 // ---------------------------------------------------------------------------
 
-/// Static IPv4 address of the VM inside the relay network.
-/// Both relay implementations configure the guest with this address.
-pub const VM_IP4: &str = "192.168.105.2";
+/// Default guest IPv4 (used when no per-profile subnet is configured).
+/// Profiles with an explicit `vm_ip` in `vm.conf` use a different address.
+pub const DEFAULT_GUEST_IP4: [u8; 4] = [192, 168, 105, 2];
 
 /// A running Linux VM. Holds all AVF resources.
 pub struct Vm {
@@ -183,6 +192,8 @@ pub struct Vm {
     config: VmConfig,
     /// Keeps the utun relay alive for the VM's lifetime (Drop tears it down).
     _relay: crate::tun_relay::TunRelayHandle,
+    /// Guest IPv4, stored separately so port-forward rules use the right address.
+    guest_ip: [u8; 4],
 }
 
 #[derive(Debug)]
@@ -298,9 +309,11 @@ impl Vm {
     /// Add a TCP host→VM port forward via pf RDR rule (pelagos-pfctl).
     ///
     /// Connections to `127.0.0.1:host_port` (and the egress interface) are
-    /// kernel-redirected to `VM_IP4:vm_port`.
+    /// kernel-redirected to the guest IP of this VM at `vm_port`.
     pub fn add_port_forward(&self, proto: &str, host_port: u16, vm_port: u16) -> Result<(), crate::Error> {
-        self._relay.add_rdr(proto, host_port, VM_IP4, vm_port)
+        let ip = self.guest_ip;
+        let ip_str = format!("{}.{}.{}.{}", ip[0], ip[1], ip[2], ip[3]);
+        self._relay.add_rdr(proto, host_port, &ip_str, vm_port)
     }
 
     /// Remove a previously added port forward.
@@ -432,7 +445,8 @@ unsafe fn start_vm(config: VmConfig) -> Result<(Vm, std::os::unix::io::OwnedFd),
 
     // 5. Network relay via VZFileHandleNetworkDeviceAttachment.
     //    Returns a SOCK_DGRAM fd that AVF consumes directly as raw Ethernet frames.
-    let (vmnet_fd, relay) = crate::tun_relay::start()
+    let subnet = crate::tun_relay::VmSubnet::from_guest_ip(config.guest_ip);
+    let (vmnet_fd, relay) = crate::tun_relay::start(subnet)
         .map_err(|e| crate::Error::Runtime(format!("tun_relay: {e}")))?;
     let vmnet_fh = NSFileHandle::initWithFileDescriptor(NSFileHandle::alloc(), vmnet_fd);
     let net_attach = VZFileHandleNetworkDeviceAttachment::initWithFileHandle(
@@ -599,6 +613,7 @@ unsafe fn start_vm(config: VmConfig) -> Result<(Vm, std::os::unix::io::OwnedFd),
 
     let queue_arc = Arc::new(SendQueue(queue));
 
+    let guest_ip = config.guest_ip;
     Ok((
         Vm {
             vm: vm_arc,
@@ -606,6 +621,7 @@ unsafe fn start_vm(config: VmConfig) -> Result<(Vm, std::os::unix::io::OwnedFd),
             queue: queue_arc,
             config,
             _relay: relay,
+            guest_ip,
         },
         relay_console_fd,
     ))

--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -663,6 +663,7 @@ initrd    = $UBUNTU_INITRD
 memory    = $MEMORY_MIB
 cpus      = $CPUS
 ping_mode = ssh
+vm_ip     = 192.168.106.2
 # net.ifnames=0: prevent udev from renaming eth0 → enp0sN.
 # Without this, udev brings eth0 down to rename it, dropping the IP configured
 # by the initramfs before switch_root, leaving smoltcp unable to ARP the VM.

--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -288,8 +288,8 @@ cat > "\$MNT/etc/systemd/network/10-eth.network" << 'NETCFG'
 Name=en* eth*
 
 [Network]
-Address=192.168.105.2/24
-Gateway=192.168.105.1
+Address=192.168.106.2/24
+Gateway=192.168.106.1
 DNS=8.8.8.8
 DNS=1.1.1.1
 # Keep any IP pre-configured by the initramfs so the relay can reach the

--- a/scripts/vm-restart.sh
+++ b/scripts/vm-restart.sh
@@ -29,13 +29,11 @@ else
     STATE_DIR="$PELAGOS_BASE/profiles/$PROFILE"
 fi
 
-# Kill ALL running pelagos daemons, not just this profile's.
-# All profiles share the same socket_vmnet NAT IP (192.168.105.2); only one
-# VM can hold that address at a time. If a different profile's daemon is still
-# running when we start, it wins the IP and the new VM becomes unreachable.
+# Kill only this profile's running daemon before restart.
+# Each profile has its own vm_ip subnet so multiple profiles can run
+# simultaneously; only stop the one we're about to restart.
 for pid_file in \
-    "$PELAGOS_BASE/vm.pid" \
-    "$PELAGOS_BASE"/profiles/*/vm.pid; do
+    "$STATE_DIR/vm.pid"; do
     [[ -f "$pid_file" ]] || continue
     pid="$(cat "$pid_file")"
     if kill -0 "$pid" 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Each VM profile is assigned a unique `192.168.N.0/24` subnet, eliminating macOS routing conflicts when multiple VMs run simultaneously
- The default profile keeps `192.168.105.2`; the build profile gets `192.168.106.2`; new profiles auto-allocate from `192.168.107+`
- `vm ssh` now connects to the correct VM regardless of how many profiles are running

## Root cause

macOS silently skips adding a second route when a route for the same prefix already exists. When the first VM stopped and removed its route, the second VM's route was gone too — it became permanently unreachable until manually re-added.

## Changes

| Component | Change |
|---|---|
| `pelagos-vz/tun_relay` | Remove hardcoded `GATEWAY_IP4`; add `VmSubnet` struct; parameterize all subnet-dependent functions |
| `pelagos-vz/vm` | Add `VmConfig.guest_ip` field; `Vm` tracks `guest_ip` for port-forward target resolution |
| `pelagos-mac/state` | Add `VmProfileConfig.vm_ip`; `ensure_vm_ip()` auto-allocation; parse `vm_ip` from `vm.conf` |
| `pelagos-mac/daemon` | Call `ensure_vm_ip()` in `ensure_running()`; pass `guest_ip` to `VmConfig` builder |
| `pelagos-mac/main` | `vm ssh` reads `vm_ip` from profile config instead of hardcoded constant |
| `scripts/build-build-image.sh` | Write `vm_ip = 192.168.106.2` into generated `vm.conf` |
| `scripts/vm-restart.sh` | Remove stale "kill all daemons" workaround (no longer needed) |

## Test results

Both VMs running simultaneously:
```
192.168.105.2  utun10  ← default Alpine VM   ping ✓  pelagos ping → pong ✓  vm ssh ✓
192.168.106.2  utun9   ← build Ubuntu VM     ping ✓                         vm ssh → ubuntu-build ✓
```

Stopping default VM → build VM remains fully reachable at 192.168.106.2 ✓ (the original bug, now fixed)

Restarting default VM → both VMs reachable simultaneously ✓

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)