### PR TITLE
chore: bump workspace version to 0.6.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pelagos-docker"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "clap",
  "serde",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-guest"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "env_logger",
  "libc",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-mac"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "clap",
  "env_logger",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-pfctl"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "env_logger",
  "libc",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "pelagos-vz"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "block2",
  "dispatch2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.18"
+version = "0.6.19"
 edition = "2021"
 authors = ["skeptomai"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for the v0.6.19 release.

Changes since v0.6.18:
- pelagos bumped to v0.64.0 (PR #287)
- Periodic RA every 200s to keep VM IPv6 default route alive (PR #287)
- fix: port-proxy was connecting to host_port instead of container_port (PR #289)
- fix: volume host path existence validation before virtiofs share (PR #291)
- chore: remove stale #252 comment (PR #290)

🤖 Generated with [Claude Code](https://claude.com/claude-code)