### PR TITLE
fix(daemon): send GuestResponse::Error when vsock connect fails instead of silent EOF

### DIFF
--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -626,6 +626,10 @@ fn handle_connection(
         Ok(fd) => fd,
         Err(e) => {
             log::error!("[{conn_id:?}] vsock connect: {}", e);
+            // Send a protocol-level error so the client receives a meaningful
+            // message rather than a silent EOF that causes a JSON parse error.
+            let msg = serde_json::to_string(&e.to_string()).unwrap_or_default();
+            let _ = writeln!(unix, r#"{{"error":{msg}}}"#);
             return;
         }
     };


### PR DESCRIPTION
## Summary

- When the VM is still booting and the UI sends a `GuestCommand` (e.g. `Ps` to list containers), `connect_vsock()` fails and the daemon was silently closing the Unix socket with no response. The client gets EOF, `stdout` is empty, and `serde_json::from_str("")` fails with `"failed to parse pelagos output: expected value at line 1 column 1"`.
- Fix: write `{"error":"VM not ready: ..."}` before returning so the client receives a proper `BackendError::Other` instead of a confusing parse error.

## Test plan

- [ ] Start daemon, trigger `list_containers` before VM finishes booting — should now show "VM not ready" error instead of "failed to parse pelagos output"
- [ ] `bash scripts/test-e2e.sh --cold` still passes 40/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)