### PR TITLE
docs(formula): clarify upgrade caveats — binary vs disk upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,15 @@ jobs:
                   pelagos ping
                   pelagos run alpine echo hello
 
-                To upgrade:
+                To upgrade (binary + kernel only — preserves your OCI image cache):
                   brew upgrade pelagos-containers/tap/pelagos-mac
-                  pelagos vm init --force   # stops old VM, re-inits with new image
+                  pelagos ping
+
+                To replace the VM disk (destroys OCI image cache — only needed when
+                the release notes say the disk format changed):
+                  pelagos vm stop
+                  brew upgrade pelagos-containers/tap/pelagos-mac
+                  pelagos vm init --force
                   pelagos ping
 
                 To uninstall completely:


### PR DESCRIPTION
## Summary

- Splits upgrade instructions into two cases: normal upgrade (binary + kernel, cache preserved) and disk replacement (cache destroyed, only needed when disk format changes)
- Removes the misleading `pelagos vm init --force` from the normal upgrade path — it was unnecessary and destructive for users who had accumulated OCI image caches

## Why

`brew upgrade` replaces the kernel and initramfs (which contain `pelagos-guest`). The disk (`root.img`) is a pure data volume and survives upgrades unchanged. The old caveats told users to run `vm init --force` on every upgrade, which silently wiped their image cache.

`vm init --force` is only needed when a release explicitly changes the on-disk format — which will be called out in release notes when it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)