### PR TITLE
fix(vm): guarantee ACPI shutdown on vm stop, increase CLI timeout to 45s

### DIFF
--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -474,9 +474,13 @@ pub fn run(args: DaemonArgs) -> ! {
             log::info!("shutdown requested, stopping VM...");
 
             drop(router);
-            // Drop the Arc. If no proxy threads are active, Vm::drop runs stop().
-            // If threads still hold clones the VM will stop when the last clone
-            // drops. Either way the process exits immediately after cleanup.
+            // Send ACPI power-off explicitly before releasing the Arc.
+            // Vm::drop also calls stop(), but only when the refcount reaches 0.
+            // Active connection-handler threads hold Arc<Vm> clones that may
+            // prevent the refcount from reaching 0 here, causing process::exit
+            // to hard-kill the guest with unflushed writes — corrupting the
+            // guest filesystem.  Calling stop() directly avoids that race.
+            let _ = vm.stop();
             drop(vm);
             state.clear();
             std::process::exit(0);

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -1829,14 +1829,16 @@ fn vm_stop(profile: &str) {
             // this wait a caller that immediately re-invokes pelagos (e.g.
             // the e2e test restarting with different mounts) sees the still-
             // alive daemon and gets a "different mount configuration" error.
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+            // 45 s: the daemon sends an ACPI power-off and waits for the guest
+            // to complete its systemd shutdown sequence before exiting.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
             while std::time::Instant::now() < deadline {
                 if state.running_pid().is_none() {
                     return;
                 }
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
-            log::warn!("daemon (pid {}) did not exit within 15 s", pid);
+            log::warn!("daemon (pid {}) did not exit within 45 s", pid);
         }
     }
 }
@@ -2091,7 +2093,7 @@ fn vm_init(profile: &str, vm_data: Option<&std::path::Path>, force: bool) -> std
             if let Some(pid) = state.running_pid() {
                 println!("Stopping running VM (pid {}) …", pid);
                 unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
-                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
                 while std::time::Instant::now() < deadline {
                     if state.running_pid().is_none() {
                         break;
@@ -2099,7 +2101,7 @@ fn vm_init(profile: &str, vm_data: Option<&std::path::Path>, force: bool) -> std
                     std::thread::sleep(std::time::Duration::from_millis(100));
                 }
                 if state.running_pid().is_some() {
-                    log::warn!("VM daemon (pid {}) did not exit within 15 s", pid);
+                    log::warn!("VM daemon (pid {}) did not exit within 45 s", pid);
                 }
             }
         }


### PR DESCRIPTION
Closes #271

## Summary

- Call `vm.stop()` explicitly before `drop(vm)` in the daemon's SIGTERM shutdown path. Previously the code relied on `Vm::drop` to initiate the ACPI power-off, but `Vm::drop` only runs when the Arc refcount reaches 0. Active vsock connection-handler threads hold `Arc<Vm>` clones; if any are live when SIGTERM fires, `process::exit` runs without ACPI ever being sent — hard-killing the guest.
- Increase the CLI-side wait in `vm_stop` (and `vm init --force`) from 15 s to 45 s. Ubuntu's systemd shutdown sequence can exceed 15 s with active services, causing a spurious timeout warning while the guest is still syncing.

## Test plan

- [ ] `pelagos vm stop` while a container is running — verify the guest shuts down cleanly (no journal errors on next boot)
- [ ] `cargo build && cargo clippy -- -D warnings` pass