### PR TITLE
feat(build-vm): create 4GB swapfile during provisioning

### DIFF
--- a/docs/RUSTERNETES_ON_PELAGOS.md
+++ b/docs/RUSTERNETES_ON_PELAGOS.md
@@ -13,22 +13,6 @@ pelagos source mounted via virtiofs at `/mnt/Projects`.
 
 Rusternetes source is expected at `/mnt/Projects/rusternetes`.
 
-### Swap
-
-The build VM has 4GB RAM. Compiling large rusternetes crates (api-server
-especially) will OOM without swap. A 4GB swapfile is required:
-
-```bash
-sudo fallocate -l 4G /swapfile
-sudo chmod 600 /swapfile
-sudo mkswap /swapfile
-sudo swapon /swapfile
-# Make persistent across reboots:
-echo "/swapfile none swap sw 0 0" | sudo tee -a /etc/fstab
-```
-
-This only needs to be done once per VM image. Verify with `free -h`.
-
 ### pelagos-dockerd
 
 `pelagos-dockerd` must be running before starting the kubelet:

--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -418,6 +418,22 @@ chroot "\$MNT" git config --global http.sslCAInfo /etc/ssl/certs/ca-certificates
 ln -sf /lib/systemd/system/systemd-timesyncd.service \
     "\$MNT/etc/systemd/system/multi-user.target.wants/systemd-timesyncd.service" 2>/dev/null || true
 
+# ---- Swap file ----
+# rustc peaks well above 4 GB RSS when compiling large crates (e.g. rusternetes
+# api-server). Without swap the OOM killer terminates rustc mid-compile.
+# A 4 GB swapfile gives enough headroom for single-job debug builds.
+
+if [ ! -f "\$MNT/swapfile" ]; then
+    echo "[provision] creating 4 GB swapfile"
+    fallocate -l 4G "\$MNT/swapfile" || dd if=/dev/zero of="\$MNT/swapfile" bs=1M count=4096
+    chmod 600 "\$MNT/swapfile"
+    chroot "\$MNT" mkswap /swapfile
+    echo "/swapfile none swap sw 0 0" >> "\$MNT/etc/fstab"
+    echo "  swapfile created and registered in /etc/fstab"
+else
+    echo "[provision] swapfile already exists -- skipping"
+fi
+
 # ---- Extract Ubuntu kernel and initrd for AVF boot ----
 #
 # AVF VZLinuxBootLoader requires a raw arm64 EFI-stub Image (MZ + ARMd at


### PR DESCRIPTION
## Summary

- Adds 4GB swapfile creation to `build-build-image.sh` provisioning script so it is present on every fresh build VM image
- Removes the manual swap setup step from `RUSTERNETES_ON_PELAGOS.md` since it is now handled automatically

## Why

rustc peaks well above 4GB RSS when compiling large crates (rusternetes api-server). Without swap the OOM killer terminates rustc mid-compile. A freshly provisioned build VM will now have swap active immediately on first boot.