### PR TITLE
fix: always use pasta network so containers get an isolated netns (#204)

### DIFF
--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -994,7 +994,12 @@ fn main() {
                         mounts,
                         labels,
                         publish: cli.ports.clone(),
-                        network: network.first().cloned(),
+                        network: Some(
+                            network
+                                .first()
+                                .cloned()
+                                .unwrap_or_else(|| "pasta".to_string()),
+                        ),
                         dns: dns.clone(),
                     },
                     tty,
@@ -1012,7 +1017,12 @@ fn main() {
                     env: env_map,
                     labels,
                     publish: cli.ports.clone(),
-                    network: network.first().cloned(),
+                    network: Some(
+                        network
+                            .first()
+                            .cloned()
+                            .unwrap_or_else(|| "pasta".to_string()),
+                    ),
                     dns: dns.clone(),
                 },
             );


### PR DESCRIPTION
Fixes pelagos-containers/pelagos#204.

## Root cause

`GuestCommand::Run` and `GuestCommand::Exec` were constructed with `network: network.first().cloned()`. When the user provides no `--network` flag, `network` is an empty `Vec`, so `first()` returns `None`. pelagos-guest receives `None` and omits `--network` from the `pelagos run` invocation — the container runs in the **host network namespace**, sharing PID 1's netns. No isolated netns is created, pasta has nothing to configure, and the container gets no IPv6.

## Fix

Default to `"pasta"` when no `--network` flag is given. Pasta handles IPv6 natively via `--config-net`: it reads the host interface's GUA, synthesises an RA into the container's netns, and sets up NAT66 masquerade for outbound traffic. No changes to pelagos itself are needed.

Both the Run (foreground/detached) and Exec (interactive/PTY) paths are fixed.

## Verification checklist

- [ ] `pelagos run alpine ip -6 addr` — container has a ULA `/64` address
- [ ] `pelagos run alpine ip -6 route` — container has a default IPv6 route
- [ ] `pelagos run alpine ping6 -c3 2001:4860:4860::8888` — outbound IPv6 works (0% packet loss)
- [ ] `pelagos run --network bridge alpine ping6 -c3 2001:4860:4860::8888` — explicit `--network` flag still honoured
- [ ] `pelagos run alpine curl -6 https://ipv6.google.com` — full IPv6 internet access

🤖 Generated with [Claude Code](https://claude.com/claude-code)