### PR TITLE
fix(ssh): suppress Broken pipe noise by disabling mux inheritance

### DIFF
--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -835,7 +835,13 @@ fn main() {
                 .arg("-o")
                 .arg("UserKnownHostsFile=/dev/null")
                 .arg("-o")
-                .arg("LogLevel=ERROR");
+                .arg("LogLevel=ERROR")
+                .arg("-o")
+                // Disable mux multiplexing entirely so user-level ~/.ssh/config
+                // ControlMaster settings don't cause "Broken pipe" noise on first
+                // connection.  Option B (pelagos-managed ControlPersist socket for
+                // faster repeated connections) is tracked in issue #252.
+                .arg("ControlMaster=no");
 
             // utun relay: the VM is directly routable at its per-profile guest IP.
             let guest_ip = state::VmProfileConfig::load(&profile)
@@ -3007,6 +3013,8 @@ fn ping_ssh(cli: &Cli) -> i32 {
             .arg("UserKnownHostsFile=/dev/null")
             .arg("-o")
             .arg("LogLevel=ERROR")
+            .arg("-o")
+            .arg("ControlMaster=no")
             .arg("-o")
             .arg("ConnectTimeout=30")
             .arg("-o")


### PR DESCRIPTION
Related to #252 (Option A — leaves issue open for Option B).

## Problem

`pelagos vm ssh` inherits the user's `~/.ssh/config`. A common global setting is `ControlMaster auto`; when no mux master exists the handshake fails with `Broken pipe` on stderr before falling back to a direct connection.

## Fix

Add `-o ControlMaster=no` to both `ssh` invocations (`vm ssh` and `ping_ssh`). Opts out of any user mux config, giving clean predictable behaviour.

## Verified

```
$ pelagos vm ssh -- uname 2>&1 | cat
Linux
```
No `Broken pipe`.

## Future work (issue #252 Option B)

Add `-o ControlMaster=auto -o ControlPath=~/.local/share/pelagos/... -o ControlPersist=60` so pelagos manages its own mux socket independently of the user's config. Faster repeated connections; useful when devcontainer tooling calls `pelagos vm ssh` in a tight loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)