### PR TITLE
chore: bump workspace version to 0.6.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.15"
+version = "0.6.16"
 edition = "2021"
 authors = ["skeptomai"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for v0.6.16 release. The release workflow reads from Cargo.toml.