### PR TITLE
chore: bump PELAGOS_VERSION to 0.65.2

### DIFF
--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -56,7 +56,7 @@ KERNEL_OUT="$OUT/vmlinuz"
 UBUNTU_VMLINUZ="$OUT/ubuntu-vmlinuz"
 UBUNTU_MODULES="$OUT/ubuntu-modules"
 
-PELAGOS_VERSION="0.60.9"
+PELAGOS_VERSION="0.65.2"
 PELAGOS_BIN="$WORK/pelagos-${PELAGOS_VERSION}-aarch64-linux"
 PELAGOS_URL="https://github.com/pelagos-containers/pelagos/releases/download/v${PELAGOS_VERSION}/pelagos-aarch64-linux"
 PELAGOS_DNS_BIN="$WORK/pelagos-dns-${PELAGOS_VERSION}-aarch64-linux"


### PR DESCRIPTION
Bumps the pinned pelagos version in `scripts/build-vm-image.sh` from `0.60.9` to `0.65.2`.

Picks up two CRI fixes:
- **terminationMessagePath bind-mount** — user bind mounts are now applied after `/dev/` tmpfs setup, so mounts targeting `/dev/**` (e.g. `/dev/termination-log`) are no longer silently covered by the tmpfs.
- **ContainerStatus.message** — termination log content is now returned in `ContainerStatus.message`, making `kubectl describe pod` exit messages visible.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)