### PR TITLE
fix(port-forward): userspace TCP proxy + fix macOS network_isolation blocking host<->VM

### DIFF
--- a/pelagos-docker/src/main.rs
+++ b/pelagos-docker/src/main.rs
@@ -1743,6 +1743,17 @@ fn cmd_build(
     target: Option<&str>,
     context: &str,
 ) -> i32 {
+    // When the Dockerfile path is relative (e.g. the default "Dockerfile"),
+    // resolve it against the build context directory so `docker build ctx/`
+    // finds ctx/Dockerfile rather than looking in the current working directory.
+    let abs_file_buf;
+    let file = if std::path::Path::new(file).is_relative() {
+        abs_file_buf = format!("{}/{}", context, file);
+        abs_file_buf.as_str()
+    } else {
+        file
+    };
+
     // Preprocess: substitute --build-arg values into FROM lines so pelagos
     // receives fully-resolved image/stage references.
     let resolved = preprocess_dockerfile_args(file, build_args);

--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -27,23 +27,120 @@ use pelagos_vz::vm::{Vm, VmConfig};
 use crate::state::StateDir;
 
 // ---------------------------------------------------------------------------
-// PortRouter — port-forward abstraction over Arc<Vm>
+// PortProxy — userspace TCP port-forward listener
 // ---------------------------------------------------------------------------
+//
+// macOS pf RDR rules do not intercept locally-generated loopback packets
+// (the kernel RSTs them before pf's translation hook fires).  A userspace
+// TcpListener bound on 0.0.0.0:host_port is reliable for both localhost and
+// external callers, and requires no root privileges.
 
-/// Routes port-forward add/remove to the utun relay (pf RDR rules via pelagos-pfctl).
+struct PortProxy {
+    shutdown: Arc<AtomicBool>,
+    host_port: u16,
+}
+
+impl PortProxy {
+    fn start(host_port: u16, guest_ip: [u8; 4], container_port: u16) -> Self {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = Arc::clone(&shutdown);
+        std::thread::Builder::new()
+            .name(format!("port-proxy-{host_port}"))
+            .spawn(move || port_proxy_loop(host_port, guest_ip, container_port, shutdown_clone))
+            .expect("spawn port-proxy");
+        PortProxy {
+            shutdown,
+            host_port,
+        }
+    }
+}
+
+impl Drop for PortProxy {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        // Wake the accept() call so the loop can observe the flag.
+        let _ = std::net::TcpStream::connect(("127.0.0.1", self.host_port));
+    }
+}
+
+fn port_proxy_loop(
+    host_port: u16,
+    guest_ip: [u8; 4],
+    container_port: u16,
+    shutdown: Arc<AtomicBool>,
+) {
+    let listener = match std::net::TcpListener::bind(("0.0.0.0", host_port)) {
+        Ok(l) => l,
+        Err(e) => {
+            log::error!("port-proxy: bind 0.0.0.0:{host_port}: {e}");
+            return;
+        }
+    };
+    log::info!(
+        "port-proxy: 0.0.0.0:{host_port} -> {}.{}.{}.{}:{container_port}",
+        guest_ip[0],
+        guest_ip[1],
+        guest_ip[2],
+        guest_ip[3]
+    );
+    for stream in listener.incoming() {
+        if shutdown.load(Ordering::Relaxed) {
+            break;
+        }
+        match stream {
+            Ok(client) => {
+                std::thread::spawn(move || relay_tcp(client, guest_ip, container_port));
+            }
+            Err(e) => {
+                if !shutdown.load(Ordering::Relaxed) {
+                    log::warn!("port-proxy: accept: {e}");
+                }
+            }
+        }
+    }
+    log::info!("port-proxy: 0.0.0.0:{host_port} stopped");
+}
+
+fn relay_tcp(client: std::net::TcpStream, guest_ip: [u8; 4], container_port: u16) {
+    let peer = std::net::SocketAddr::from((guest_ip, container_port));
+    let server = match std::net::TcpStream::connect(peer) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("port-proxy: connect to {peer}: {e}");
+            return;
+        }
+    };
+    let client_r = match client.try_clone() {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("port-proxy: clone client: {e}");
+            return;
+        }
+    };
+    let server_r = match server.try_clone() {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("port-proxy: clone server: {e}");
+            return;
+        }
+    };
+    let t = std::thread::spawn(move || {
+        let _ = io::copy(&mut &client_r, &mut &server);
+    });
+    let _ = io::copy(&mut &server_r, &mut &client);
+    let _ = t.join();
+}
+
+/// Routes port-forward add/remove to the userspace TCP proxy.
 struct PortRouter(Arc<Vm>);
 
 impl PortRouter {
-    fn add(&self, host_port: u16, container_port: u16) {
-        if let Err(e) = self.0.add_port_forward("tcp", host_port, container_port) {
-            log::warn!("add_rdr :{host_port}→:{container_port}: {e}");
-        }
+    fn add(&self, host_port: u16, container_port: u16) -> PortProxy {
+        PortProxy::start(host_port, self.0.guest_ip(), container_port)
     }
 
-    fn remove(&self, host_port: u16) {
-        if let Err(e) = self.0.remove_port_forward("tcp", host_port) {
-            log::warn!("remove_rdr :{host_port}: {e}");
-        }
+    fn remove(&self, _host_port: u16) {
+        // Removal is handled by dropping the PortProxy from PortState.
     }
 }
 
@@ -124,13 +221,15 @@ pub enum DaemonResponse {
     Err { message: String },
 }
 
-/// Live port-forward state shared between connection handler threads and (in a
-/// future PR) the subscription watcher thread.
+/// Live port-forward state shared between connection handler threads.
 struct PortState {
     /// Maps host_port → container_port for every currently active forward.
     active: HashMap<u16, u16>,
     /// Maps compose project name → list of host ports it registered.
     compose_projects: HashMap<String, Vec<u16>>,
+    /// Live userspace TCP proxy handles keyed by host_port.
+    /// Dropping a handle stops the proxy listener.
+    proxies: HashMap<u16, PortProxy>,
 }
 
 impl PortState {
@@ -138,6 +237,7 @@ impl PortState {
         Self {
             active: HashMap::new(),
             compose_projects: HashMap::new(),
+            proxies: HashMap::new(),
         }
     }
 }
@@ -324,7 +424,8 @@ pub fn run(args: DaemonArgs) -> ! {
     {
         let mut ps = port_state.lock().unwrap();
         for pf in &args.port_forwards {
-            router.add(pf.host_port, pf.container_port);
+            let proxy = router.add(pf.host_port, pf.container_port);
+            ps.proxies.insert(pf.host_port, proxy);
             ps.active.insert(pf.host_port, pf.container_port);
         }
     }
@@ -563,17 +664,30 @@ fn handle_daemon_cmd(
             container_port,
         } => {
             let mut ps = port_state.lock().unwrap();
-            if let std::collections::hash_map::Entry::Vacant(e) = ps.active.entry(host_port) {
-                router.add(host_port, container_port);
-                e.insert(container_port);
+            if !ps.active.contains_key(&host_port) {
+                let proxy = router.add(host_port, container_port);
+                ps.proxies.insert(host_port, proxy);
+                ps.active.insert(host_port, container_port);
                 log::info!(
                     "[{conn_id:?}] registered port {}:{}",
                     host_port,
                     container_port
                 );
                 DaemonResponse::Ok
+            } else if ps.active[&host_port] == container_port {
+                // Idempotent: same mapping already registered (pre-registered at daemon
+                // startup via --port and now requested again by the run command).
+                log::debug!(
+                    "[{conn_id:?}] port {} already registered with same mapping — ok",
+                    host_port
+                );
+                DaemonResponse::Ok
             } else {
-                let msg = format!("port {} is already registered", host_port);
+                let existing = ps.active[&host_port];
+                let msg = format!(
+                    "port {} is already registered to container port {}",
+                    host_port, existing
+                );
                 log::warn!("[{conn_id:?}] register port: {}", msg);
                 DaemonResponse::Err { message: msg }
             }
@@ -581,7 +695,7 @@ fn handle_daemon_cmd(
         DaemonCmd::UnregisterPort { host_port } => {
             let mut ps = port_state.lock().unwrap();
             if ps.active.remove(&host_port).is_some() {
-                router.remove(host_port);
+                ps.proxies.remove(&host_port); // Drop PortProxy → shuts down listener
                 log::info!("[{conn_id:?}] unregistered port {}", host_port);
             }
             DaemonResponse::Ok

--- a/pelagos-pfctl/src/main.rs
+++ b/pelagos-pfctl/src/main.rs
@@ -40,10 +40,6 @@ const SOCK_PATH: &str = "/var/run/pelagos-pfctl.sock";
 const ANCHOR_NAT: &str = "com.apple/pelagos-nat";
 const ANCHOR_FILE_NAT: &str = "/etc/pf.anchors/pelagos-nat";
 
-// RDR anchor used by the utun relay for port forwarding.
-const ANCHOR_RDR: &str = "com.apple/pelagos-rdr";
-const ANCHOR_FILE_RDR: &str = "/etc/pf.anchors/pelagos-rdr";
-
 // ---------------------------------------------------------------------------
 // macOS utun constants and C structs (used by create_utun_privileged)
 // ---------------------------------------------------------------------------
@@ -83,7 +79,9 @@ struct DaemonState {
     utun_iface: Option<String>,
     /// Egress interface used by the active utun setup — needed for RDR rules.
     egress_iface: Option<String>,
-    /// Active port-forward rules, rebuilt into the RDR anchor on every change.
+    /// VM subnet CIDR (e.g. "192.168.105.0/24") for the NAT and pass rules.
+    ipv4_cidr: Option<String>,
+    /// Active port-forward rules, rebuilt into the combined anchor on every change.
     rdr_rules: Vec<RdrRule>,
     /// Number of utun relays currently set up. IP forwarding is only disabled
     /// when this reaches zero, preventing a racing teardown from killing a live relay.
@@ -106,6 +104,7 @@ impl DaemonState {
         Self {
             utun_iface: None,
             egress_iface: None,
+            ipv4_cidr: None,
             rdr_rules: Vec::new(),
             active_utun_count: 0,
             ipv6_aliases: Vec::new(),
@@ -338,20 +337,39 @@ fn handle_setup_utun(
     }
 
     // 3. Write and load NAT44 anchor (IPv4 only; no NAT66 — VM has real GUA via SLAAC).
-    let nat_rules =
-        format!("nat on {egress_iface} inet from {ipv4_cidr} to any -> ({egress_iface})\n");
-    if let Err(e) = std::fs::write(ANCHOR_FILE_NAT, &nat_rules) {
-        return err_resp(format!("write {ANCHOR_FILE_NAT}: {e}"));
-    }
-    let _ = Command::new("/sbin/pfctl").arg("-e").output();
-    if let Err(e) = run_pfctl(&["-a", ANCHOR_NAT, "-f", ANCHOR_FILE_NAT]) {
-        return err_resp(format!("pfctl nat anchor: {e}"));
-    }
+    //
+    // The anchor file includes a `pass quick` filter rule for the VM subnet
+    // so that macOS Internet Sharing's network_isolation anchor (which uses
+    // `block drop quick` for subnets it manages) cannot silently drop
+    // host-to-VM traffic.  The `com.apple/*` anchor (which contains this
+    // anchor) is evaluated before `com.apple.internet-sharing` in the main
+    // ruleset, so `pass quick` here wins.
+    //
+    // We also remove the VM subnet from the network_isolation_table_v4 table
+    // (best-effort: the table may not exist or may not contain this subnet).
+    // The `pass quick` rule above is the durable fix; the table removal
+    // prevents the block from re-appearing on the same pf pass.
+    let _ = run_pfctl(&[
+        "-a",
+        "com.apple.internet-sharing/network_isolation",
+        "-t",
+        "network_isolation_table_v4",
+        "-T",
+        "delete",
+        ipv4_cidr,
+    ]);
 
-    log::info!("utun relay setup: iface={iface} egress={egress_iface}");
     state.utun_iface = Some(iface.to_string());
     state.egress_iface = Some(egress_iface.to_string());
+    state.ipv4_cidr = Some(ipv4_cidr.to_string());
     state.active_utun_count += 1;
+
+    let _ = Command::new("/sbin/pfctl").arg("-e").output();
+    let resp = reload_nat_anchor(state);
+    if !resp.ok {
+        return resp;
+    }
+    log::info!("utun relay setup: iface={iface} egress={egress_iface}");
     ok_resp()
 }
 
@@ -361,14 +379,14 @@ fn handle_teardown_utun(iface: &str, state: &mut DaemonState) -> Response {
     let last_relay = state.active_utun_count == 0;
 
     if last_relay {
-        // Flush NAT and RDR anchors — ignore errors (anchor may not be active).
+        // Flush the combined NAT/RDR/filter anchor — ignore errors (may not be active).
         let _ = run_pfctl(&["-a", ANCHOR_NAT, "-F", "all"]);
-        let _ = run_pfctl(&["-a", ANCHOR_RDR, "-F", "all"]);
         // Disable IP forwarding only when no utun relays remain.
         let _ = run_sysctl_set("net.inet.ip.forwarding", "0");
         let _ = run_sysctl_set("net.inet6.ip6.forwarding", "0");
         state.utun_iface = None;
         state.egress_iface = None;
+        state.ipv4_cidr = None;
         state.rdr_rules.clear();
     }
     // Remove any GUA aliases assigned to this utun via assign_utun_alias.
@@ -446,9 +464,9 @@ fn handle_assign_utun_alias(iface: &str, addr: &str, state: &mut DaemonState) ->
                                     Err(e) => log::warn!("NDP probe NS failed: {e}"),
                                 }
                             }
-                            None => log::warn!(
-                                "router MAC not in NDP table yet, skipping NS probe"
-                            ),
+                            None => {
+                                log::warn!("router MAC not in NDP table yet, skipping NS probe")
+                            }
                         },
                         None => {
                             log::warn!("no IPv6 default gateway on {egress}, skipping NS probe")
@@ -487,25 +505,39 @@ fn handle_add_rdr(
         vm_ip: vm_ip.to_string(),
         vm_port,
     });
-    reload_rdr_anchor(state)
+    reload_nat_anchor(state)
 }
 
 fn handle_remove_rdr(proto: &str, host_port: u16, state: &mut DaemonState) -> Response {
     state
         .rdr_rules
         .retain(|r| !(r.proto == proto && r.host_port == host_port));
-    reload_rdr_anchor(state)
+    reload_nat_anchor(state)
 }
 
-fn reload_rdr_anchor(state: &DaemonState) -> Response {
-    if state.rdr_rules.is_empty() {
-        let _ = run_pfctl(&["-a", ANCHOR_RDR, "-F", "all"]);
-        return ok_resp();
+/// Rebuild and reload the combined pelagos-nat anchor.
+///
+/// pf requires rules in section order: translation (nat, rdr) then filtering (pass/block).
+/// All pelagos rules live in a single `com.apple/pelagos-nat` anchor so that the
+/// `nat-anchor "com.apple/*"`, `rdr-anchor "com.apple/*"`, and `anchor "com.apple/*"`
+/// wildcards in the main ruleset all traverse the same anchor file.  Using separate
+/// `pelagos-nat` and `pelagos-rdr` sub-anchors does NOT work because pf's wildcard
+/// expansion only finds sub-anchors that are explicitly referenced from their parent —
+/// loading rules directly into `com.apple/pelagos-rdr` via pfctl does not register it
+/// under the `com.apple` anchor for wildcard traversal.
+fn reload_nat_anchor(state: &DaemonState) -> Response {
+    let mut rules = String::new();
+
+    // Translation section: NAT (IPv4 masquerade) — only when egress is known.
+    if let (Some(egress), Some(cidr)) = (&state.egress_iface, &state.ipv4_cidr) {
+        rules.push_str(&format!(
+            "nat on {egress} inet from {cidr} to any -> ({egress})\n"
+        ));
     }
 
-    let mut rules = String::new();
+    // Translation section: RDR port-forward rules.
     for r in &state.rdr_rules {
-        // Redirect on loopback for local connections (e.g. `pelagos vm ssh`).
+        // Redirect on loopback so localhost connections reach the VM.
         rules.push_str(&format!(
             "rdr pass on lo0 proto {proto} from any to 127.0.0.1 port {hp} -> {vm_ip} port {vp}\n",
             proto = r.proto,
@@ -513,7 +545,7 @@ fn reload_rdr_anchor(state: &DaemonState) -> Response {
             vm_ip = r.vm_ip,
             vp = r.vm_port,
         ));
-        // Also redirect on the egress interface for external connections.
+        // Also redirect on the egress interface for external inbound connections.
         if let Some(egress) = &state.egress_iface {
             rules.push_str(&format!(
                 "rdr pass on {egress} proto {proto} from any to any port {hp} -> {vm_ip} port {vp}\n",
@@ -525,11 +557,22 @@ fn reload_rdr_anchor(state: &DaemonState) -> Response {
         }
     }
 
-    if let Err(e) = std::fs::write(ANCHOR_FILE_RDR, &rules) {
-        return err_resp(format!("write {ANCHOR_FILE_RDR}: {e}"));
+    // Filter section: allow host<->VM traffic before the internet-sharing
+    // network_isolation anchor can block it.
+    if let Some(cidr) = &state.ipv4_cidr {
+        rules.push_str(&format!("pass quick inet from {cidr} to {cidr}\n"));
     }
-    if let Err(e) = run_pfctl(&["-a", ANCHOR_RDR, "-f", ANCHOR_FILE_RDR]) {
-        return err_resp(format!("pfctl rdr anchor: {e}"));
+
+    if rules.is_empty() {
+        let _ = run_pfctl(&["-a", ANCHOR_NAT, "-F", "all"]);
+        return ok_resp();
+    }
+
+    if let Err(e) = std::fs::write(ANCHOR_FILE_NAT, &rules) {
+        return err_resp(format!("write {ANCHOR_FILE_NAT}: {e}"));
+    }
+    if let Err(e) = run_pfctl(&["-a", ANCHOR_NAT, "-f", ANCHOR_FILE_NAT]) {
+        return err_resp(format!("pfctl nat anchor: {e}"));
     }
     ok_resp()
 }
@@ -784,8 +827,12 @@ fn detect_ipv6_gateway(egress: &str) -> Option<[u8; 16]> {
         // Use `else { continue }` — `?` inside a loop exits the whole function.
         let mut fields = line.split_whitespace();
         let Some(dest) = fields.next() else { continue };
-        let Some(gw_raw) = fields.next() else { continue };
-        let Some(_flags) = fields.next() else { continue };
+        let Some(gw_raw) = fields.next() else {
+            continue;
+        };
+        let Some(_flags) = fields.next() else {
+            continue;
+        };
         let Some(iface) = fields.next() else { continue };
         if dest == "default" && iface == egress {
             let gw_str = gw_raw.split('%').next().unwrap_or(gw_raw);
@@ -801,10 +848,7 @@ fn detect_ipv6_gateway(egress: &str) -> Option<[u8; 16]> {
 /// Returns None if the entry is absent or unresolved (INCOMPLETE).
 fn get_ndp_mac(addr: [u8; 16]) -> Option<[u8; 6]> {
     let target = std::net::Ipv6Addr::from(addr).to_string();
-    let out = Command::new("/usr/sbin/ndp")
-        .args(["-an"])
-        .output()
-        .ok()?;
+    let out = Command::new("/usr/sbin/ndp").args(["-an"]).output().ok()?;
     let s = String::from_utf8_lossy(&out.stdout);
     for line in s.lines() {
         let mut fields = line.split_whitespace();
@@ -881,18 +925,15 @@ fn send_ndp_probe_ns(
     frame[12..14].copy_from_slice(&[0x86, 0xdd]);
     frame[14] = 0x60; // IPv6
     frame[18..20].copy_from_slice(&32u16.to_be_bytes()); // payload length
-    frame[20] = 58;   // ICMPv6
-    frame[21] = 255;  // hop limit
-    frame[22..38].copy_from_slice(&vm_gua);  // src
-    frame[38..54].copy_from_slice(&router);  // dst: unicast router address
+    frame[20] = 58; // ICMPv6
+    frame[21] = 255; // hop limit
+    frame[22..38].copy_from_slice(&vm_gua); // src
+    frame[38..54].copy_from_slice(&router); // dst: unicast router address
     frame[54..86].copy_from_slice(&icmp);
 
     let r = unsafe { libc::write(bpf_fd, frame.as_ptr() as *const libc::c_void, frame.len()) };
     if r < 0 {
-        Err(format!(
-            "BPF write NS: {}",
-            std::io::Error::last_os_error()
-        ))
+        Err(format!("BPF write NS: {}", std::io::Error::last_os_error()))
     } else {
         Ok(())
     }
@@ -911,16 +952,14 @@ fn send_ndp_probe_ns(
 ///   option: TLLA (type 2) = en0_mac
 fn send_gratuitous_na(bpf_fd: i32, en0_mac: [u8; 6], vm_gua: [u8; 16]) -> Result<(), String> {
     const ALL_NODES_MAC: [u8; 6] = [0x33, 0x33, 0x00, 0x00, 0x00, 0x01];
-    const ALL_NODES_IP6: [u8; 16] = [
-        0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
-    ];
+    const ALL_NODES_IP6: [u8; 16] = [0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01];
 
     // ICMPv6 NA payload (32 bytes):
     //   type(1) code(1) checksum(2) flags(4) target(16) TLLA-option(8)
     let mut icmp = [0u8; 32];
     icmp[0] = 136; // NA
-    icmp[1] = 0;   // code
-    // [2..4] checksum — filled below
+    icmp[1] = 0; // code
+                 // [2..4] checksum — filled below
     icmp[4] = 0x20; // R=0 S=0 O=1 → byte 4 of the flags word = 0b0010_0000
     icmp[8..24].copy_from_slice(&vm_gua);
     icmp[24] = 2; // option type: Target Link-Layer Address
@@ -936,23 +975,20 @@ fn send_gratuitous_na(bpf_fd: i32, en0_mac: [u8; 6], vm_gua: [u8; 16]) -> Result
     frame[0..6].copy_from_slice(&ALL_NODES_MAC);
     frame[6..12].copy_from_slice(&en0_mac);
     frame[12..14].copy_from_slice(&[0x86, 0xdd]); // ethertype IPv6
-    // IPv6 header (offset 14)
+                                                  // IPv6 header (offset 14)
     frame[14] = 0x60; // version=6, TC=0, FL=0
-    // [15..18] = 0 (TC/FL continued)
+                      // [15..18] = 0 (TC/FL continued)
     frame[18..20].copy_from_slice(&32u16.to_be_bytes()); // payload length
-    frame[20] = 58;  // next-header = ICMPv6
+    frame[20] = 58; // next-header = ICMPv6
     frame[21] = 255; // hop limit
-    frame[22..38].copy_from_slice(&vm_gua);       // src
+    frame[22..38].copy_from_slice(&vm_gua); // src
     frame[38..54].copy_from_slice(&ALL_NODES_IP6); // dst ff02::1
-    // ICMPv6 payload (offset 54)
+                                                   // ICMPv6 payload (offset 54)
     frame[54..86].copy_from_slice(&icmp);
 
     let r = unsafe { libc::write(bpf_fd, frame.as_ptr() as *const libc::c_void, frame.len()) };
     if r < 0 {
-        Err(format!(
-            "BPF write: {}",
-            std::io::Error::last_os_error()
-        ))
+        Err(format!("BPF write: {}", std::io::Error::last_os_error()))
     } else {
         Ok(())
     }

--- a/pelagos-vz/src/vm.rs
+++ b/pelagos-vz/src/vm.rs
@@ -330,6 +330,10 @@ impl Vm {
         &self.config
     }
 
+    pub fn guest_ip(&self) -> [u8; 4] {
+        self.guest_ip
+    }
+
     /// Request a clean shutdown (ACPI power-off) and wait until the VM
     /// reaches the Stopped state.
     ///

--- a/scripts/test-devcontainer-e2e.sh
+++ b/scripts/test-devcontainer-e2e.sh
@@ -556,7 +556,7 @@ if suite_active E; then
 
     # TC-T2-14: exec works in restarted container
     if [ -n "$E_CONT" ]; then
-        E_EXEC=$(pelagos exec-into "$E_CONT" uname -s 2>&1 | tr -d '\r\n')
+        E_EXEC=$(pelagos exec "$E_CONT" uname -s 2>&1 | tr -d '\r\n')
         if [ "$E_EXEC" = "Linux" ]; then
             pass "TC-T2-14: exec works in restarted container: uname -s = Linux"
         else

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -11,12 +11,9 @@
 #   - make sign    (builds and signs target/aarch64-apple-darwin/release/pelagos)
 #
 # Cold-start timing note:
-#   The --cold mode stops the daemon and boots a fresh VM. socket_vmnet provides
-#   NAT via vmnet.framework (VMNET_SHARED_MODE); the first boot after a long idle
-#   period may take ~2-5 s for the gateway to establish.
-#
-# If image pulls fail with "error sending request", socket_vmnet NAT has degraded.
-# Fix with: sudo brew services restart socket_vmnet
+#   The --cold mode stops the daemon and boots a fresh VM. NAT is provided by
+#   the utun/pf relay inside pelagos-mac; the first boot may take ~2-5 s
+#   for the guest network to come up.
 
 set -uo pipefail
 
@@ -229,8 +226,13 @@ echo "=== test 7: exec (non-tty) ==="
 pelagos ping > /dev/null 2>&1 || true
 sleep 1
 
+# Start a named detached container to exec into.
+EXEC_CTR="pelagos-exec-$$"
+pelagos run --detach --name "$EXEC_CTR" "$TEST_IMAGE" /bin/sh -c "sleep 30" > /dev/null 2>&1
+sleep 1
+
 # Simple exec: output from echo
-OUT=$(pelagos exec "$TEST_IMAGE" /bin/echo hello)
+OUT=$(pelagos exec "$EXEC_CTR" /bin/echo hello)
 echo "$OUT" | grep -v "^\["
 if echo "$OUT" | grep -q "^hello$"; then
     pass "exec: output correct"
@@ -239,13 +241,16 @@ else
 fi
 
 # Stdin forwarding: pipe data to cat
-OUT=$(echo "hello from stdin" | pelagos exec "$TEST_IMAGE" cat)
+OUT=$(echo "hello from stdin" | pelagos exec "$EXEC_CTR" cat)
 echo "$OUT" | grep -v "^\["
 if echo "$OUT" | grep -q "hello from stdin"; then
     pass "exec: stdin forwarded and echoed back"
 else
     fail "exec: expected 'hello from stdin', got: $(echo "$OUT" | grep -v '^\[')"
 fi
+
+pelagos stop "$EXEC_CTR" > /dev/null 2>&1 || true
+pelagos rm   "$EXEC_CTR" > /dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
 # Test 7a: vm shell (non-TTY) — shell directly in the VM, not in a container
@@ -318,13 +323,18 @@ fi
 
 echo ""
 echo "=== test 7d: exec -t (tty mode) ==="
-OUT=$(pelagos exec -t "$TEST_IMAGE" /bin/echo hello-tty 2>&1 | tr -d '\r')
+EXEC_CTR_TTY="pelagos-exec-tty-$$"
+pelagos run --detach --name "$EXEC_CTR_TTY" "$TEST_IMAGE" /bin/sh -c "sleep 30" > /dev/null 2>&1
+sleep 1
+OUT=$(pelagos exec -t "$EXEC_CTR_TTY" /bin/echo hello-tty 2>&1 | tr -d '\r')
 echo "$OUT" | grep -v "^\["
 if echo "$OUT" | grep -q "hello-tty"; then
     pass "exec -t: PTY output correct"
 else
     fail "exec -t: expected 'hello-tty', got: $(echo "$OUT" | grep -v '^\[')"
 fi
+pelagos stop "$EXEC_CTR_TTY" > /dev/null 2>&1 || true
+pelagos rm   "$EXEC_CTR_TTY" > /dev/null 2>&1 || true
 
 # Stop daemon so port-forward and lifecycle tests get a clean slate.
 pelagos vm stop > /dev/null 2>&1 || true
@@ -616,6 +626,9 @@ fi
 
 echo ""
 echo "=== test 7s: docker volume create/ls/rm ==="
+# Ensure daemon is alive — test 7r stops it; a dead daemon fakes volume ops silently.
+pelagos ping > /dev/null 2>&1 || true
+sleep 1
 VOL_NAME="pelagos-e2e-vol-$$"
 shim volume create "$VOL_NAME" > /dev/null 2>&1; CREATE_EXIT=$?
 LS_OUT=$(shim volume ls 2>&1)
@@ -855,7 +868,7 @@ if [ "$FAIL" -eq 0 ]; then
 else
     echo "FAIL  ($FAIL failed, $PASS passed)"
     echo ""
-    echo "If image pulls are failing with 'error sending request', socket_vmnet"
-    echo "NAT has degraded. Fix with:  sudo brew services restart socket_vmnet"
+    echo "If image pulls are failing with 'error sending request', the utun/pf"
+    echo "NAT relay may have stalled. Fix with:  pelagos vm stop && pelagos ping"
     exit 1
 fi


### PR DESCRIPTION
## Summary

- **Port forwarding** was broken by two issues: (1) pf RDR silently drops loopback-originated connections on macOS (kernel RSTs the SYN before pf translation fires) — replaced with a userspace `TcpListener` proxy that relays to `guest_ip:container_port`; (2) double-registration error when `--port` is given at daemon startup then `run` re-registers the same port — made `RegisterPort` idempotent for identical mappings.
- **Host-to-VM connectivity** was blocked by macOS Internet Sharing adding the VM subnet to `network_isolation_table_v4` which silently drops all intra-subnet traffic (SSH, container-to-container, etc.). Fixed by best-effort table delete at utun setup + `pass quick inet from {cidr} to {cidr}` in the pelagos-nat anchor so it beats the block rule.
- **Anchor unification**: merged the formerly separate `pelagos-rdr` anchor into `pelagos-nat` to avoid the wildcard-traversal limitation where sub-anchors not explicitly referenced from a parent anchor are never evaluated.
- Includes a pre-existing devcontainer fix (Dockerfile path resolution vs CWD) and a `pelagos exec` subcommand name fix in test-devcontainer-e2e.sh.

## Test plan

- [ ] `bash scripts/test-e2e.sh --cold` passes 40/40
- [ ] `bash scripts/test-devcontainer-e2e.sh` passes relevant suites
- [ ] After merge: reinstall `pelagos-pfctl` — `sudo cp target/.../pelagos-pfctl /Library/PrivilegedHelperTools/com.pelagos.pfctl && sudo launchctl kickstart -k system/com.pelagos.pfctl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)