### PR TITLE
chore: bump pelagos runtime to v0.64.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pelagos-docker"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "clap",
  "serde",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-guest"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "env_logger",
  "libc",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-mac"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "clap",
  "env_logger",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-pfctl"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "env_logger",
  "libc",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-vz"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "block2",
  "dispatch2",

--- a/pelagos-vz/src/tun_relay.rs
+++ b/pelagos-vz/src/tun_relay.rs
@@ -51,6 +51,7 @@
 use std::io::{BufRead, BufReader, Write};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixStream;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 
@@ -350,6 +351,11 @@ fn run_relay(
     gua_prefix: Option<[u8; 16]>,
 ) {
     log::info!("tun_relay: relay loop started (relay_fd={relay_fd} utun_fd={utun_fd})");
+    // Periodic unsolicited RA interval (RFC 4861 §6.2.4 recommends 200–600s).
+    // Keeps the VM's default IPv6 route alive and the fe80::1 neighbour REACHABLE
+    // so that NUD does not silently remove the default route between RS/RA exchanges.
+    const RA_INTERVAL: Duration = Duration::from_secs(200);
+    let mut last_ra = Instant::now();
     let mut state = RelayState {
         vm_mac: None,
         gateway_ip4,
@@ -418,6 +424,23 @@ fn run_relay(
         if pollfds[1].revents & (libc::POLLHUP | libc::POLLERR) != 0 {
             log::info!("tun_relay: utun fd closed — relay exiting");
             break;
+        }
+
+        // Periodic unsolicited RA: keeps the VM's default IPv6 route alive and
+        // the fe80::1 neighbour REACHABLE so NUD cannot silently remove the route.
+        if last_ra.elapsed() >= RA_INTERVAL {
+            if let Some(gua_prefix) = state.gua_prefix {
+                let ra = build_ra(&gua_prefix);
+                send_to_avf(relay_fd, &ra);
+                log::debug!(
+                    "tun_relay: sent periodic RA (prefix={:02x}{:02x}{:02x}{:02x}:...)",
+                    gua_prefix[0],
+                    gua_prefix[1],
+                    gua_prefix[2],
+                    gua_prefix[3]
+                );
+            }
+            last_ra = Instant::now();
         }
     }
 

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -56,7 +56,7 @@ KERNEL_OUT="$OUT/vmlinuz"
 UBUNTU_VMLINUZ="$OUT/ubuntu-vmlinuz"
 UBUNTU_MODULES="$OUT/ubuntu-modules"
 
-PELAGOS_VERSION="0.61.3"
+PELAGOS_VERSION="0.64.0"
 PELAGOS_BIN="$WORK/pelagos-${PELAGOS_VERSION}-aarch64-linux"
 PELAGOS_URL="https://github.com/pelagos-containers/pelagos/releases/download/v${PELAGOS_VERSION}/pelagos-aarch64-linux"
 PELAGOS_DNS_BIN="$WORK/pelagos-dns-${PELAGOS_VERSION}-aarch64-linux"


### PR DESCRIPTION
## Summary

- Bumps `PELAGOS_VERSION` in `build-vm-image.sh` from `0.61.3` → `0.64.0`
- Adds periodic unsolicited RA (every 200s) in the smoltcp relay to keep the VM's default IPv6 route stable (closes #288)
- Rebuilt VM image; local pelagos repo updated to latest main (25 commits past tag)
- All 37 e2e tests pass

## Notable changes in pelagos v0.62–v0.64

- `pelagos stop --time` flag + idempotent stop behaviour
- Pod sandbox — named namespace groups for multi-container sharing
- Full CRI gRPC server (k3s / rusternetes path)
- Fail-fast with clear error when host port is already in use
- inotify-based log follow
- Native `NETLINK_NETFILTER` client replacing all `nft` subprocess calls (v0.64.0)

## IPv6 fix (closes #288)

The relay previously sent an RA only at VM boot (in response to RS). When pasta forwards container IPv6 traffic through the VM's eth0, the kernel triggers NUD for the `fe80::1` neighbour. If the NUD probe fails before the relay processes it, the neighbour goes FAILED and the kernel removes the default route — breaking all subsequent container IPv6.

The relay now sends a periodic unsolicited RA every 200 seconds (RFC 4861 §6.2.4 range: 200–600s) to keep the default route alive and the neighbour REACHABLE.

## Test plan

- [x] `bash scripts/build-vm-image.sh` — succeeded
- [x] `bash scripts/test-e2e.sh` — 37/37 pass (run twice)
- [x] Container IPv6: ping6 + wget to ipv6.google.com — confirmed working
- [x] VM IPv6 default route stable after container start

🤖 Generated with [Claude Code](https://claude.com/claude-code)