### PR TITLE
feat(ipv6): NDP proxy Phase 1 — VM gets working IPv6 via SLAAC

### DIFF
--- a/docs/IPV6_NETWORKING.md
+++ b/docs/IPV6_NETWORKING.md
@@ -1,0 +1,179 @@
+# IPv6 Networking in pelagos-mac
+
+*Implemented in v0.6.15 (PRs #250-era). Covers SLAAC, NDP proxy, routing, and the
+host-side machinery that gives the VM a real Global Unicast Address (GUA).*
+
+---
+
+## Overview
+
+The VM gets a real GUA — the same /64 prefix as the macOS host — via SLAAC.  No NAT
+occurs for IPv6; packets flow with the VM's address as source and destination, fully
+visible to the upstream router.  This requires active cooperation from the host:
+
+1. **RA synthesis** — the relay synthesises a Router Advertisement so the VM learns
+   the /64 prefix and default router without needing one from the actual router.
+2. **NDP proxy (Phase 1)** — when the VM's GUA is assigned, the pfctl helper seeds
+   the upstream router's NDP cache and adds a kernel host route so inbound replies
+   reach the VM.
+3. **NDP proxy (Phase 2, pending #250)** — a BPF listener on en0 that responds to
+   ongoing NS probes from the router, keeping the cache valid after expiry.
+
+---
+
+## Packet Path
+
+### Outbound (VM → internet)
+
+```
+VM eth0  →  relay (avf socket)  →  utun10  →  macOS routing table
+                                                    │  default via en0
+                                                    ▼
+                                               en0 → upstream router → internet
+```
+
+- The relay receives raw Ethernet frames from the AVF socket, strips the 14-byte
+  Ethernet header, prepends a 4-byte utun AF header (`AF_INET6 = 30`), and writes
+  to the utun fd.
+- The macOS kernel sees an incoming IPv6 packet on utun10 and routes it via the
+  default route (en0).  `net.inet6.ip6.forwarding = 1` must be set (it is by
+  default on most systems).
+- Source address is the VM's GUA — no NAT.
+
+### Inbound (internet → VM)
+
+```
+internet → upstream router → en0 (host)
+                                  │  kernel sees dst=vm_gua, looks up route
+                                  │  host route: vm_gua → utun10  (added by pfctl)
+                                  ▼
+                             utun10  →  relay (reads from utun fd)
+                                  │  prepend Ethernet header (dst=vm_mac, src=GATEWAY_MAC)
+                                  ▼
+                             relay (avf socket) → VM eth0
+```
+
+- The pfctl helper adds a `/128` host route for the VM's GUA pointing at utun10
+  when `AssignUtunAlias` is called.
+- Inbound packets addressed to vm_gua arrive at en0, and the kernel's routing table
+  directs them to utun10.
+- The relay reads from utun_fd, wraps in an Ethernet frame with `dst = vm_mac` and
+  `src = GATEWAY_MAC (02:00:00:00:00:01)`, and delivers to the VM.
+
+---
+
+## SLAAC — how the VM gets its GUA
+
+The relay detects the host's GUA /64 prefix on the egress interface at startup using
+`ifconfig` output.  When the VM sends a Router Solicitation (ICMPv6 type 133), the
+relay synthesises a Router Advertisement containing:
+
+- **Prefix Information option**: the real host /64 prefix, `A=1` (SLAAC), `L=1`
+  (on-link), lifetime 30 days.
+- **Router Lifetime**: 1800 s (so the VM installs a default route via `fe80::1`).
+- **Source**: `fe80::1` (the relay's virtual link-local address on the virtual Ethernet).
+
+The VM does SLAAC: it forms its EUI-64 IID from its MAC, appends it to the prefix,
+runs DAD, and assigns the GUA to `eth0`.
+
+The relay detects SLAAC completion by waiting for the first non-DAD IPv6 packet
+sourced from the GUA (DAD NS uses `::` as source).  At that point it calls
+`pfctl_assign_utun_alias` to set up the host route and NDP seed.
+
+---
+
+## NDP proxy — why it is needed
+
+The upstream router knows the host's en0 MAC (`aa:bb:cc:...`).  It does NOT know
+the VM's GUA.  When the router wants to deliver a packet to `vm_gua`, it first sends
+a Neighbour Solicitation (NS) to the solicited-node multicast address for `vm_gua`.
+Nobody on the physical LAN answers — the VM is behind the utun tunnel, not on en0.
+The router marks `vm_gua` as `(incomplete)` and drops the packet.
+
+The host must act as an NDP proxy: answer NS for `vm_gua` with an NA that names
+`en0_mac` as the link-layer address.  The router then caches `vm_gua → en0_mac` and
+can deliver replies.
+
+### Phase 1 — seeding at alias time (implemented)
+
+When `pfctl_assign_utun_alias` is called with the VM's GUA:
+
+1. **Gratuitous NA** — an unsolicited Neighbour Advertisement (ICMPv6 type 136) is
+   broadcast to `ff02::1` (all-nodes multicast) on en0, advertising
+   `vm_gua → en0_mac`.  Most routers accept gratuitous NAs and update their cache.
+
+2. **Unicast probe NS** — a Neighbour Solicitation (type 135) is sent as a unicast
+   Ethernet frame directly to the router's MAC address (looked up from the host NDP
+   table), sourced from vm_gua with SLLA=en0_mac.  This causes the router to send an
+   NA back to the host, simultaneously seeding its own cache with `vm_gua → en0_mac`.
+   **Unicast is critical**: sending to the solicited-node multicast address would also
+   hit our own en0 NIC, causing the host's NDP stack to create a conflicting `/128
+   UHLWI` entry for vm_gua on en0 that overrides the utun10 host route.
+
+Both frames are injected via BPF (`/dev/bpfN` with `BIOCSETIF`).
+
+### Phase 2 — ongoing proxy (pending, issue #250)
+
+Router NDP caches expire (typically every 20–30 s after the router re-probes).  After
+the first expiry the router sends a new NS; if nobody answers, `vm_gua` goes
+incomplete again and inbound traffic stops.
+
+Phase 2 adds a BPF listener on en0 that watches for ICMPv6 NS (type 135) targeting
+vm_gua and immediately responds with an NA.  This keeps the router's cache valid
+indefinitely.  Until Phase 2 lands, reachability degrades after ~30 s of idle.
+
+---
+
+## Virtual gateway addresses
+
+The relay presents itself to the VM as a virtual gateway with the following fixed
+addresses, all answered by NDP synthesised in the relay:
+
+| Address | Scope | Purpose |
+|---|---|---|
+| `02:00:00:00:00:01` | Ethernet MAC | GATEWAY_MAC — used for all gateway Ethernet frames |
+| `fe80::1` | Link-local | Default router advertised in RA; VM routes GUA traffic here |
+| `fd00::1/128` | ULA | Infrastructure anchor on utun10; VM static config may use this as default gateway |
+
+`fd00::1/128` exists solely to give utun10 an IPv6 address so the macOS kernel
+accepts `route add -inet6 -host <gua> -interface utunN` (rejected with ENETUNREACH
+otherwise).  The relay intercepts NDP NS for `fd00::1` and responds with GATEWAY_MAC
+— the kernel routes `fd00::1` via `lo0`, so without relay interception the VM's NS
+goes unanswered.
+
+---
+
+## Host-side setup sequence
+
+```
+relay start
+  └── detect_host_gua_prefix(en0)          → gua_prefix stored in RelayState
+  └── pfctl_setup_utun(utun10, en0, subnet)
+        └── ifconfig utun10 inet 192.168.N.1 192.168.N.2 up
+        └── ifconfig utun10 inet6 fd00::1 prefixlen 128 alias   ← IPv6 anchor
+        └── pfctl NAT44 rule: nat on en0 from 192.168.N.0/24
+
+VM sends Router Solicitation
+  └── relay intercepts RS, sends synthesised RA (prefix=gua_prefix)
+  └── VM does SLAAC → assigns vm_gua to eth0, DAD, then usable
+
+VM sends first real GUA-sourced packet
+  └── maybe_assign_gua_alias fires
+  └── pfctl_assign_utun_alias(utun10, vm_gua)
+        └── route add -inet6 -host vm_gua -interface utun10
+        └── BPF: send gratuitous NA (vm_gua → en0_mac) to ff02::1
+        └── BPF: send unicast probe NS (src=vm_gua, dst=router) to router_mac
+
+Inbound IPv6 reply arrives at en0
+  └── kernel route: vm_gua → utun10  →  relay reads, wraps in Ethernet → VM
+```
+
+---
+
+## Known limitations
+
+| Limitation | Issue | Notes |
+|---|---|---|
+| NDP cache expiry breaks inbound after ~30 s idle | #250 Phase 2 | BPF listener needed |
+| Prefix mobility (host roams to new network) | #248 | Re-issue RA when GUA prefix changes |
+| IPv6 assignment inside container network namespaces | #244 | Post-SLAAC work |

--- a/pelagos-pfctl/src/main.rs
+++ b/pelagos-pfctl/src/main.rs
@@ -14,7 +14,9 @@
 //!     → assigns IPv4 P2P address, enables ip4/ip6 forwarding, loads NAT44 pf anchor.
 //!   {"action":"assign_utun_alias","iface":"utun5","addr":"2601:x:y:z::a1b2"}
 //!     → aliases a GUA to the utun so the kernel delivers inbound IPv6 to the VM.
-//!       Called by the relay after observing the VM's SLAAC DAD Neighbour Solicitation.
+//!       Called by the relay after observing the VM's SLAAC DAD completion.
+//!       Also sends an unsolicited Neighbour Advertisement on the egress interface
+//!       (e.g. en0) to populate the upstream router's NDP cache immediately.
 //!   {"action":"teardown_utun","iface":"utun5"}
 //!   {"action":"add_rdr","proto":"tcp","host_port":2222,
 //!    "vm_ip":"192.168.105.2","vm_port":22}
@@ -316,6 +318,15 @@ fn handle_setup_utun(
         return err_resp(format!("ifconfig inet: {e}"));
     }
 
+    // Add an IPv6 anchor address (fd00::1/128) so the kernel accepts host
+    // routes via this interface.  macOS silently rejects `route add -inet6
+    // -host ... -interface <iface>` with ENETUNREACH when the interface has
+    // no IPv6 address at all.  A /128 creates only a local (lo0) host route
+    // for fd00::1 — no /64 prefix, no NDP entries on en0.
+    // The VM's guest daemon configures fd00::2/64 on its side; fd00::1/128
+    // here is the matching host anchor.
+    let _ = run_ifconfig(&[iface, "inet6", "fd00::1", "prefixlen", "128", "alias"]);
+
     // 2. Enable kernel IPv4 forwarding for NAT44 (utun → egress).
     //    IPv6 forwarding is also needed so packets from utun can be routed to
     //    the egress interface (VM → internet without NAT).
@@ -363,12 +374,14 @@ fn handle_teardown_utun(iface: &str, state: &mut DaemonState) -> Response {
     // Remove any GUA aliases assigned to this utun via assign_utun_alias.
     state.ipv6_aliases.retain(|(alias_iface, addr)| {
         if alias_iface == iface {
-            let _ = run_ifconfig(&[iface, "inet6", addr.as_str(), "-alias"]);
+            let _ = run_route(&["delete", "-inet6", "-host", addr.as_str()]);
             false // remove from list
         } else {
             true
         }
     });
+    // Remove the IPv6 anchor address added at setup time.
+    let _ = run_ifconfig(&[iface, "inet6", "fd00::1", "-alias"]);
     // Bring the interface down to clear the P2P IPv4 address and associated routes.
     // macOS utun interfaces persist after their fd closes; bringing them down
     // prevents the zombie from holding a stale route for the guest IP.
@@ -384,16 +397,73 @@ fn handle_assign_utun_alias(iface: &str, addr: &str, state: &mut DaemonState) ->
     if !is_safe_iface(iface) {
         return err_resp("invalid interface name");
     }
-    if addr.parse::<std::net::Ipv6Addr>().is_err() {
-        return err_resp(format!("invalid IPv6 address: {addr:?}"));
+    let gua: std::net::Ipv6Addr = match addr.parse() {
+        Ok(a) => a,
+        Err(_) => return err_resp(format!("invalid IPv6 address: {addr:?}")),
+    };
+    // Add a host route for vm_gua via the utun interface instead of an ifconfig
+    // alias.  An ifconfig inet6 alias on a P2P tunnel always creates a /64
+    // neighbor entry regardless of the prefixlen argument; the kernel then tries
+    // NDP resolution into the tunnel, gets nothing, stays INCOMPLETE, and drops
+    // inbound packets.  A direct host route bypasses NDP entirely.
+    if let Err(e) = run_route(&["add", "-inet6", "-host", addr, "-interface", iface]) {
+        return err_resp(format!("route add -inet6 -host: {e}"));
     }
-    if let Err(e) = run_ifconfig(&[iface, "inet6", addr, "alias"]) {
-        return err_resp(format!("ifconfig inet6 alias: {e}"));
-    }
-    log::info!("assigned IPv6 alias {addr} to {iface}");
+    log::info!("added host route {addr} → {iface}");
     state
         .ipv6_aliases
         .push((iface.to_string(), addr.to_string()));
+
+    // Send an unsolicited Neighbour Advertisement on the egress interface to
+    // populate the upstream router's NDP cache.  This resolves "who has
+    // <vm_gua>?" before the router ever asks — or, if the router already has
+    // an INCOMPLETE entry (it tried and failed), the NA with O=1 will update
+    // that entry to REACHABLE immediately.
+    if let Some(egress) = &state.egress_iface {
+        let egress = egress.clone();
+        match get_iface_mac(&egress) {
+            Ok(mac) => match open_bpf(&egress) {
+                Ok(bpf_fd) => {
+                    let gua_bytes = gua.octets();
+                    match send_gratuitous_na(bpf_fd, mac, gua_bytes) {
+                        Ok(()) => log::info!("sent gratuitous NA for {addr} on {egress}"),
+                        Err(e) => log::warn!("gratuitous NA send failed: {e}"),
+                    }
+                    // Send a unicast probe NS from vm_gua to the upstream router so
+                    // the router creates a cache entry for vm_gua → en0_mac.
+                    // The NS is sent with Ethernet dst = router_mac (unicast), so our
+                    // own en0 NIC discards the frame — preventing the host's NDP stack
+                    // from creating a spurious en0 entry that would override the utun10
+                    // host route.
+                    match detect_ipv6_gateway(&egress) {
+                        Some(router) => match get_ndp_mac(router) {
+                            Some(router_mac) => {
+                                match send_ndp_probe_ns(bpf_fd, mac, router_mac, gua_bytes, router)
+                                {
+                                    Ok(()) => log::info!(
+                                        "sent unicast NDP probe NS for {addr} on {egress}"
+                                    ),
+                                    Err(e) => log::warn!("NDP probe NS failed: {e}"),
+                                }
+                            }
+                            None => log::warn!(
+                                "router MAC not in NDP table yet, skipping NS probe"
+                            ),
+                        },
+                        None => {
+                            log::warn!("no IPv6 default gateway on {egress}, skipping NS probe")
+                        }
+                    }
+                    unsafe { libc::close(bpf_fd) };
+                }
+                Err(e) => log::warn!("open_bpf({egress}): {e}"),
+            },
+            Err(e) => log::warn!("get_iface_mac({egress}): {e}"),
+        }
+    } else {
+        log::warn!("assign_utun_alias: no egress_iface in state, skipping gratuitous NA");
+    }
+
     ok_resp()
 }
 
@@ -603,6 +673,292 @@ fn handle_create_utun_with_fd(stream: &std::os::unix::net::UnixStream) {
 }
 
 // ---------------------------------------------------------------------------
+// NDP proxy helpers — gratuitous NA via BPF raw injection
+// ---------------------------------------------------------------------------
+
+// BIOCSETIF = _IOW('B', 108, struct ifreq) on macOS.
+// sizeof(struct ifreq) on arm64 macOS = ifr_name[16] + union sockaddr(16) = 32.
+const BIOCSETIF: libc::c_ulong = 0x8020_426c;
+
+/// Minimal ifreq layout: only ifr_name is read by BIOCSETIF.
+#[repr(C)]
+struct Ifreq {
+    ifr_name: [libc::c_char; 16],
+    _ifr_union: [u8; 16],
+}
+
+/// Read the Ethernet MAC address of `iface` from `ifconfig` output.
+fn get_iface_mac(iface: &str) -> Result<[u8; 6], String> {
+    let out = Command::new("/sbin/ifconfig")
+        .arg(iface)
+        .output()
+        .map_err(|e| format!("ifconfig {iface}: {e}"))?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    for line in s.lines() {
+        if let Some(rest) = line.trim().strip_prefix("ether ") {
+            let mac_str = rest.split_whitespace().next().unwrap_or("");
+            let parts: Vec<u8> = mac_str
+                .split(':')
+                .filter_map(|x| u8::from_str_radix(x, 16).ok())
+                .collect();
+            if parts.len() == 6 {
+                return Ok([parts[0], parts[1], parts[2], parts[3], parts[4], parts[5]]);
+            }
+        }
+    }
+    Err(format!("no MAC address found for {iface}"))
+}
+
+/// Open the first available `/dev/bpfN` device and attach it to `iface`.
+/// Returns the raw fd; caller must close it.
+fn open_bpf(iface: &str) -> Result<i32, String> {
+    for i in 0..10u32 {
+        let path = CString::new(format!("/dev/bpf{i}")).unwrap();
+        let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDWR) };
+        if fd < 0 {
+            continue; // device busy or past the end
+        }
+        let mut ifr: Ifreq = unsafe { std::mem::zeroed() };
+        let name_bytes = iface.as_bytes();
+        let copy_len = name_bytes.len().min(15);
+        for (dst, &src) in ifr.ifr_name[..copy_len].iter_mut().zip(name_bytes) {
+            *dst = src as libc::c_char;
+        }
+        let r = unsafe { libc::ioctl(fd, BIOCSETIF, &ifr) };
+        if r < 0 {
+            let e = std::io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(format!("BIOCSETIF /dev/bpf{i} {iface}: {e}"));
+        }
+        return Ok(fd);
+    }
+    Err(format!("no available /dev/bpf device for {iface}"))
+}
+
+/// Compute ICMPv6 checksum over the IPv6 pseudo-header and `payload`
+/// (with the checksum field zeroed).  Per RFC 4443 §2.3.
+fn icmpv6_checksum(src: &[u8; 16], dst: &[u8; 16], payload: &[u8]) -> u16 {
+    // Pseudo-header: src(16) + dst(16) + upper-layer length(4) + zeros(3) + next-header(1)
+    let ulen = payload.len() as u32;
+    let pseudo = {
+        let mut p = [0u8; 40];
+        p[0..16].copy_from_slice(src);
+        p[16..32].copy_from_slice(dst);
+        p[32..36].copy_from_slice(&ulen.to_be_bytes());
+        // p[36..39] = 0 (zeroed)
+        p[39] = 58; // next-header = ICMPv6
+        p
+    };
+
+    let mut sum: u32 = 0;
+    let mut add = |bytes: &[u8]| {
+        let mut i = 0;
+        while i + 1 < bytes.len() {
+            sum += u16::from_be_bytes([bytes[i], bytes[i + 1]]) as u32;
+            i += 2;
+        }
+        if i < bytes.len() {
+            sum += (bytes[i] as u32) << 8;
+        }
+    };
+    add(&pseudo);
+    add(payload);
+    while sum >> 16 != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+/// Parse the default IPv6 gateway for `egress` from `netstat -rn -f inet6`.
+///
+/// Returns the gateway address (link-local or global) as raw bytes, without
+/// any zone-id suffix.  Returns None if no default route is found.
+fn detect_ipv6_gateway(egress: &str) -> Option<[u8; 16]> {
+    let out = Command::new("/usr/sbin/netstat")
+        .args(["-rn", "-f", "inet6"])
+        .output()
+        .ok()?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    for line in s.lines() {
+        // e.g. "default  fe80::1afd:74ff:fec2:614f%en0  UGcg  en0"
+        // Use `else { continue }` — `?` inside a loop exits the whole function.
+        let mut fields = line.split_whitespace();
+        let Some(dest) = fields.next() else { continue };
+        let Some(gw_raw) = fields.next() else { continue };
+        let Some(_flags) = fields.next() else { continue };
+        let Some(iface) = fields.next() else { continue };
+        if dest == "default" && iface == egress {
+            let gw_str = gw_raw.split('%').next().unwrap_or(gw_raw);
+            if let Ok(ip6) = gw_str.parse::<std::net::Ipv6Addr>() {
+                return Some(ip6.octets());
+            }
+        }
+    }
+    None
+}
+
+/// Look up the link-layer address of `addr` in the local NDP table (`ndp -an`).
+/// Returns None if the entry is absent or unresolved (INCOMPLETE).
+fn get_ndp_mac(addr: [u8; 16]) -> Option<[u8; 6]> {
+    let target = std::net::Ipv6Addr::from(addr).to_string();
+    let out = Command::new("/usr/sbin/ndp")
+        .args(["-an"])
+        .output()
+        .ok()?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    for line in s.lines() {
+        let mut fields = line.split_whitespace();
+        let Some(entry_raw) = fields.next() else {
+            continue;
+        };
+        // Strip zone ID (e.g. "%en0") before comparing.
+        let entry_addr = entry_raw.split('%').next().unwrap_or(entry_raw);
+        if entry_addr != target {
+            continue;
+        }
+        let Some(mac_str) = fields.next() else {
+            continue;
+        };
+        // Skip unresolved entries (shown as "(incomplete)" etc.)
+        if !mac_str.contains(':') {
+            continue;
+        }
+        let parts: Vec<&str> = mac_str.split(':').collect();
+        if parts.len() != 6 {
+            continue;
+        }
+        let mut mac = [0u8; 6];
+        for (i, p) in parts.iter().enumerate() {
+            mac[i] = u8::from_str_radix(p, 16).ok()?;
+        }
+        return Some(mac);
+    }
+    None
+}
+
+/// Inject a **unicast** Neighbour Solicitation from `vm_gua` (SLLA=`en0_mac`)
+/// targeting `router` via `bpf_fd`, with Ethernet dst = `router_mac`.
+///
+/// Sending unicast (Ethernet dst = router_mac, not a multicast address) means
+/// the frame is delivered only to the router.  Our own en0 NIC discards it
+/// because dst_mac ≠ en0_mac — so the host's NDP stack never processes the
+/// frame and never creates a spurious cache entry for vm_gua on en0.
+///
+/// The router, per RFC 4861 §7.2.3, creates a Neighbor Cache entry for
+/// `vm_gua → en0_mac` (STALE) on receipt, enabling it to deliver return
+/// packets to vm_gua without an additional NS/NA round-trip.
+///
+/// Frame: Ethernet (unicast) → IPv6 → ICMPv6 NS (type 135)
+///   eth dst: router_mac  (unicast — host NIC will not pass this up the stack)
+///   eth src: en0_mac
+///   ip6 src: vm_gua
+///   ip6 dst: router (unicast)
+///   target:  router
+///   option:  SLLA (type 1) = en0_mac
+fn send_ndp_probe_ns(
+    bpf_fd: i32,
+    en0_mac: [u8; 6],
+    router_mac: [u8; 6],
+    vm_gua: [u8; 16],
+    router: [u8; 16],
+) -> Result<(), String> {
+    // ICMPv6 NS payload (32 bytes):
+    //   type(1) code(1) checksum(2) reserved(4) target(16) SLLA-option(8)
+    let mut icmp = [0u8; 32];
+    icmp[0] = 135; // NS
+                   // [1] code = 0, [2..4] checksum, [4..8] reserved = 0
+    icmp[8..24].copy_from_slice(&router); // target
+    icmp[24] = 1; // option type: Source Link-Layer Address
+    icmp[25] = 1; // length in units of 8 bytes
+    icmp[26..32].copy_from_slice(&en0_mac);
+    // Checksum pseudo-header uses the unicast router address as dst.
+    let csum = icmpv6_checksum(&vm_gua, &router, &icmp);
+    icmp[2..4].copy_from_slice(&csum.to_be_bytes());
+
+    let mut frame = [0u8; 86];
+    frame[0..6].copy_from_slice(&router_mac); // Ethernet dst: unicast to router
+    frame[6..12].copy_from_slice(&en0_mac);
+    frame[12..14].copy_from_slice(&[0x86, 0xdd]);
+    frame[14] = 0x60; // IPv6
+    frame[18..20].copy_from_slice(&32u16.to_be_bytes()); // payload length
+    frame[20] = 58;   // ICMPv6
+    frame[21] = 255;  // hop limit
+    frame[22..38].copy_from_slice(&vm_gua);  // src
+    frame[38..54].copy_from_slice(&router);  // dst: unicast router address
+    frame[54..86].copy_from_slice(&icmp);
+
+    let r = unsafe { libc::write(bpf_fd, frame.as_ptr() as *const libc::c_void, frame.len()) };
+    if r < 0 {
+        Err(format!(
+            "BPF write NS: {}",
+            std::io::Error::last_os_error()
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Build and inject an unsolicited Neighbour Advertisement for `vm_gua` onto
+/// the link via `bpf_fd`.  Advertises `en0_mac` as the link-layer address so
+/// the upstream router updates its NDP cache (INCOMPLETE → REACHABLE) without
+/// waiting for a probe/reply cycle.
+///
+/// Frame: Ethernet → IPv6 → ICMPv6 NA (type 136)
+///   dst:    ff02::1 / 33:33:00:00:00:01  (all-nodes multicast)
+///   src:    vm_gua  / en0_mac
+///   flags:  O=1 (override — forces cache update for existing entries)
+///   target: vm_gua
+///   option: TLLA (type 2) = en0_mac
+fn send_gratuitous_na(bpf_fd: i32, en0_mac: [u8; 6], vm_gua: [u8; 16]) -> Result<(), String> {
+    const ALL_NODES_MAC: [u8; 6] = [0x33, 0x33, 0x00, 0x00, 0x00, 0x01];
+    const ALL_NODES_IP6: [u8; 16] = [
+        0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
+    ];
+
+    // ICMPv6 NA payload (32 bytes):
+    //   type(1) code(1) checksum(2) flags(4) target(16) TLLA-option(8)
+    let mut icmp = [0u8; 32];
+    icmp[0] = 136; // NA
+    icmp[1] = 0;   // code
+    // [2..4] checksum — filled below
+    icmp[4] = 0x20; // R=0 S=0 O=1 → byte 4 of the flags word = 0b0010_0000
+    icmp[8..24].copy_from_slice(&vm_gua);
+    icmp[24] = 2; // option type: Target Link-Layer Address
+    icmp[25] = 1; // option length in units of 8 bytes
+    icmp[26..32].copy_from_slice(&en0_mac);
+
+    let csum = icmpv6_checksum(&vm_gua, &ALL_NODES_IP6, &icmp);
+    icmp[2..4].copy_from_slice(&csum.to_be_bytes());
+
+    // Full Ethernet + IPv6 + ICMPv6 frame = 14 + 40 + 32 = 86 bytes.
+    let mut frame = [0u8; 86];
+    // Ethernet header
+    frame[0..6].copy_from_slice(&ALL_NODES_MAC);
+    frame[6..12].copy_from_slice(&en0_mac);
+    frame[12..14].copy_from_slice(&[0x86, 0xdd]); // ethertype IPv6
+    // IPv6 header (offset 14)
+    frame[14] = 0x60; // version=6, TC=0, FL=0
+    // [15..18] = 0 (TC/FL continued)
+    frame[18..20].copy_from_slice(&32u16.to_be_bytes()); // payload length
+    frame[20] = 58;  // next-header = ICMPv6
+    frame[21] = 255; // hop limit
+    frame[22..38].copy_from_slice(&vm_gua);       // src
+    frame[38..54].copy_from_slice(&ALL_NODES_IP6); // dst ff02::1
+    // ICMPv6 payload (offset 54)
+    frame[54..86].copy_from_slice(&icmp);
+
+    let r = unsafe { libc::write(bpf_fd, frame.as_ptr() as *const libc::c_void, frame.len()) };
+    if r < 0 {
+        Err(format!(
+            "BPF write: {}",
+            std::io::Error::last_os_error()
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // System command helpers
 // ---------------------------------------------------------------------------
 
@@ -645,11 +1001,17 @@ fn run_route(args: &[&str]) -> Result<(), String> {
         .args(args)
         .output()
         .map_err(|e| format!("exec /sbin/route: {e}"))?;
-    if out.status.success() {
-        Ok(())
-    } else {
-        Err(String::from_utf8_lossy(&out.stderr).into_owned())
+    // macOS `route` often exits 0 even when the kernel rejects the route,
+    // printing the error to stderr instead.  Treat any stderr output as failure.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if !out.status.success() || !stderr.trim().is_empty() {
+        return Err(format!(
+            "{}{}",
+            stderr,
+            String::from_utf8_lossy(&out.stdout)
+        ));
     }
+    Ok(())
 }
 
 fn run_ifconfig(args: &[&str]) -> Result<(), String> {

--- a/pelagos-vz/src/tun_relay.rs
+++ b/pelagos-vz/src/tun_relay.rs
@@ -62,6 +62,10 @@ const GATEWAY_MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
 // GATEWAY_IP4 is per-VM (stored in RelayState).
 // GATEWAY_IP6_LL is the link-local gateway address advertised in the RA and answered by NDP.
 const GATEWAY_IP6_LL: [u8; 16] = [0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+// GATEWAY_IP6_ULA is the ULA anchor address (fd00::1/128) added to the utun interface so the
+// kernel accepts host routes via it.  The VM static network config uses fd00::1 as the default
+// IPv6 gateway, so we must answer NDP NS for it here (the kernel routes it via lo0, not utun).
+const GATEWAY_IP6_ULA: [u8; 16] = [0xfd, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 // Ethernet multicast destination for IPv6 all-nodes (ff02::1).
 const ALL_NODES_MAC: [u8; 6] = [0x33, 0x33, 0x00, 0x00, 0x00, 0x01];
 const ALL_NODES_IP6: [u8; 16] = [0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
@@ -523,9 +527,10 @@ fn handle_ndp_ns(frame: &[u8], relay_fd: RawFd, state: &RelayState) -> bool {
         Err(_) => return false,
     };
 
-    // Only respond for our link-local gateway address (fe80::1).
-    // The VM's default route (from the RA) is via fe80::1, so it will NS for it.
-    if target != GATEWAY_IP6_LL {
+    // Respond for fe80::1 (RA-advertised default router) and fd00::1 (ULA anchor / static
+    // default gateway in the VM network config).  The kernel routes fd00::1 via lo0, so NDP
+    // NS for it would never get a reply unless we synthesise the NA here.
+    if target != GATEWAY_IP6_LL && target != GATEWAY_IP6_ULA {
         return false;
     }
 

--- a/scripts/update-pfctl-daemon.sh
+++ b/scripts/update-pfctl-daemon.sh
@@ -1,20 +1,34 @@
 #!/usr/bin/env bash
 # update-pfctl-daemon.sh — install the locally built pelagos-pfctl daemon and restart it.
+#
+# The daemon plist runs /Library/PrivilegedHelperTools/com.pelagos.pfctl.
+# sign.sh places the correctly-signed binary at:
+#   target/aarch64-apple-darwin/release/Contents/Library/LaunchServices/com.pelagos.pfctl
+# which is what this script installs.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 RELEASE="$REPO/target/aarch64-apple-darwin/release"
+SRC="$RELEASE/Contents/Library/LaunchServices/com.pelagos.pfctl"
+DST="/Library/PrivilegedHelperTools/com.pelagos.pfctl"
+
+if [ ! -f "$SRC" ]; then
+    echo "ERROR: signed binary not found at $SRC"
+    echo "       Run 'cargo build --release -p pelagos-pfctl && bash scripts/sign.sh' first."
+    exit 1
+fi
 
 echo "==> installing pelagos-pfctl..."
-sudo cp "$RELEASE/pelagos-pfctl" /usr/local/lib/pelagos/pelagos-pfctl
-sudo chown root:wheel /usr/local/lib/pelagos/pelagos-pfctl
-sudo chmod 755 /usr/local/lib/pelagos/pelagos-pfctl
+sudo cp "$SRC" "$DST"
+sudo chown root:wheel "$DST"
+sudo chmod 755 "$DST"
 sudo launchctl kickstart -k system/com.pelagos.pfctl
 sleep 1
 
 if [ -S /var/run/pelagos-pfctl.sock ]; then
     echo "    daemon OK (socket present)"
 else
-    echo "ERROR: socket not present after restart — check /var/log/pelagos-pfctl.log"
+    echo "ERROR: socket not present after restart — check logs via:"
+    echo "       sudo log show --predicate 'process == \"com.pelagos.pfctl\"' --last 1m"
     exit 1
 fi


### PR DESCRIPTION
Closes #250 Phase 1 (Phase 2 BPF listener tracked in same issue).

## What this does

Gives the VM a working Global Unicast Address via SLAAC and makes `ping6` to external IPv6 addresses work end-to-end.

## Root causes fixed

**`fd00::1` NDP NS went unanswered** — The ULA anchor address (`fd00::1/128`) on utun10 is routed by macOS via `lo0`. When the VM sent NS for its static default gateway (`fd00::1`), the kernel's NA response went out `lo0` instead of utun10, so the relay never delivered it. VM marked `fd00::1 FAILED` and dropped all outbound IPv6. Fix: relay intercepts NS for `fd00::1` in `handle_ndp_ns` (same as `fe80::1`).

**`route add -inet6 -host` silently failed** — `/sbin/route` exits 0 on ENETUNREACH but writes the error to stderr. `run_route` only checked exit status. utun10 had no IPv6 address, so the kernel rejected the route. Fix: `run_route` treats stderr output as failure; `handle_setup_utun` now adds `fd00::1/128` to utun10 first.

**Unicast NDP probe NS — multicast poisoned host route** — Probe NS to the solicited-node multicast also reached our own en0 NIC, causing the host NDP stack to create a `/128 UHLWI` entry for `vm_gua` on en0 that overrode the utun10 host route. Fix: NS sent as unicast Ethernet directly to `router_mac`.

**`update-pfctl-daemon.sh` wrong install path** — Was installing to `/usr/local/lib/pelagos/`; LaunchDaemon runs from `/Library/PrivilegedHelperTools/`. Fixed.

## Changes

- `pelagos-vz/src/tun_relay.rs`: intercept NS for `fd00::1` (`GATEWAY_IP6_ULA`); add `fd00::1/128` anchor at utun setup
- `pelagos-pfctl/src/main.rs`: `run_route` checks stderr; `handle_assign_utun_alias` uses `/128` host route; gratuitous NA + unicast probe NS on alias; `get_ndp_mac` helper
- `scripts/update-pfctl-daemon.sh`: correct install path
- `docs/IPV6_NETWORKING.md`: full architecture documentation

## Verified

```
$ pelagos vm ssh -- ping6 -c 3 2606:4700:4700::1111
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 21.344/38.855/72.114 ms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)