### PR TITLE
docs(rusternetes): require --pelagos-bin when starting pelagos-dockerd

### DIFF
--- a/docs/RUSTERNETES_ON_PELAGOS.md
+++ b/docs/RUSTERNETES_ON_PELAGOS.md
@@ -35,14 +35,16 @@ Rusternetes source is expected at `/mnt/Projects/rusternetes` (inside the VM).
 ### pelagos-dockerd
 
 `pelagos-dockerd` must be running inside the build VM before starting the
-kubelet:
+kubelet. SSH in interactively and run:
 
 ```bash
-# On macOS — start pelagos-dockerd in the background inside the VM
-pelagos --profile build vm ssh -- sudo /mnt/Projects/pelagos/target/debug/pelagos-dockerd &
+# Inside the VM
+sudo /mnt/Projects/pelagos/target/debug/pelagos-dockerd \
+  --pelagos-bin /mnt/Projects/pelagos/target/debug/pelagos &
 ```
 
-Or SSH in interactively and run `sudo /mnt/Projects/pelagos/target/debug/pelagos-dockerd &` in the VM shell.
+The `--pelagos-bin` flag is required — without it pelagos-dockerd defaults to
+looking for `pelagos` on PATH, which is not available under `sudo`.
 
 ## Building
 


### PR DESCRIPTION
## Summary

`pelagos-dockerd` defaults `--pelagos-bin` to `"pelagos"` (just the binary name). Under `sudo`, this isn't on PATH, so every container operation fails with `exec pelagos: No such file or directory`. The binary then crashes and the kubelet can't run or delete any pods.

Fix: pass `--pelagos-bin /mnt/Projects/pelagos/target/debug/pelagos` explicitly.

Found during manual testing — this was the actual cause of `kubectl delete` appearing to hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)