### PR TITLE
chore: add libgtk-3-dev and libwebkit2gtk-4.1-dev to build VM

### DIFF
--- a/scripts/build-build-image.sh
+++ b/scripts/build-build-image.sh
@@ -268,6 +268,7 @@ chroot "\$MNT" env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-instal
     pkg-config libssl-dev \
     rsync file strace zstd \
     initramfs-tools \
+    libgtk-3-dev libwebkit2gtk-4.1-dev \
     linux-image-6.11.0-29-generic linux-modules-6.11.0-29-generic
 
 # Explicitly generate the initrd — apt's post-install hook is blocked by the


### PR DESCRIPTION
Required to compile the pelagos-ui Tauri backend on Linux (`cargo clippy` and `cargo test` both fail without these). Discovered while running `scripts/test-logs.sh` against the build VM as part of pelagos-ui#40.

These packages pull in the GTK3 and WebKitGTK4.1 development headers that Tauri's Linux tray icon and webview features depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)