### PR TITLE
docs(rusternetes): replace kubectl logs with VM-side log check

### DIFF
--- a/docs/RUSTERNETES_ON_PELAGOS.md
+++ b/docs/RUSTERNETES_ON_PELAGOS.md
@@ -212,9 +212,9 @@ Wait a few seconds, then check container output (in VM):
 
 Expected: `hello-from-kubectl`
 
-Note: `kubectl logs` is not usable — it either returns mock data or hangs
-indefinitely waiting for a streaming connection that never closes. Use the
-VM-side log file above instead.
+Note: `kubectl logs` hangs indefinitely — pelagos-dockerd holds the streaming
+connection open even after the container exits. Use the VM-side log file
+above instead.
 
 Clean up:
 

--- a/docs/RUSTERNETES_ON_PELAGOS.md
+++ b/docs/RUSTERNETES_ON_PELAGOS.md
@@ -212,8 +212,9 @@ Wait a few seconds, then check container output (in VM):
 
 Expected: `hello-from-kubectl`
 
-Note: `kubectl logs hello` returns mock data from rusternetes and cannot be
-used to verify real container output.
+Note: `kubectl logs` is not usable — it either returns mock data or hangs
+indefinitely waiting for a streaming connection that never closes. Use the
+VM-side log file above instead.
 
 Clean up:
 

--- a/docs/RUSTERNETES_ON_PELAGOS.md
+++ b/docs/RUSTERNETES_ON_PELAGOS.md
@@ -204,13 +204,16 @@ Check the scheduler picked it up (in VM):
 
 Expected: `Successfully bound pod to node pelagos-node`
 
-Wait a few seconds, then check logs:
+Wait a few seconds, then check container output (in VM):
 
 ```bash
-kubectl logs hello
+(in VM) cat /run/pelagos/containers/hello_app/stdout.log
 ```
 
 Expected: `hello-from-kubectl`
+
+Note: `kubectl logs hello` returns mock data from rusternetes and cannot be
+used to verify real container output.
 
 Clean up:
 


### PR DESCRIPTION
## Summary

`kubectl logs` returns mock data from rusternetes's `generate_pod_logs()` fallback, not real container output. The manual testing doc incorrectly claimed it would show `hello-from-kubectl`.

Replace the verification step with `(in VM) cat /run/pelagos/containers/hello_app/stdout.log` and add a note explaining that `kubectl logs` is not usable for this purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)