### PR TITLE
fix(volumes): validate host path exists before building virtiofs share

### DIFF
--- a/pelagos-mac/src/main.rs
+++ b/pelagos-mac/src/main.rs
@@ -1808,6 +1808,13 @@ fn parse_volumes(volumes: &[String]) -> Vec<daemon::VirtiofsShare> {
                 process::exit(1);
             }
             let host_path = PathBuf::from(parts[0]);
+            if !host_path.exists() {
+                log::error!(
+                    "volume host path does not exist: {}",
+                    host_path.display()
+                );
+                process::exit(1);
+            }
             let container_path = parts[1].to_string();
             let read_only = parts.get(2).is_some_and(|s| *s == "ro");
             daemon::VirtiofsShare {


### PR DESCRIPTION
## Summary

- `parse_volumes` extracted `host_path` from the `-v` spec but never checked whether the path exists
- A typo like `-v /nonexistent:/container` silently produced an empty virtiofs mount inside the container with no diagnostic
- Added an existence check immediately after extracting `host_path`; exits with `log::error!` before the VM starts

## Test plan

- [ ] `pelagos run -v /nonexistent/path:/app alpine` exits immediately with `error: volume host path does not exist: /nonexistent/path`
- [ ] `pelagos run -v /tmp:/app alpine ls /app` still works
- [ ] Read-only: `pelagos run -v /tmp:/app:ro alpine` still works

Fixes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)