### PR TITLE
feat(guest): KubernetesStatus/Start/Stop command handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pelagos-docker"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "clap",
  "serde",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-guest"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "env_logger",
  "libc",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-mac"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "clap",
  "env_logger",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-pfctl"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "env_logger",
  "libc",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-vz"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "block2",
  "dispatch2",

--- a/pelagos-guest/src/main.rs
+++ b/pelagos-guest/src/main.rs
@@ -325,6 +325,12 @@ pub enum GuestCommand {
         #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
         env: std::collections::HashMap<String, String>,
     },
+    /// Check whether rusternetes (api-server + kubelet) is running.
+    KubernetesStatus,
+    /// Start the rusternetes control plane.
+    KubernetesStart,
+    /// Stop the rusternetes control plane.
+    KubernetesStop,
 }
 
 // ---------------------------------------------------------------------------
@@ -415,6 +421,10 @@ pub enum GuestResponse {
         /// VM kernel version (`uname -r`).
         #[serde(skip_serializing_if = "Option::is_none")]
         kernel: Option<String>,
+    },
+    /// Response to KubernetesStatus command.
+    KubernetesStatus {
+        running: bool,
     },
 }
 
@@ -851,6 +861,15 @@ fn handle_connection(fd: libc::c_int) -> std::io::Result<()> {
                     &args,
                     &env,
                 )?;
+            }
+            GuestCommand::KubernetesStatus => {
+                handle_kubernetes_status(&mut writer)?;
+            }
+            GuestCommand::KubernetesStart => {
+                handle_kubernetes_start(&mut writer)?;
+            }
+            GuestCommand::KubernetesStop => {
+                handle_kubernetes_stop(&mut writer)?;
             }
         }
     }
@@ -2807,6 +2826,151 @@ fn accept_vsock(_listener: &OwnedFd) -> std::io::Result<libc::c_int> {
         std::io::ErrorKind::Unsupported,
         "AF_VSOCK is Linux-only",
     ))
