### PR TITLE
fix(daemon): port-proxy connected to host_port instead of container_port

### DIFF
--- a/pelagos-mac/src/daemon.rs
+++ b/pelagos-mac/src/daemon.rs
@@ -89,7 +89,7 @@ fn port_proxy_loop(
         }
         match stream {
             Ok(client) => {
-                std::thread::spawn(move || relay_tcp(client, guest_ip, host_port));
+                std::thread::spawn(move || relay_tcp(client, guest_ip, container_port));
             }
             Err(e) => {
                 if !shutdown.load(Ordering::Relaxed) {


### PR DESCRIPTION
## Summary

- `port_proxy_loop` accepted both `host_port` and `container_port` as parameters but passed `host_port` as the third argument to `relay_tcp()`, which expects `container_port`
- `relay_tcp` then connected to `guest_ip:host_port` instead of `guest_ip:container_port` — so e.g. `-p 8080:80` would attempt to connect to port 8080 inside the guest rather than port 80
- One-character fix: change `host_port` → `container_port` at the call site

This is the "routing key collision" described in #286: the forwarding was broken for any mapping where host_port ≠ container_port, and two mappings with the same container_port would both land on the same wrong guest port.

## Test plan

- [ ] `cargo build -p pelagos-mac` passes (verified)
- [ ] `pelagos run -p 8080:80 nginx` — curl localhost:8080 returns nginx response
- [ ] `pelagos run -p 8081:80 nginx` (second container, same container port) — both host ports work independently

Closes #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)