### PR TITLE
fix(scripts): stop writing to live brew tap to prevent brew update conflicts

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -22,7 +22,7 @@
 # To install locally after running this script:
 #
 #   brew uninstall pelagos-mac 2>/dev/null || true
-#   HOMEBREW_DEVELOPER=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install pelagos-containers/tap/pelagos-mac
+#   HOMEBREW_NO_INSTALL_FROM_API=1 brew install dist/tap/Formula/pelagos-mac.rb
 #
 # Prerequisites: out/ must exist (run scripts/build-vm-image.sh first).
 
@@ -117,7 +117,6 @@ echo "[release]   $(du -sh "$DIST/$VM_TARBALL" | awk '{print $1}')  sha256: ${VM
 # Write formula into dist/tap (canonical source) and sync to brew tap
 # ---------------------------------------------------------------------------
 TAP_FORMULA="$DIST/tap/Formula/pelagos-mac.rb"
-BREW_TAP_FORMULA="/opt/homebrew/Library/Taps/pelagos-containers/homebrew-tap/Formula/pelagos-mac.rb"
 
 mkdir -p "$DIST/tap/Formula"
 
@@ -186,13 +185,10 @@ class PelagosMac < Formula
 end
 FORMULA
 
-# Sync to the brew tap directory so no manual copy is needed at install time.
-if [[ -d "$(dirname "$BREW_TAP_FORMULA")" ]]; then
-    cp "$TAP_FORMULA" "$BREW_TAP_FORMULA"
-    echo "[release] synced formula to brew tap"
-else
-    echo "[release] warning: brew tap not found at $(dirname "$BREW_TAP_FORMULA") — run 'brew tap skeptomai/tap dist/tap' first"
-fi
+# The formula is intentionally NOT copied to the live brew tap git repo.
+# Copying there causes merge conflicts whenever the release workflow pushes
+# the GitHub-URL formula upstream and brew update pulls it.
+# dev-reinstall.sh installs directly from $TAP_FORMULA by file path instead.
 
 # ---------------------------------------------------------------------------
 # Summary
@@ -206,4 +202,4 @@ echo "  $TAP_FORMULA"
 echo ""
 echo "  To install:"
 echo "    brew uninstall pelagos-mac 2>/dev/null || true"
-echo "    HOMEBREW_DEVELOPER=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install pelagos-containers/tap/pelagos-mac"
+echo "    HOMEBREW_NO_INSTALL_FROM_API=1 brew install \"$TAP_FORMULA\""

--- a/scripts/dev-reinstall.sh
+++ b/scripts/dev-reinstall.sh
@@ -63,7 +63,9 @@ if [[ $SKIP_MAC -eq 0 ]]; then
 
     echo "[dev-reinstall] installing via brew..."
     brew uninstall pelagos-mac 2>/dev/null || true
-    HOMEBREW_DEVELOPER=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install pelagos-containers/tap/pelagos-mac
+    # Install from the formula file directly to avoid polluting the live brew tap
+    # git repo with local file:// URLs (which conflicts with brew update).
+    HOMEBREW_NO_INSTALL_FROM_API=1 brew install "$REPO/dist/tap/Formula/pelagos-mac.rb"
 
     echo "[dev-reinstall] macOS install done -- $(pelagos --version 2>&1 | head -1)"
 fi


### PR DESCRIPTION
## Summary

- `build-release.sh` was `cp`-ing the local `file://` formula into the `pelagos-containers/homebrew-tap` git repo after every local build
- The release workflow then pushes the GitHub-URL formula to that same repo
- `brew update` does `git pull --autostash` on the tap: stashes the local `file://` modification, pulls the GitHub formula, then fails to pop the stash because both versions modified the same lines — producing a merge conflict that requires manual resolution every release
- Fix: remove the `cp` entirely; `dev-reinstall.sh` now installs directly from `dist/tap/Formula/pelagos-mac.rb` by absolute path, which never touches the tap git repo

## After this change

- `brew update` on the tap will always cleanly fast-forward (no local modifications to conflict with)
- Local dev installs work identically — `brew install /path/to/formula.rb` is standard Homebrew

🤖 Generated with [Claude Code](https://claude.com/claude-code)