+}
+
+// ---------------------------------------------------------------------------
+// Kubernetes (rusternetes) handlers
+// ---------------------------------------------------------------------------
+
+fn k8s_is_running(name: &str) -> bool {
+    std::process::Command::new("pgrep")
+        .args(["-x", name])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn k8s_find_bin(name: &str, dirs: &[&str]) -> String {
+    for dir in dirs {
+        let p = format!("{}/{}", dir, name);
+        if std::path::Path::new(&p).exists() {
+            return p;
+        }
+    }
+    name.to_string()
+}
+
+fn k8s_wait_for_port(port: u16, timeout_secs: u64) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    while std::time::Instant::now() < deadline {
+        if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+}
+
+fn handle_kubernetes_status(writer: &mut impl std::io::Write) -> std::io::Result<()> {
+    let running = k8s_is_running("api-server") && k8s_is_running("kubelet");
+    send_response(writer, &GuestResponse::KubernetesStatus { running })
+}
+
+fn handle_kubernetes_start(writer: &mut impl std::io::Write) -> std::io::Result<()> {
+    let dockerd = k8s_find_bin(
+        "pelagos-dockerd",
+        &["/usr/local/bin", "/mnt/Projects/pelagos/target/debug"],
+    );
+    let api_bin = k8s_find_bin(
+        "api-server",
+        &["/usr/local/bin", "/mnt/Projects/rusternetes/target/debug"],
+    );
+    let kubelet_bin = k8s_find_bin(
+        "kubelet",
+        &["/usr/local/bin", "/mnt/Projects/rusternetes/target/debug"],
+    );
+    let data_dir = "/var/lib/rusternetes/cluster.db";
+    let _ = std::fs::create_dir_all("/var/lib/rusternetes");
+
+    if !k8s_is_running("pelagos-dockerd") {
+        let pelagos = pelagos_bin();
+        let _ = std::process::Command::new(&dockerd)
+            .arg("--pelagos-bin")
+            .arg(&pelagos)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+        send_response(
+            writer,
+            &GuestResponse::Stream {
+                stream: StreamKind::Stdout,
+                data: "started pelagos-dockerd\n".into(),
+            },
+        )?;
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    if !k8s_is_running("api-server") {
+        let _ = std::process::Command::new(&api_bin)
+            .args([
+                "--storage-backend",
+                "sqlite",
+                "--data-dir",
+                data_dir,
+                "--skip-auth",
+                "--tls",
+                "--tls-self-signed",
+                "--tls-san",
+                "localhost,127.0.0.1",
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+        send_response(
+            writer,
+            &GuestResponse::Stream {
+                stream: StreamKind::Stdout,
+                data: "started api-server, waiting for ready...\n".into(),
+            },
+        )?;
+        k8s_wait_for_port(6443, 30);
+        send_response(
+            writer,
+            &GuestResponse::Stream {
+                stream: StreamKind::Stdout,
+                data: "api-server ready\n".into(),
+            },
+        )?;
+    }
+
+    if !k8s_is_running("kubelet") {
+        let _ = std::process::Command::new(&kubelet_bin)
+            .args([
+                "--node-name",
+                "pelagos-node",
+                "--storage-backend",
+                "sqlite",
+                "--data-dir",
+                data_dir,
+                "--network",
+                "bridge",
+            ])
+            .env("DOCKER_HOST", "unix:///var/run/pelagos-dockerd.sock")
+            .env("RUST_MIN_STACK", "8388608")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+        send_response(
+            writer,
+            &GuestResponse::Stream {
+                stream: StreamKind::Stdout,
+                data: "started kubelet\n".into(),
+            },
+        )?;
+    }
+
+    send_response(writer, &GuestResponse::Exit { exit: 0 })
+}
+
+fn handle_kubernetes_stop(writer: &mut impl std::io::Write) -> std::io::Result<()> {
+    for name in &["kubelet", "api-server", "pelagos-dockerd"] {
+        let _ = std::process::Command::new("pkill")
+            .args(["-x", name])
+            .status();
+    }
+    send_response(writer, &GuestResponse::Exit { exit: 0 })
 }
 
 // ---------------------------------------------------------------------------

--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -286,6 +286,11 @@ enum Commands {
         #[command(subcommand)]
         sub: VmCommands,
     },
+    /// Manage the rusternetes Kubernetes control plane inside the VM
+    Kubernetes {
+        #[command(subcommand)]
+        sub: KubernetesCmd,
+    },
     /// Internal: run as the persistent VM daemon. Not for direct use.
     #[command(hide = true)]
     VmDaemonInternal,
@@ -295,6 +300,16 @@ enum Commands {
         /// TCP port to connect to on the VM guest IP
         port: u16,
     },
+}
+
+#[derive(Subcommand, Debug)]
+enum KubernetesCmd {
+    /// Report whether the rusternetes control plane is running
+    Status,
+    /// Start the rusternetes control plane (pelagos-dockerd, api-server, kubelet)
+    Start,
+    /// Stop the rusternetes control plane
+    Stop,
 }
 
 #[derive(Subcommand, Debug)]
@@ -557,6 +572,9 @@ enum GuestCommand {
     Ping,
     Version,
     Subscribe,
+    KubernetesStatus,
+    KubernetesStart,
+    KubernetesStop,
     Build {
         tag: String,
         dockerfile: String,
@@ -655,6 +673,9 @@ enum GuestResponse {
     },
     Ready {
         ready: bool,
+    },
+    KubernetesStatus {
+        running: bool,
     },
     /// Precedes `size` raw bytes written directly to the socket.
     RawBytes {
@@ -1058,6 +1079,21 @@ fn main() {
             }
             let stream = connect_or_exit(&profile);
             subscribe_command(stream);
+        }
+
+        Commands::Kubernetes { sub } => {
+            let stream = connect_or_exit(&profile);
+            match sub {
+                KubernetesCmd::Status => {
+                    process::exit(kubernetes_status_command(stream));
+                }
+                KubernetesCmd::Start => {
+                    process::exit(passthrough_command(stream, GuestCommand::KubernetesStart));
+                }
+                KubernetesCmd::Stop => {
+                    process::exit(passthrough_command(stream, GuestCommand::KubernetesStop));
+                }
+            }
         }
 
         Commands::Ping => {
@@ -2906,6 +2942,37 @@ fn ping_command(stream: UnixStream) -> i32 {
         }
         other => {
             log::error!("unexpected ping response: {:?}", other);
+            1
+        }
+    }
+}
+
+fn kubernetes_status_command(stream: UnixStream) -> i32 {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut writer = stream;
+
+    let mut msg = serde_json::to_string(&GuestCommand::KubernetesStatus).unwrap();
+    msg.push('\n');
+    if let Err(e) = writer.write_all(msg.as_bytes()) {
+        log::error!("write error: {}", e);
+        return 1;
+    }
+
+    let mut line = String::new();
+    match reader.read_line(&mut line) {
+        Ok(0) | Err(_) => {
+            log::error!("no response from guest");
+            return 1;
+        }
+        Ok(_) => {}
+    }
+    match serde_json::from_str::<GuestResponse>(line.trim_end()) {
+        Ok(GuestResponse::KubernetesStatus { running }) => {
+            println!("{}", if running { "running" } else { "stopped" });
+            0
+        }
+        other => {
+            log::error!("unexpected kubernetes status response: {:?}", other);
             1
         }
     }


### PR DESCRIPTION
## Summary

Add three new `GuestCommand` handlers to `pelagos-guest` to support the Kubernetes tab in pelagos-ui PR #45.

## Changes

**`GuestCommand` variants (matching pelagos-protocol v3)**
- `KubernetesStatus` — replies with `GuestResponse::KubernetesStatus { running: bool }`
- `KubernetesStart` — starts pelagos-dockerd → api-server → kubelet, streams progress
- `KubernetesStop` — pkill kubelet, api-server, pelagos-dockerd in order

**Start sequence**
1. pelagos-dockerd (if not running) — 500ms settle delay
2. api-server (if not running) — waits up to 30s for port 6443 to respond
3. kubelet (if not running) — with `DOCKER_HOST` and `RUST_MIN_STACK` env vars

**Binary discovery** — checks `/usr/local/bin` first (production), then dev build paths under `/mnt/Projects/*/target/debug`

**Data dir** — `/var/lib/rusternetes/cluster.db` (created on demand)

## Test plan
- [ ] `cargo check -p pelagos-guest` passes
- [ ] `KubernetesStatus` returns correct running/stopped state
- [ ] `KubernetesStart` starts all three processes in order
- [ ] `KubernetesStop` kills all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)